### PR TITLE
Disable all unessential solc optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # The `zksolc` changelog
 
+## [Unreleased]
+
+### Changed
+
+- `solc` optimizer is completely turned off
+
 ## [1.3.15] - 2023-10-05
 
 ### Added

--- a/src/evmla/ethereal_ir/function/mod.rs
+++ b/src/evmla/ethereal_ir/function/mod.rs
@@ -254,7 +254,11 @@ impl Function {
             } => {
                 queue_element.predecessor = Some((queue_element.block_key.clone(), instance));
 
-                let block_key = match block_stack.elements.last().expect("Always exists") {
+                let block_key = match block_stack
+                    .elements
+                    .last()
+                    .ok_or_else(|| anyhow::anyhow!("Destination tag is missing"))?
+                {
                     Element::Tag(destination) if destination > &num::BigUint::from(u32::MAX) => {
                         compiler_llvm_context::EraVMFunctionBlockKey::new(
                             compiler_llvm_context::EraVMCodeType::Runtime,
@@ -311,7 +315,11 @@ impl Function {
             } => {
                 queue_element.predecessor = Some((queue_element.block_key.clone(), instance));
 
-                let block_key = match block_stack.elements.last().expect("Always exists") {
+                let block_key = match block_stack
+                    .elements
+                    .last()
+                    .ok_or_else(|| anyhow::anyhow!("Destination tag is missing"))?
+                {
                     Element::Tag(destination) if destination > &num::BigUint::from(u32::MAX) => {
                         compiler_llvm_context::EraVMFunctionBlockKey::new(
                             compiler_llvm_context::EraVMCodeType::Runtime,
@@ -941,7 +949,10 @@ impl Function {
                 name: InstructionName::ISZERO,
                 ..
             } => {
-                let operand = block_stack.elements.last().expect("Always exists");
+                let operand = block_stack
+                    .elements
+                    .last()
+                    .ok_or_else(|| anyhow::anyhow!("Operand is missing"))?;
 
                 let result = match operand {
                     Element::Tag(operand) => Element::Constant(if operand.is_zero() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,11 @@ pub fn standard_output(
         input_files,
         libraries,
         SolcStandardJsonInputSettingsSelection::new_required(solc_pipeline),
-        SolcStandardJsonInputSettingsOptimizer::new(solc_optimizer_enabled, None),
+        SolcStandardJsonInputSettingsOptimizer::new(
+            solc_optimizer_enabled,
+            None,
+            &solc_version.default,
+        ),
         None,
         solc_pipeline == SolcPipeline::Yul,
         suppressed_warnings,

--- a/src/solc/mod.rs
+++ b/src/solc/mod.rs
@@ -87,9 +87,10 @@ impl Compiler {
             command.arg(allow_paths);
         }
 
+        input.normalize(&version.default);
+
         let suppressed_warnings = input.suppressed_warnings.take().unwrap_or_default();
 
-        input.normalize(&version.default);
         let input_json = serde_json::to_vec(&input).expect("Always valid");
 
         let process = command.spawn().map_err(|error| {

--- a/src/solc/standard_json/input/settings/optimizer/details.rs
+++ b/src/solc/standard_json/input/settings/optimizer/details.rs
@@ -8,10 +8,23 @@ use serde::Serialize;
 ///
 /// The `solc --standard-json` input settings optimizer details.
 ///
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Details {
-    /// Whether the constant optimizer is enabled.
+    /// Whether the pass is enabled.
+    pub peephole: bool,
+    /// Whether the pass is enabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inliner: Option<bool>,
+    /// Whether the pass is enabled.
+    pub jumpdest_remover: bool,
+    /// Whether the pass is enabled.
+    pub order_literals: bool,
+    /// Whether the pass is enabled.
+    pub deduplicate: bool,
+    /// Whether the pass is enabled.
+    pub cse: bool,
+    /// Whether the pass is enabled.
     pub constant_optimizer: bool,
 }
 
@@ -19,7 +32,36 @@ impl Details {
     ///
     /// A shortcut constructor.
     ///
-    pub fn new(constant_optimizer: bool) -> Self {
-        Self { constant_optimizer }
+    pub fn new(
+        peephole: bool,
+        inliner: Option<bool>,
+        jumpdest_remover: bool,
+        order_literals: bool,
+        deduplicate: bool,
+        cse: bool,
+        constant_optimizer: bool,
+    ) -> Self {
+        Self {
+            peephole,
+            inliner,
+            jumpdest_remover,
+            order_literals,
+            deduplicate,
+            cse,
+            constant_optimizer,
+        }
+    }
+
+    ///
+    /// Creates a set of disabled optimizations.
+    ///
+    pub fn disabled(version: &semver::Version) -> Self {
+        let inliner = if version >= &semver::Version::new(0, 8, 5) {
+            Some(false)
+        } else {
+            None
+        };
+
+        Self::new(false, inliner, false, false, false, false, false)
     }
 }

--- a/src/solc/standard_json/input/settings/optimizer/mod.rs
+++ b/src/solc/standard_json/input/settings/optimizer/mod.rs
@@ -29,11 +29,11 @@ impl Optimizer {
     ///
     /// A shortcut constructor.
     ///
-    pub fn new(enabled: bool, mode: Option<char>) -> Self {
+    pub fn new(enabled: bool, mode: Option<char>, version: &semver::Version) -> Self {
         Self {
             enabled,
             mode,
-            details: Some(Details::default()),
+            details: Some(Details::disabled(version)),
         }
     }
 
@@ -42,7 +42,7 @@ impl Optimizer {
     ///
     pub fn normalize(&mut self, version: &semver::Version) {
         self.details = if version >= &semver::Version::new(0, 5, 5) {
-            Some(Details::default())
+            Some(Details::disabled(version))
         } else {
             None
         };


### PR DESCRIPTION
# What ❔

Makes it impossible to enable the `solc` optimizations.

## Why ❔

After migration to our fork of `solc`, we'll be only relying on the LLVM optimizer, and we'd like to reduce the test surface by disabling all `solc` optimizations except the library inliner.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
