### PR TITLE
ci: add unit tests workflow

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -157,21 +157,21 @@ jobs:
         uses: actions/checkout@v4
       - name: Prepare msys2
         uses: msys2/setup-msys2@v2
-      - name: Prepare env
-        run: |
-          pacman-key --refresh
-          pacman -Sy
-          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-          pacman --noconfirm -S --needed --overwrite \
-          base-devel \
-          git \
-          ninja \
-          mingw-w64-x86_64-clang \
-          mingw-w64-x86_64-lld \
-          mingw-w64-x86_64-rust \
-          mingw-w64-x86_64-gcc-libs \
-          mingw-w64-x86_64-gcc
+#      - name: Prepare env
+#        run: |
+#          pacman-key --refresh
+#          pacman -Sy
+#          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+#          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+#          pacman --noconfirm -S --needed --overwrite \
+#          base-devel \
+#          git \
+#          ninja \
+#          mingw-w64-x86_64-clang \
+#          mingw-w64-x86_64-lld \
+#          mingw-w64-x86_64-rust \
+#          mingw-w64-x86_64-gcc-libs \
+#          mingw-w64-x86_64-gcc
       - name: Install solc compiler
         run: |
           curl --verbose --location -o solc.exe "${SOLC_URL}/${SOLC_VERSION}/solc-windows-amd64-${SOLC_VERSION}.exe"
@@ -179,6 +179,9 @@ jobs:
       - name: Build LLVM framework
         run: |
           export PATH="${PATH}:{$PWD}"
+          echo $PATH
+          ls -la .
+          chmod a+x solc.exe
           solc.exe --version
           cargo install compiler-llvm-builder
           export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -121,7 +121,7 @@ jobs:
       - name: Build zksolc
         run: |
           set -x
-          if [[ "${{ matrix.target }}" == "aarch64-unknown-linux-musl" ]]; then
+          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-musl" ]; then
             export RUSTFLAGS="-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
           fi
           echo "RUSTFLAGS=${RUSTFLAGS}"

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -16,139 +16,133 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false # for now, false (put jobs in queue) allowing multiple PR testing consequently (tbd)
 
+env:
+  SOLC_VERSION: 0.8.23-1.0.0 # How should we manage solc version updates?
+  SOLC_URL: "https://github.com/matter-labs/era-solidity/releases/download"
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+  UNIT_TESTS_RESULTS_XML: unit-tests-results.xml
+  RUSTC_BOOTSTRAP: 1 # Use rustc in bootstrap mode allowing cargo2junit to use experimental --json feature
+
 jobs:
-#  unit-tests-macos:
-#    strategy:
-#      matrix:
-#        include:
-#          - name: "MacOS x86"
-#            runner: macos-12-large
-#            solc-name: "solc-macosx-amd64"
-#          - name: "MacOS arm64"
-#            runner: [self-hosted, macOS, ARM64]
-#            solc-name: "solc-macosx-arm64"
-#    runs-on: ${{ matrix.runner }}
-#    name: ${{ matrix.name }}
-#    defaults:
-#      run:
-#        shell: zsh {0} # For MacOS hosts, .zprofile is pre-configured
-#    env:
-#      SOLC_VERSION: 0.8.23-1.0.0 # How should we manage solc version updates?
-#      SOLC_URL: "https://github.com/matter-labs/era-solidity/releases/download"
-#      CARGO_NET_GIT_FETCH_WITH_CLI: true
-#      UNIT_TESTS_RESULTS_XML: unit-tests-results.xml
-#      RUSTC_BOOTSTRAP: 1 # Use rustc in bootstrap mode allowing cargo2junit to use experimental --json feature
-#    steps:
-#      # TODO: This step should be done as part of github runners hooks
-#      # Users should always expect clean workspace when a new job starts
-#      # https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/
-#      - name: Cleanup workspace
-#        if: ${{ matrix.name }} == "MacOS ARM64"
-#        run: |
-#          setopt rmstarsilent
-#          setopt +o nomatch
-#          rm -rf ${{ github.workspace }}/*
-#      - name: Checkout source
-#        uses: actions/checkout@v4
-#      - name: Prepare environment
-#        run: |
-#          brew install cmake ninja
-#      - name: Build LLVM framework
-#        run: |
-#          cargo install compiler-llvm-builder
-#          zkevm-llvm clone
-#          zkevm-llvm build
-#      - name: Install solc compiler
-#        run: |
-#          curl --verbose \
-#            --location -o "${PWD}/solc" "${SOLC_URL}/${SOLC_VERSION}/${{ matrix.solc-name }}-${SOLC_VERSION}" && \
-#            chmod a+x "${PWD}/solc"
-#          echo "${PWD}" >> "${GITHUB_PATH}"
-#      - name: Build zksolc
-#        run: |
-#          cargo build --release
-#          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
-#      - name: Run unit tests
-#        continue-on-error: true
-#        run: |
-#          cargo install cargo2junit
-#          cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
-#      - name: Upload test results
-#        uses: EnricoMi/publish-unit-test-result-action/composite@v2
-#        with:
-#          check_name: ${{ matrix.name }} Unit Tests Results
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-#  unit-tests-linux:
-#    strategy:
-#      matrix:
-#        include:
-#          - name: "Linux x86"
-#            runner: matterlabs-ci-runner
-#            solc-name: "solc-linux-amd64"
-#            target: "x86_64-unknown-linux-musl"
-#          - name: "Linux arm64"
-#            runner: matterlabs-ci-runner-arm
-#            solc-name: "solc-linux-arm64"
-#            target: "aarch64-unknown-linux-musl"
-#    runs-on: ${{ matrix.runner }}
-#    name: ${{ matrix.name }}
-#    env:
-#      SOLC_VERSION: 0.8.23-1.0.0 # How should we manage solc version updates?
-#      SOLC_URL: "https://github.com/matter-labs/era-solidity/releases/download"
-#      CARGO_NET_GIT_FETCH_WITH_CLI: true
-#      UNIT_TESTS_RESULTS_XML: unit-tests-results.xml
-#      RUSTC_BOOTSTRAP: 1 # Use rustc in bootstrap mode allowing cargo2junit to use experimental --json feature
-#    container:
-#      image: matterlabs/llvm_runner_jammy:latest
-#      credentials:
-#        username: ${{ secrets.DOCKERHUB_USER }}
-#        password: ${{ secrets.DOCKERHUB_TOKEN }}
-#    steps:
-#      - name: Checkout source
-#        uses: actions/checkout@v4
-#      - name: Prepare environment
-#        run: |
-#          rustup target add ${{ matrix.target }}
-#      - name: Install solc compiler
-#        run: |
-#          curl --verbose \
-#            --location -o "${PWD}/solc" "${SOLC_URL}/${SOLC_VERSION}/${{ matrix.solc-name }}-${SOLC_VERSION}" && \
-#            chmod a+x "${PWD}/solc"
-#          echo "${PWD}" >> "${GITHUB_PATH}"
-#      - name: Build LLVM framework
-#        run: |
-#          cargo install compiler-llvm-builder --target ${{ matrix.target }}
-#          zkevm-llvm clone
-#          zkevm-llvm build
-#      - name: Build zksolc
-#        run: |
-#          if [[ ${{ matrix.target }} == aarch64-unknown-linux-musl ]]; then
-#            export RUSTFLAGS="-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
-#          fi
-#          cargo build --release --target ${{ matrix.target }}
-#          echo "${PWD}/target/${{ matrix.target }}/release" >> "${GITHUB_PATH}"
-#      - name: Run unit tests
-#        continue-on-error: true
-#        run: |
-#          cargo install cargo2junit
-#          cargo test --verbose --target ${{ matrix.target }} -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
-#          cat "${UNIT_TESTS_RESULTS_XML}"
-#      - name: Upload test results
-#        uses: EnricoMi/publish-unit-test-result-action@v2
-#        with:
-#          check_name: ${{ matrix.name }} Unit Tests Results
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+  unit-tests-macos:
+    strategy:
+      matrix:
+        include:
+          - name: "MacOS x86"
+            runner: macos-12-large
+            solc-name: "solc-macosx-amd64"
+          - name: "MacOS arm64"
+            runner: [self-hosted, macOS, ARM64]
+            solc-name: "solc-macosx-arm64"
+    runs-on: ${{ matrix.runner }}
+    name: ${{ matrix.name }}
+    defaults:
+      run:
+        shell: zsh {0} # For MacOS hosts, .zprofile is pre-configured
+    steps:
+      # TODO: This step should be done as part of github runners hooks
+      # Users should always expect clean workspace when a new job starts
+      # https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/
+      - name: Cleanup workspace
+        if: ${{ matrix.name }} == "MacOS ARM64"
+        run: |
+          setopt rmstarsilent
+          setopt +o nomatch
+          rm -rf ${{ github.workspace }}/*
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Prepare environment
+        run: |
+          brew install cmake ninja
+      - name: Build LLVM framework
+        run: |
+          cargo install compiler-llvm-builder
+          zkevm-llvm clone
+          zkevm-llvm build
+      - name: Install solc compiler
+        run: |
+          curl --verbose \
+            --location -o "${PWD}/solc" "${SOLC_URL}/${SOLC_VERSION}/${{ matrix.solc-name }}-${SOLC_VERSION}" && \
+            chmod a+x "${PWD}/solc"
+          echo "${PWD}" >> "${GITHUB_PATH}"
+      - name: Build zksolc
+        run: |
+          cargo build --release
+          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
+      - name: Run unit tests
+        continue-on-error: true
+        run: |
+          cargo install cargo2junit
+          cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+      - name: Upload test results
+        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        with:
+          check_name: ${{ matrix.name }} Unit Tests Results
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+          action_fail_on_inconclusive: true
+
+  unit-tests-linux:
+    strategy:
+      matrix:
+        include:
+          - name: "Linux x86"
+            runner: matterlabs-ci-runner
+            solc-name: "solc-linux-amd64"
+            target: "x86_64-unknown-linux-musl"
+          - name: "Linux arm64"
+            runner: matterlabs-ci-runner-arm
+            solc-name: "solc-linux-arm64"
+            target: "aarch64-unknown-linux-musl"
+    runs-on: ${{ matrix.runner }}
+    name: ${{ matrix.name }}
+    container:
+      image: matterlabs/llvm_runner_jammy:latest
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USER }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Prepare environment
+        run: |
+          rustup target add ${{ matrix.target }}
+      - name: Install solc compiler
+        run: |
+          curl --verbose \
+            --location -o "${PWD}/solc" "${SOLC_URL}/${SOLC_VERSION}/${{ matrix.solc-name }}-${SOLC_VERSION}" && \
+            chmod a+x "${PWD}/solc"
+          echo "${PWD}" >> "${GITHUB_PATH}"
+      - name: Build LLVM framework
+        run: |
+          cargo install compiler-llvm-builder --target ${{ matrix.target }}
+          zkevm-llvm clone
+          zkevm-llvm build
+      - name: Build zksolc
+        run: |
+          if [[ ${{ matrix.target }} == aarch64-unknown-linux-musl ]]; then
+            export RUSTFLAGS="-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
+          fi
+          cargo build --release --target ${{ matrix.target }}
+          echo "${PWD}/target/${{ matrix.target }}/release" >> "${GITHUB_PATH}"
+      - name: Run unit tests
+        continue-on-error: true
+        run: |
+          cargo install cargo2junit
+          cargo test --verbose --target ${{ matrix.target }} -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+          cat "${UNIT_TESTS_RESULTS_XML}"
+      - name: Upload test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          check_name: ${{ matrix.name }} Unit Tests Results
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+          action_fail_on_inconclusive: true
+
   build_windows_amd64:
     runs-on: windows-2022-github-hosted-16core
     env:
-      CARGO_NET_GIT_FETCH_WITH_CLI: true
       LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
-      SOLC_URL: "https://github.com/matter-labs/era-solidity/releases/download"
-      SOLC_VERSION: 0.8.23-1.0.0 # How should we manage solc version updates?
-      UNIT_TESTS_RESULTS_XML: unit-tests-results.xml
-      RUSTC_BOOTSTRAP: 1 # Use rustc in bootstrap mode allowing cargo2junit to use experimental --json feature
     defaults:
       run:
         shell: msys2 {0}
@@ -189,9 +183,6 @@ jobs:
         run: |
           cargo install cargo2junit
           export PATH="$PWD/target/release:$PWD:$PATH:/c/Users/runneradmin/.cargo/bin/"
-          echo $PATH
-          zksolc.exe --version
-          solc.exe --version
           cargo test --verbose -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
           cat "${UNIT_TESTS_RESULTS_XML}"
       - name: Upload test results
@@ -200,3 +191,4 @@ jobs:
           check_name: Windows Unit Tests Results
           github_token: ${{ secrets.GITHUB_TOKEN }}
           files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+          action_fail_on_inconclusive: true

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -14,8 +14,6 @@ jobs:
   run-unit-tests:
     runs-on: [self-hosted, macOS, ARM64]
     name: Unit Tests
-    container:
-      image: matterlabs/llvm_runner:latest
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: true
       UNIT_TESTS_RESULTS_XML: unit-tests-results.xml

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -90,10 +90,10 @@ jobs:
             runner: matterlabs-ci-runner
             solc-name: "solc-linux-amd64"
             target: "x86_64-unknown-linux-musl"
-          - name: "Linux arm64"
-            runner: matterlabs-ci-runner-arm
-            solc-name: "solc-linux-arm64"
-            target: "aarch64-unknown-linux-musl"
+#          - name: "Linux arm64"
+#            runner: matterlabs-ci-runner-arm
+#            solc-name: "solc-linux-arm64"
+#            target: "aarch64-unknown-linux-musl"
     runs-on: ${{ matrix.runner }}
     name: ${{ matrix.name }}
     env:
@@ -111,7 +111,6 @@ jobs:
         run: |
           rustup target add ${{ matrix.target }}
       - name: Install solc compiler
-        shell: zsh {0}
         run: |
           curl --verbose \
             --location -o "${PWD}/solc" "${SOLC_URL}/${SOLC_VERSION}/${{ matrix.solc-name }}-${SOLC_VERSION}" && \

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -38,6 +38,10 @@ jobs:
           rm -rf ${{ github.workspace }}/*
       - name: Checkout source
         uses: actions/checkout@v4
+      - name: Prepare environment
+        shell: zsh {0}
+        run: |
+          brew install cmake ninja
       - name: Build LLVM framework
         shell: zsh {0}
         run: |

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,55 +1,115 @@
 name: Unit Tests
 
+# Execute workflow for each PR and with each merge to the trunk
 on:
   pull_request:
   push:
     branches:
       - main
 
+# Cancel the workflow if any new changes pushed to a feature branch or the trunk
+#
+# if the same workspace is shared between runners (today it's true for ARM64 MacOS host)
+# /Users/hetzner/actions-runner/_work/era-compiler-solidity
+# we cannot allow any concurrent jobs for it, otherwise, CI will fail for 2 PRs tested at the same time
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false # for now, false (put jobs in queue) allowing multiple PR testing consequently (tbd)
 
 jobs:
-  unit-tests-macos:
+#  unit-tests-macos:
+#    strategy:
+#      matrix:
+#        include:
+#          - name: "MacOS x86"
+#            runner: macos-12-large
+#            solc-name: "solc-macosx-amd64"
+#          - name: "MacOS arm64"
+#            runner: [self-hosted, macOS, ARM64]
+#            solc-name: "solc-macosx-arm64"
+#    runs-on: ${{ matrix.runner }}
+#    name: ${{ matrix.name }}
+#    env:
+#      SOLC_VERSION: 0.8.23-1.0.0 # How should we manage solc version updates?
+#      SOLC_URL: "https://github.com/matter-labs/era-solidity/releases/download"
+#      CARGO_NET_GIT_FETCH_WITH_CLI: true
+#      UNIT_TESTS_RESULTS_XML: unit-tests-results.xml
+#      RUSTC_BOOTSTRAP: 1 # Use rustc in bootstrap mode allowing cargo2junit to use experimental --json feature
+#    steps:
+#      # TODO: This step should be done as part of github runners hooks
+#      # Users should always expect clean workspace when a new job starts
+#      # https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/
+#      - name: Cleanup workspace
+#        if: ${{ matrix.name }} == "MacOS ARM64"
+#        shell: zsh {0}
+#        run: |
+#          setopt rmstarsilent
+#          setopt +o nomatch
+#          rm -rf ${{ github.workspace }}/*
+#      - name: Checkout source
+#        uses: actions/checkout@v4
+#      - name: Prepare environment
+#        shell: zsh {0}
+#        run: |
+#          brew install cmake ninja
+#      - name: Build LLVM framework
+#        shell: zsh {0}
+#        run: |
+#          cargo install compiler-llvm-builder
+#          zkevm-llvm clone
+#          zkevm-llvm build
+#      - name: Install solc compiler
+#        shell: zsh {0}
+#        run: |
+#          curl --verbose \
+#            --location -o "${PWD}/solc" "${SOLC_URL}/${SOLC_VERSION}/${{ matrix.solc-name }}-${SOLC_VERSION}" && \
+#            chmod a+x "${PWD}/solc"
+#          echo "${PWD}" >> "${GITHUB_PATH}"
+#      - name: Build zksolc
+#        shell: zsh {0}
+#        run: |
+#          cargo build --release
+#          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
+#      - name: Run unit tests
+#        shell: zsh {0}
+#        continue-on-error: true
+#        run: |
+#          cargo install cargo2junit
+#          cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+#      - name: Upload test results
+#        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+#        with:
+#          check_name: ${{ matrix.name }} Unit Tests Results
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+  unit-tests-linux:
     strategy:
       matrix:
         include:
-          - name: "MacOS x86"
-            runner: macos-12-large
-            solc-name: "solc-macosx-amd64"
-          - name: "MacOS ARM64"
-            runner: [self-hosted, macOS, ARM64]
-            solc-name: "solc-macosx-arm64"
+          - name: "Linux x86"
+            runner: matterlabs-ci-runner
+            solc-name: "solc-linux-amd64"
+            target: "x86_64-unknown-linux-musl"
+          - name: "Linux arm64"
+            runner: matterlabs-ci-runner-arm
+            solc-name: "solc-linux-arm64"
+            target: "aarch64-unknown-linux-musl"
     runs-on: ${{ matrix.runner }}
     name: ${{ matrix.name }}
     env:
+      SOLC_VERSION: 0.8.23-1.0.0 # How should we manage solc version updates?
       SOLC_URL: "https://github.com/matter-labs/era-solidity/releases/download"
-      SOLC_VERSION: 0.8.23-1.0.0
       CARGO_NET_GIT_FETCH_WITH_CLI: true
       UNIT_TESTS_RESULTS_XML: unit-tests-results.xml
-      RUSTC_BOOTSTRAP: 1
+      RUSTC_BOOTSTRAP: 1 # Use rustc in bootstrap mode allowing cargo2junit to use experimental --json feature
+    container:
+      image: matterlabs/llvm_runner:latest
     steps:
-      - name: Cleanup workspace
-        shell: zsh {0}
-        run: |
-          echo "${{ github.workspace }}"
-          ls -la "${{ github.workspace }}"
-          setopt rmstarsilent
-          setopt +o nomatch
-          rm -rf ${{ github.workspace }}/*
       - name: Checkout source
         uses: actions/checkout@v4
       - name: Prepare environment
-        shell: zsh {0}
         run: |
-          brew install cmake ninja
-      - name: Build LLVM framework
-        shell: zsh {0}
-        run: |
-          cargo install compiler-llvm-builder
-          zkevm-llvm clone
-          zkevm-llvm build
+          rustup target add ${{ matrix.target }}
       - name: Install solc compiler
         shell: zsh {0}
         run: |
@@ -57,13 +117,16 @@ jobs:
             --location -o "${PWD}/solc" "${SOLC_URL}/${SOLC_VERSION}/${{ matrix.solc-name }}-${SOLC_VERSION}" && \
             chmod a+x "${PWD}/solc"
           echo "${PWD}" >> "${GITHUB_PATH}"
-      - name: Build zksolc
-        shell: zsh {0}
+      - name: Build LLVM framework
         run: |
-          cargo build --release
+          cargo install compiler-llvm-builder --target ${{ matrix.target }}
+          zkevm-llvm clone
+          zkevm-llvm build
+      - name: Build zksolc
+        run: |
+          cargo build --release --target ${{ matrix.target }}
           echo "${PWD}/target/release" >> "${GITHUB_PATH}"
       - name: Run unit tests
-        shell: zsh {0}
         continue-on-error: true
         run: |
           cargo install cargo2junit

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -157,32 +157,45 @@ jobs:
         uses: actions/checkout@v4
       - name: Prepare msys2
         uses: msys2/setup-msys2@v2
-#      - name: Prepare env
-#        run: |
-#          pacman-key --refresh
-#          pacman -Sy
-#          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-#          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-#          pacman --noconfirm -S --needed --overwrite \
-#          base-devel \
-#          git \
-#          ninja \
-#          mingw-w64-x86_64-clang \
-#          mingw-w64-x86_64-lld \
-#          mingw-w64-x86_64-rust \
-#          mingw-w64-x86_64-gcc-libs \
-#          mingw-w64-x86_64-gcc
+      - name: Prepare env
+        run: |
+          pacman-key --refresh
+          pacman -Sy
+          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+          pacman --noconfirm -S --needed --overwrite \
+          base-devel \
+          git \
+          ninja \
+          mingw-w64-x86_64-clang \
+          mingw-w64-x86_64-lld \
+          mingw-w64-x86_64-rust \
+          mingw-w64-x86_64-gcc-libs \
+          mingw-w64-x86_64-gcc
       - name: Install solc compiler
         run: |
           curl --verbose --location -o solc.exe "${SOLC_URL}/${SOLC_VERSION}/solc-windows-amd64-${SOLC_VERSION}.exe"
           echo "${PWD}" >> "${GITHUB_PATH}"
           ./solc.exe --version
-#      - name: Build LLVM framework
-#        run: |
-#          cargo install compiler-llvm-builder
-#          export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"
-#          zkevm-llvm clone
-#          zkevm-llvm build
-#      - name: Build compiler
-#        run: |
-#          cargo build --release
+      - name: Build LLVM framework
+        run: |
+          solc.exe --version
+          cargo install compiler-llvm-builder
+          export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"
+          zkevm-llvm clone
+          zkevm-llvm build
+      - name: Build compiler
+        run: |
+          cargo build --release
+      - name: Run unit tests
+        continue-on-error: true
+        run: |
+          cargo install cargo2junit
+          cargo test --verbose -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+          cat "${UNIT_TESTS_RESULTS_XML}"
+      - name: Upload test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          check_name: ${{ matrix.name }} Unit Tests Results
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: ${{ env.UNIT_TESTS_RESULTS_XML }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -128,8 +128,6 @@ jobs:
       - name: Run unit tests
         continue-on-error: true
         run: |
-#          cargo install cargo2junit --target ${{ matrix.target }}
-#          cargo test -- -Z unstable-options --format json --verbose --target ${{ matrix.target }} | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
            cargo test -vv --target ${{ matrix.target }}
       - name: Upload test results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -128,7 +128,7 @@ jobs:
       - name: Run unit tests
         continue-on-error: true
         run: |
-          cargo install cargo2junit
+          cargo install cargo2junit --target ${{ matrix.target }}
           cargo test -- -Z unstable-options --format json --target ${{ matrix.target }} | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
       - name: Upload test results
         uses: EnricoMi/publish-unit-test-result-action/composite@v2

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,6 +17,7 @@ jobs:
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: true
       UNIT_TESTS_RESULTS_XML: unit-tests-results.xml
+      RUSTC_BOOTSTRAP: 1
     steps:
       - name: Cleanup workspace
         shell: zsh {0}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -157,21 +157,21 @@ jobs:
         uses: actions/checkout@v4
       - name: Prepare msys2
         uses: msys2/setup-msys2@v2
-#      - name: Prepare env
-#        run: |
-#          pacman-key --refresh
-#          pacman -Sy
-#          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-#          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-#          pacman --noconfirm -S --needed --overwrite \
-#          base-devel \
-#          git \
-#          ninja \
-#          mingw-w64-x86_64-clang \
-#          mingw-w64-x86_64-lld \
-#          mingw-w64-x86_64-rust \
-#          mingw-w64-x86_64-gcc-libs \
-#          mingw-w64-x86_64-gcc
+      - name: Prepare env
+        run: |
+          pacman-key --refresh
+          pacman -Sy
+          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+          pacman --noconfirm -S --needed --overwrite \
+          base-devel \
+          git \
+          ninja \
+          mingw-w64-x86_64-clang \
+          mingw-w64-x86_64-lld \
+          mingw-w64-x86_64-rust \
+          mingw-w64-x86_64-gcc-libs \
+          mingw-w64-x86_64-gcc
       - name: Install solc compiler
         run: |
           curl --verbose --location -o solc.exe "${SOLC_URL}/${SOLC_VERSION}/solc-windows-amd64-${SOLC_VERSION}.exe"
@@ -179,9 +179,6 @@ jobs:
       - name: Build LLVM framework
         run: |
           export PATH="$PATH:$PWD"
-          echo $PATH
-          ls -la .
-          solc.exe --version
           cargo install compiler-llvm-builder
           export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"
           zkevm-llvm clone

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -36,15 +36,12 @@ jobs:
 #          zkevm-llvm clone
 #          zkevm-llvm build
 
-      - name: Binaries Simulation
-        run: |
-          wget https://github.com/matter-labs/era-solidity/releases/download/0.8.23-1.0.0/solc-macosx-arm64-0.8.23-1.0.0 -O "${PWD}/solc"
-          wget https://github.com/matter-labs/zksolc-bin/raw/main/macosx-arm64/zksolc-macosx-arm64-v1.3.22 -O "${PWD}/zksolc"
-
       - name: Run unit tests
         shell: zsh {0}
         continue-on-error: true
         run: |
+          wget https://github.com/matter-labs/era-solidity/releases/download/0.8.23-1.0.0/solc-macosx-arm64-0.8.23-1.0.0 -O "${PWD}/solc"
+          wget https://github.com/matter-labs/zksolc-bin/raw/main/macosx-arm64/zksolc-macosx-arm64-v1.3.22 -O "${PWD}/zksolc"
           cargo install cargo2junit
 #          cargo build --release
           export PATH="${PWD}:${PATH}"

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,71 +17,68 @@ concurrency:
   cancel-in-progress: false # for now, false (put jobs in queue) allowing multiple PR testing consequently (tbd)
 
 jobs:
-#  unit-tests-macos:
-#    strategy:
-#      matrix:
-#        include:
-#          - name: "MacOS x86"
-#            runner: macos-12-large
-#            solc-name: "solc-macosx-amd64"
-#          - name: "MacOS arm64"
-#            runner: [self-hosted, macOS, ARM64]
-#            solc-name: "solc-macosx-arm64"
-#    runs-on: ${{ matrix.runner }}
-#    name: ${{ matrix.name }}
-#    env:
-#      SOLC_VERSION: 0.8.23-1.0.0 # How should we manage solc version updates?
-#      SOLC_URL: "https://github.com/matter-labs/era-solidity/releases/download"
-#      CARGO_NET_GIT_FETCH_WITH_CLI: true
-#      UNIT_TESTS_RESULTS_XML: unit-tests-results.xml
-#      RUSTC_BOOTSTRAP: 1 # Use rustc in bootstrap mode allowing cargo2junit to use experimental --json feature
-#    steps:
-#      # TODO: This step should be done as part of github runners hooks
-#      # Users should always expect clean workspace when a new job starts
-#      # https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/
-#      - name: Cleanup workspace
-#        if: ${{ matrix.name }} == "MacOS ARM64"
-#        shell: zsh {0}
-#        run: |
-#          setopt rmstarsilent
-#          setopt +o nomatch
-#          rm -rf ${{ github.workspace }}/*
-#      - name: Checkout source
-#        uses: actions/checkout@v4
-#      - name: Prepare environment
-#        shell: zsh {0}
-#        run: |
-#          brew install cmake ninja
-#      - name: Build LLVM framework
-#        shell: zsh {0}
-#        run: |
-#          cargo install compiler-llvm-builder
-#          zkevm-llvm clone
-#          zkevm-llvm build
-#      - name: Install solc compiler
-#        shell: zsh {0}
-#        run: |
-#          curl --verbose \
-#            --location -o "${PWD}/solc" "${SOLC_URL}/${SOLC_VERSION}/${{ matrix.solc-name }}-${SOLC_VERSION}" && \
-#            chmod a+x "${PWD}/solc"
-#          echo "${PWD}" >> "${GITHUB_PATH}"
-#      - name: Build zksolc
-#        shell: zsh {0}
-#        run: |
-#          cargo build --release
-#          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
-#      - name: Run unit tests
-#        shell: zsh {0}
-#        continue-on-error: true
-#        run: |
-#          cargo install cargo2junit
-#          cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
-#      - name: Upload test results
-#        uses: EnricoMi/publish-unit-test-result-action/composite@v2
-#        with:
-#          check_name: ${{ matrix.name }} Unit Tests Results
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+  unit-tests-macos:
+    strategy:
+      matrix:
+        include:
+          - name: "MacOS x86"
+            runner: macos-12-large
+            solc-name: "solc-macosx-amd64"
+          - name: "MacOS arm64"
+            runner: [self-hosted, macOS, ARM64]
+            solc-name: "solc-macosx-arm64"
+    runs-on: ${{ matrix.runner }}
+    name: ${{ matrix.name }}
+    defaults:
+      run:
+        shell: zsh {0} # For MacOS hosts, .zprofile is pre-configured
+    env:
+      SOLC_VERSION: 0.8.23-1.0.0 # How should we manage solc version updates?
+      SOLC_URL: "https://github.com/matter-labs/era-solidity/releases/download"
+      CARGO_NET_GIT_FETCH_WITH_CLI: true
+      UNIT_TESTS_RESULTS_XML: unit-tests-results.xml
+      RUSTC_BOOTSTRAP: 1 # Use rustc in bootstrap mode allowing cargo2junit to use experimental --json feature
+    steps:
+      # TODO: This step should be done as part of github runners hooks
+      # Users should always expect clean workspace when a new job starts
+      # https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/
+      - name: Cleanup workspace
+        if: ${{ matrix.name }} == "MacOS ARM64"
+        run: |
+          setopt rmstarsilent
+          setopt +o nomatch
+          rm -rf ${{ github.workspace }}/*
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Prepare environment
+        run: |
+          brew install cmake ninja
+      - name: Build LLVM framework
+        run: |
+          cargo install compiler-llvm-builder
+          zkevm-llvm clone
+          zkevm-llvm build
+      - name: Install solc compiler
+        run: |
+          curl --verbose \
+            --location -o "${PWD}/solc" "${SOLC_URL}/${SOLC_VERSION}/${{ matrix.solc-name }}-${SOLC_VERSION}" && \
+            chmod a+x "${PWD}/solc"
+          echo "${PWD}" >> "${GITHUB_PATH}"
+      - name: Build zksolc
+        run: |
+          cargo build --release
+          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
+      - name: Run unit tests
+        continue-on-error: true
+        run: |
+          cargo install cargo2junit
+          cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+      - name: Upload test results
+        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        with:
+          check_name: ${{ matrix.name }} Unit Tests Results
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
   unit-tests-linux:
     strategy:
       matrix:
@@ -102,7 +99,6 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: true
       UNIT_TESTS_RESULTS_XML: unit-tests-results.xml
       RUSTC_BOOTSTRAP: 1 # Use rustc in bootstrap mode allowing cargo2junit to use experimental --json feature
-      RUSTFLAGS: "-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
     container:
 #      image: matterlabs/llvm_runner:latest
       image: matterlabs/llvm_runner_jammy:latest
@@ -128,6 +124,9 @@ jobs:
           zkevm-llvm build
       - name: Build zksolc
         run: |
+          if [[ ${{ matrix.target }} == aarch64-unknown-linux-musl ]]; then
+            export RUSTFLAGS="-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
+          fi
           cargo build --release --target ${{ matrix.target }}
           echo "${PWD}/target/${{ matrix.target }}/release" >> "${GITHUB_PATH}"
       - name: Run unit tests
@@ -144,3 +143,40 @@ jobs:
           check_name: ${{ matrix.name }} Unit Tests Results
           github_token: ${{ secrets.GITHUB_TOKEN }}
           files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+#  build_windows_amd64:
+#    runs-on: windows-2022-github-hosted-16core
+#    env:
+#      CARGO_NET_GIT_FETCH_WITH_CLI: true
+#      LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
+#    defaults:
+#      run:
+#        shell: msys2 {0}
+#    steps:
+#      - name: Checkout source
+#        uses: actions/checkout@v4
+#      - name: Prepare msys2
+#        uses: msys2/setup-msys2@v2
+#      - name: Prepare env
+#        run: |
+#          pacman-key --refresh
+#          pacman -Sy
+#          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+#          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+#          pacman --noconfirm -S --needed --overwrite \
+#          base-devel \
+#          git \
+#          ninja \
+#          mingw-w64-x86_64-clang \
+#          mingw-w64-x86_64-lld \
+#          mingw-w64-x86_64-rust \
+#          mingw-w64-x86_64-gcc-libs \
+#          mingw-w64-x86_64-gcc
+#      - name: Build LLVM framework
+#        run: |
+#          cargo install compiler-llvm-builder
+#          export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"
+#          zkevm-llvm clone
+#          zkevm-llvm build
+#      - name: Build compiler
+#        run: |
+#          cargo build --release

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,145 +17,146 @@ concurrency:
   cancel-in-progress: false # for now, false (put jobs in queue) allowing multiple PR testing consequently (tbd)
 
 jobs:
-  unit-tests-macos:
-    strategy:
-      matrix:
-        include:
-          - name: "MacOS x86"
-            runner: macos-12-large
-            solc-name: "solc-macosx-amd64"
-          - name: "MacOS arm64"
-            runner: [self-hosted, macOS, ARM64]
-            solc-name: "solc-macosx-arm64"
-    runs-on: ${{ matrix.runner }}
-    name: ${{ matrix.name }}
-    defaults:
-      run:
-        shell: zsh {0} # For MacOS hosts, .zprofile is pre-configured
-    env:
-      SOLC_VERSION: 0.8.23-1.0.0 # How should we manage solc version updates?
-      SOLC_URL: "https://github.com/matter-labs/era-solidity/releases/download"
-      CARGO_NET_GIT_FETCH_WITH_CLI: true
-      UNIT_TESTS_RESULTS_XML: unit-tests-results.xml
-      RUSTC_BOOTSTRAP: 1 # Use rustc in bootstrap mode allowing cargo2junit to use experimental --json feature
-    steps:
-      # TODO: This step should be done as part of github runners hooks
-      # Users should always expect clean workspace when a new job starts
-      # https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/
-      - name: Cleanup workspace
-        if: ${{ matrix.name }} == "MacOS ARM64"
-        run: |
-          setopt rmstarsilent
-          setopt +o nomatch
-          rm -rf ${{ github.workspace }}/*
-      - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Prepare environment
-        run: |
-          brew install cmake ninja
-      - name: Build LLVM framework
-        run: |
-          cargo install compiler-llvm-builder
-          zkevm-llvm clone
-          zkevm-llvm build
-      - name: Install solc compiler
-        run: |
-          curl --verbose \
-            --location -o "${PWD}/solc" "${SOLC_URL}/${SOLC_VERSION}/${{ matrix.solc-name }}-${SOLC_VERSION}" && \
-            chmod a+x "${PWD}/solc"
-          echo "${PWD}" >> "${GITHUB_PATH}"
-      - name: Build zksolc
-        run: |
-          cargo build --release
-          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
-      - name: Run unit tests
-        continue-on-error: true
-        run: |
-          cargo install cargo2junit
-          cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
-      - name: Upload test results
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
-        with:
-          check_name: ${{ matrix.name }} Unit Tests Results
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-  unit-tests-linux:
-    strategy:
-      matrix:
-        include:
-          - name: "Linux x86"
-            runner: matterlabs-ci-runner
-            solc-name: "solc-linux-amd64"
-            target: "x86_64-unknown-linux-musl"
+#  unit-tests-macos:
+#    strategy:
+#      matrix:
+#        include:
+#          - name: "MacOS x86"
+#            runner: macos-12-large
+#            solc-name: "solc-macosx-amd64"
+#          - name: "MacOS arm64"
+#            runner: [self-hosted, macOS, ARM64]
+#            solc-name: "solc-macosx-arm64"
+#    runs-on: ${{ matrix.runner }}
+#    name: ${{ matrix.name }}
+#    defaults:
+#      run:
+#        shell: zsh {0} # For MacOS hosts, .zprofile is pre-configured
+#    env:
+#      SOLC_VERSION: 0.8.23-1.0.0 # How should we manage solc version updates?
+#      SOLC_URL: "https://github.com/matter-labs/era-solidity/releases/download"
+#      CARGO_NET_GIT_FETCH_WITH_CLI: true
+#      UNIT_TESTS_RESULTS_XML: unit-tests-results.xml
+#      RUSTC_BOOTSTRAP: 1 # Use rustc in bootstrap mode allowing cargo2junit to use experimental --json feature
+#    steps:
+#      # TODO: This step should be done as part of github runners hooks
+#      # Users should always expect clean workspace when a new job starts
+#      # https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/
+#      - name: Cleanup workspace
+#        if: ${{ matrix.name }} == "MacOS ARM64"
+#        run: |
+#          setopt rmstarsilent
+#          setopt +o nomatch
+#          rm -rf ${{ github.workspace }}/*
+#      - name: Checkout source
+#        uses: actions/checkout@v4
+#      - name: Prepare environment
+#        run: |
+#          brew install cmake ninja
+#      - name: Build LLVM framework
+#        run: |
+#          cargo install compiler-llvm-builder
+#          zkevm-llvm clone
+#          zkevm-llvm build
+#      - name: Install solc compiler
+#        run: |
+#          curl --verbose \
+#            --location -o "${PWD}/solc" "${SOLC_URL}/${SOLC_VERSION}/${{ matrix.solc-name }}-${SOLC_VERSION}" && \
+#            chmod a+x "${PWD}/solc"
+#          echo "${PWD}" >> "${GITHUB_PATH}"
+#      - name: Build zksolc
+#        run: |
+#          cargo build --release
+#          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
+#      - name: Run unit tests
+#        continue-on-error: true
+#        run: |
+#          cargo install cargo2junit
+#          cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+#      - name: Upload test results
+#        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+#        with:
+#          check_name: ${{ matrix.name }} Unit Tests Results
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+#  unit-tests-linux:
+#    strategy:
+#      matrix:
+#        include:
+#          - name: "Linux x86"
+#            runner: matterlabs-ci-runner
+#            solc-name: "solc-linux-amd64"
+#            target: "x86_64-unknown-linux-musl"
 #          - name: "Linux arm64"
 #            runner: matterlabs-ci-runner-arm
 #            solc-name: "solc-linux-arm64"
 #            target: "aarch64-unknown-linux-musl"
-    runs-on: ${{ matrix.runner }}
-    name: ${{ matrix.name }}
-    env:
-      SOLC_VERSION: 0.8.23-1.0.0 # How should we manage solc version updates?
-      SOLC_URL: "https://github.com/matter-labs/era-solidity/releases/download"
-      CARGO_NET_GIT_FETCH_WITH_CLI: true
-      UNIT_TESTS_RESULTS_XML: unit-tests-results.xml
-      RUSTC_BOOTSTRAP: 1 # Use rustc in bootstrap mode allowing cargo2junit to use experimental --json feature
-    container:
-#      image: matterlabs/llvm_runner:latest
-      image: matterlabs/llvm_runner_jammy:latest
-      credentials:
-        username: ${{ secrets.DOCKERHUB_USER }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Prepare environment
-        run: |
-          rustup target add ${{ matrix.target }}
-      - name: Install solc compiler
-        run: |
-          curl --verbose \
-            --location -o "${PWD}/solc" "${SOLC_URL}/${SOLC_VERSION}/${{ matrix.solc-name }}-${SOLC_VERSION}" && \
-            chmod a+x "${PWD}/solc"
-          echo "${PWD}" >> "${GITHUB_PATH}"
-      - name: Build LLVM framework
-        run: |
-          cargo install compiler-llvm-builder --target ${{ matrix.target }}
-          zkevm-llvm clone
-          zkevm-llvm build
-      - name: Build zksolc
-        run: |
-          if [[ ${{ matrix.target }} == aarch64-unknown-linux-musl ]]; then
-            export RUSTFLAGS="-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
-          fi
-          cargo build --release --target ${{ matrix.target }}
-          echo "${PWD}/target/${{ matrix.target }}/release" >> "${GITHUB_PATH}"
-      - name: Run unit tests
-        continue-on-error: true
-        run: |
-          cargo install cargo2junit
-          which solc
-          which zksolc
-          cargo test --verbose --target ${{ matrix.target }} -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
-          cat "${UNIT_TESTS_RESULTS_XML}"
-      - name: Upload test results
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        with:
-          check_name: ${{ matrix.name }} Unit Tests Results
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-#  build_windows_amd64:
-#    runs-on: windows-2022-github-hosted-16core
+#    runs-on: ${{ matrix.runner }}
+#    name: ${{ matrix.name }}
 #    env:
+#      SOLC_VERSION: 0.8.23-1.0.0 # How should we manage solc version updates?
+#      SOLC_URL: "https://github.com/matter-labs/era-solidity/releases/download"
 #      CARGO_NET_GIT_FETCH_WITH_CLI: true
-#      LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
-#    defaults:
-#      run:
-#        shell: msys2 {0}
+#      UNIT_TESTS_RESULTS_XML: unit-tests-results.xml
+#      RUSTC_BOOTSTRAP: 1 # Use rustc in bootstrap mode allowing cargo2junit to use experimental --json feature
+#    container:
+#      image: matterlabs/llvm_runner_jammy:latest
+#      credentials:
+#        username: ${{ secrets.DOCKERHUB_USER }}
+#        password: ${{ secrets.DOCKERHUB_TOKEN }}
 #    steps:
 #      - name: Checkout source
 #        uses: actions/checkout@v4
-#      - name: Prepare msys2
-#        uses: msys2/setup-msys2@v2
+#      - name: Prepare environment
+#        run: |
+#          rustup target add ${{ matrix.target }}
+#      - name: Install solc compiler
+#        run: |
+#          curl --verbose \
+#            --location -o "${PWD}/solc" "${SOLC_URL}/${SOLC_VERSION}/${{ matrix.solc-name }}-${SOLC_VERSION}" && \
+#            chmod a+x "${PWD}/solc"
+#          echo "${PWD}" >> "${GITHUB_PATH}"
+#      - name: Build LLVM framework
+#        run: |
+#          cargo install compiler-llvm-builder --target ${{ matrix.target }}
+#          zkevm-llvm clone
+#          zkevm-llvm build
+#      - name: Build zksolc
+#        run: |
+#          if [[ ${{ matrix.target }} == aarch64-unknown-linux-musl ]]; then
+#            export RUSTFLAGS="-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
+#          fi
+#          cargo build --release --target ${{ matrix.target }}
+#          echo "${PWD}/target/${{ matrix.target }}/release" >> "${GITHUB_PATH}"
+#      - name: Run unit tests
+#        continue-on-error: true
+#        run: |
+#          cargo install cargo2junit
+#          cargo test --verbose --target ${{ matrix.target }} -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+#          cat "${UNIT_TESTS_RESULTS_XML}"
+#      - name: Upload test results
+#        uses: EnricoMi/publish-unit-test-result-action@v2
+#        with:
+#          check_name: ${{ matrix.name }} Unit Tests Results
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+  build_windows_amd64:
+    runs-on: windows-2022-github-hosted-16core
+    env:
+      CARGO_NET_GIT_FETCH_WITH_CLI: true
+      LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
+      SOLC_URL: "https://github.com/matter-labs/era-solidity/releases/download"
+      SOLC_VERSION: 0.8.23-1.0.0 # How should we manage solc version updates?
+      UNIT_TESTS_RESULTS_XML: unit-tests-results.xml
+      RUSTC_BOOTSTRAP: 1 # Use rustc in bootstrap mode allowing cargo2junit to use experimental --json feature
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Prepare msys2
+        uses: msys2/setup-msys2@v2
 #      - name: Prepare env
 #        run: |
 #          pacman-key --refresh
@@ -171,6 +172,11 @@ jobs:
 #          mingw-w64-x86_64-rust \
 #          mingw-w64-x86_64-gcc-libs \
 #          mingw-w64-x86_64-gcc
+      - name: Install solc compiler
+        run: |
+          curl --verbose --location -o solc.exe "${SOLC_URL}/${SOLC_VERSION}/solc-windows-amd64-${SOLC_VERSION}.exe"
+          echo "${PWD}" >> "${GITHUB_PATH}"
+          ./solc.exe --version
 #      - name: Build LLVM framework
 #        run: |
 #          cargo install compiler-llvm-builder

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -129,7 +129,10 @@ jobs:
         continue-on-error: true
         run: |
           cargo install cargo2junit
-          cargo test --target ${{ matrix.target }} -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+          which solc
+          which zksolc
+          cargo test --verbose --target ${{ matrix.target }} -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+          cat "${UNIT_TESTS_RESULTS_XML}"
       - name: Upload test results
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -86,14 +86,14 @@ jobs:
     strategy:
       matrix:
         include:
-#          - name: "Linux x86"
-#            runner: matterlabs-ci-runner
-#            solc-name: "solc-linux-amd64"
-#            target: "x86_64-unknown-linux-musl"
-          - name: "Linux arm64"
-            runner: matterlabs-ci-runner-arm
-            solc-name: "solc-linux-arm64"
-            target: "aarch64-unknown-linux-musl"
+          - name: "Linux x86"
+            runner: matterlabs-ci-runner
+            solc-name: "solc-linux-amd64"
+            target: "x86_64-unknown-linux-musl"
+#          - name: "Linux arm64"
+#            runner: matterlabs-ci-runner-arm
+#            solc-name: "solc-linux-arm64"
+#            target: "aarch64-unknown-linux-musl"
     runs-on: ${{ matrix.runner }}
     name: ${{ matrix.name }}
     env:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -175,10 +175,8 @@ jobs:
       - name: Install solc compiler
         run: |
           curl --verbose --location -o solc.exe "${SOLC_URL}/${SOLC_VERSION}/solc-windows-amd64-${SOLC_VERSION}.exe"
-          ./solc.exe --version
       - name: Build LLVM framework
         run: |
-          export PATH="$PATH:$PWD"
           cargo install compiler-llvm-builder
           export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"
           zkevm-llvm clone
@@ -190,15 +188,15 @@ jobs:
         continue-on-error: true
         run: |
           cargo install cargo2junit
-          export PATH="$PWD/target/release:$PATH"
+          export PATH="$PWD/target/release:$PWD:$PATH:/c/Users/runneradmin/.cargo/bin/"
           echo $PATH
-          ls -la "$PWD/target/release"
           zksolc.exe --version
-          cargo test --verbose -- -Z unstable-options --format json
+          solc.exe --version
+          cargo test --verbose -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
           cat "${UNIT_TESTS_RESULTS_XML}"
       - name: Upload test results
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
         with:
-          check_name: ${{ matrix.name }} Unit Tests Results
+          check_name: Windows Unit Tests Results
           github_token: ${{ secrets.GITHUB_TOKEN }}
           files: ${{ env.UNIT_TESTS_RESULTS_XML }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -25,10 +25,8 @@ jobs:
           setopt rmstarsilent
           setopt +o nomatch
           rm -rf ${{ github.workspace }}/*
-
       - name: Checkout source
         uses: actions/checkout@v4
-
       - name: Run unit tests
         shell: zsh {0}
         continue-on-error: true
@@ -36,13 +34,11 @@ jobs:
           wget https://github.com/matter-labs/era-solidity/releases/download/0.8.23-1.0.0/solc-macosx-arm64-0.8.23-1.0.0 -O "${PWD}/solc"
           wget https://github.com/matter-labs/zksolc-bin/raw/main/macosx-arm64/zksolc-macosx-arm64-v1.3.22 -O "${PWD}/zksolc"
           cargo install cargo2junit
-#          cargo build --release
           export PATH="${PWD}:${PATH}"
           which solc
           which zksolc
           cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
           cat "${UNIT_TESTS_RESULTS_XML}"
-
       - name: Upload test results
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
         with:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -29,20 +29,26 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: Build LLVM framework
-        shell: zsh {0}
+#      - name: Build LLVM framework
+#        shell: zsh {0}
+#        run: |
+#          cargo install compiler-llvm-builder
+#          zkevm-llvm clone
+#          zkevm-llvm build
+
+      - name: Binaries Simulation
         run: |
-          cargo install compiler-llvm-builder
-          zkevm-llvm clone
-          zkevm-llvm build
+          wget https://github.com/matter-labs/era-solidity/releases/download/0.8.23-1.0.0/solc-macosx-arm64-0.8.23-1.0.0 -O "${PWD}/solc"
+          wget https://github.com/matter-labs/zksolc-bin/raw/main/macosx-arm64/zksolc-macosx-arm64-v1.3.22 -O "${PWD}/zksolc"
 
       - name: Run unit tests
         shell: zsh {0}
         continue-on-error: true
         run: |
           cargo install cargo2junit
-          cargo build --release
-          export PATH="${PWD}/target/release:${PATH}"
+#          cargo build --release
+          export PATH="${PWD}:${PATH}"
+          which solc
           which zksolc
           cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
           cat "${UNIT_TESTS_RESULTS_XML}"

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -36,16 +36,14 @@ jobs:
           zkevm-llvm clone
           zkevm-llvm build
 
-      - name: Build compiler
-        shell: zsh {0}
-        run: |
-          cargo build --release
-
       - name: Run unit tests
         shell: zsh {0}
         run: |
           cargo install cargo2junit
+          cargo build --release
+          which zksolc
           cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+          cat "${UNIT_TESTS_RESULTS_XML}"
 
       - name: Upload test results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -86,14 +86,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: "Linux x86"
-            runner: matterlabs-ci-runner
-            solc-name: "solc-linux-amd64"
-            target: "x86_64-unknown-linux-musl"
-#          - name: "Linux arm64"
-#            runner: matterlabs-ci-runner-arm
-#            solc-name: "solc-linux-arm64"
-#            target: "aarch64-unknown-linux-musl"
+#          - name: "Linux x86"
+#            runner: matterlabs-ci-runner
+#            solc-name: "solc-linux-amd64"
+#            target: "x86_64-unknown-linux-musl"
+          - name: "Linux arm64"
+            runner: matterlabs-ci-runner-arm
+            solc-name: "solc-linux-arm64"
+            target: "aarch64-unknown-linux-musl"
     runs-on: ${{ matrix.runner }}
     name: ${{ matrix.name }}
     env:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -37,7 +37,9 @@ jobs:
         shell: zsh {0}
         continue-on-error: true
         run: |
-          wget https://github.com/matter-labs/era-solidity/releases/download/0.8.23-1.0.0/solc-macosx-arm64-0.8.23-1.0.0 -O "${PWD}/solc"          
+          curl -o "${PWD}/solc" https://github.com/matter-labs/era-solidity/releases/download/0.8.23-1.0.0/solc-macosx-arm64-0.8.23-1.0.0
+          chmod a+x "${PWD}/solc"
+          ls -la "${PWD}/solc"
           cargo install cargo2junit
           cargo build --release
           export PATH="${PWD}/target/release:${PWD}:${PATH}"

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -175,10 +175,10 @@ jobs:
       - name: Install solc compiler
         run: |
           curl --verbose --location -o solc.exe "${SOLC_URL}/${SOLC_VERSION}/solc-windows-amd64-${SOLC_VERSION}.exe"
-          echo "${PWD}" >> "${GITHUB_PATH}"
           ./solc.exe --version
       - name: Build LLVM framework
         run: |
+          export PATH="${PATH}:{$PWD}"
           solc.exe --version
           cargo install compiler-llvm-builder
           export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   run-unit-tests:
-    runs-on: matterlabs-ci-runner
+    runs-on: [self-hosted, macOS, ARM64]
     name: Unit Tests
     container:
       image: matterlabs/llvm_runner:latest
@@ -25,14 +25,13 @@ jobs:
 
       - name: Build LLVM framework
         run: |
-          rustup target add x86_64-unknown-linux-musl
-          cargo install compiler-llvm-builder --target x86_64-unknown-linux-musl
+          cargo install compiler-llvm-builder
           zkevm-llvm clone
           zkevm-llvm build
 
       - name: Build compiler
         run: |
-          cargo build --release --target x86_64-unknown-linux-musl
+          cargo build --release
 
       - name: Run unit tests
         run: |

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -123,12 +123,13 @@ jobs:
           zkevm-llvm build
       - name: Build zksolc
         run: |
-          cargo build --release -vv --target ${{ matrix.target }}
+          cargo build --release --target ${{ matrix.target }}
           echo "${PWD}/target/release" >> "${GITHUB_PATH}"
       - name: Run unit tests
         continue-on-error: true
         run: |
-           cargo test -vv --target ${{ matrix.target }}
+          cargo install cargo2junit
+          cargo test --target ${{ matrix.target }} -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
       - name: Upload test results
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run-unit-tests-macos:
+  unit-tests-macos:
     strategy:
       matrix:
         include:
@@ -22,7 +22,7 @@ jobs:
             runner: [self-hosted, macOS, ARM64]
             solc-name: "solc-macosx-arm64"
     runs-on: ${{ matrix.runner }}
-    name: Unit Tests Macos
+    name: ${{ matrix.name }}
     env:
       SOLC_URL: "https://github.com/matter-labs/era-solidity/releases/download"
       SOLC_VERSION: 0.8.23-1.0.0
@@ -33,6 +33,8 @@ jobs:
       - name: Cleanup workspace
         shell: zsh {0}
         run: |
+          echo "${{ github.workspace }}"
+          ls -la "${{ github.workspace }}"
           setopt rmstarsilent
           setopt +o nomatch
           rm -rf ${{ github.workspace }}/*
@@ -48,21 +50,24 @@ jobs:
           cargo install compiler-llvm-builder
           zkevm-llvm clone
           zkevm-llvm build
+      - name: Install solc compiler
+        shell: zsh {0}
+        run: |
+          curl --verbose \
+            --location -o "${PWD}/solc" "${SOLC_URL}/${SOLC_VERSION}/${{ matrix.solc-name }}-${SOLC_VERSION}" && \
+            chmod a+x "${PWD}/solc"
+          echo "${PWD}" >> "${GITHUB_PATH}"
+      - name: Build zksolc
+        shell: zsh {0}
+        run: |
+          cargo build --release
+          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
       - name: Run unit tests
         shell: zsh {0}
         continue-on-error: true
         run: |
-          echo "${SOLC_URL}/${SOLC_VERSION}/${{ matrix.solc-name }}-${SOLC_VERSION}"
-          curl --location -o "${PWD}/solc" "${SOLC_URL}/${SOLC_VERSION}/${{ matrix.solc-name }}-${SOLC_VERSION}"
-          chmod a+x "${PWD}/solc"
-          ls -la "${PWD}/solc"
           cargo install cargo2junit
-          cargo build --release
-          export PATH="${PWD}/target/release:${PWD}:${PATH}"
-          which solc
-          which zksolc
           cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
-          cat "${UNIT_TESTS_RESULTS_XML}"
       - name: Upload test results
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
         with:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -33,6 +33,8 @@ jobs:
         run: |
           wget https://github.com/matter-labs/era-solidity/releases/download/0.8.23-1.0.0/solc-macosx-arm64-0.8.23-1.0.0 -O "${PWD}/solc"
           wget https://github.com/matter-labs/zksolc-bin/raw/main/macosx-arm64/zksolc-macosx-arm64-v1.3.22 -O "${PWD}/zksolc"
+          cargo install compiler-llvm-builder
+          zkevm-llvm clone
           cargo install cargo2junit
           export PATH="${PWD}:${PATH}"
           which solc

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -102,8 +102,10 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: true
       UNIT_TESTS_RESULTS_XML: unit-tests-results.xml
       RUSTC_BOOTSTRAP: 1 # Use rustc in bootstrap mode allowing cargo2junit to use experimental --json feature
+      RUSTFLAGS: "-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
     container:
-      image: matterlabs/llvm_runner:latest
+#      image: matterlabs/llvm_runner:latest
+      image: matterlabs/llvm_runner_jammy:latest
     steps:
       - name: Checkout source
         uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -11,10 +11,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run-unit-tests:
-    runs-on: [self-hosted, macOS, ARM64]
-    name: Unit Tests
+  run-unit-tests-macos:
+    strategy:
+      matrix:
+        include:
+          - name: "MacOS x86"
+            runner: macos-12-large
+            solc-name: "solc-macosx-amd64"
+          - name: "MacOS ARM64"
+            runner: [self-hosted, macOS, ARM64]
+            solc-name: "solc-macosx-arm64"
+    runs-on: ${{ matrix.runner }}
+    name: Unit Tests Macos
     env:
+      SOLC_URL: "https://github.com/matter-labs/era-solidity/releases/download"
+      SOLC_VERSION: 0.8.23-1.0.0
       CARGO_NET_GIT_FETCH_WITH_CLI: true
       UNIT_TESTS_RESULTS_XML: unit-tests-results.xml
       RUSTC_BOOTSTRAP: 1
@@ -37,7 +48,8 @@ jobs:
         shell: zsh {0}
         continue-on-error: true
         run: |
-          curl --location -o "${PWD}/solc" https://github.com/matter-labs/era-solidity/releases/download/0.8.23-1.0.0/solc-macosx-arm64-0.8.23-1.0.0
+          echo "${SOLC_URL}/${SOLC_VERSION}/${{ matrix.solc-name }}-${SOLC_VERSION}"
+          curl --location -o "${PWD}/solc" "${SOLC_URL}/${SOLC_VERSION}/${{ matrix.solc-name }}-${SOLC_VERSION}"
           chmod a+x "${PWD}/solc"
           ls -la "${PWD}/solc"
           cargo install cargo2junit
@@ -50,6 +62,6 @@ jobs:
       - name: Upload test results
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
         with:
-          check_name: Unit Tests Results
+          check_name: ${{ matrix.name }} Unit Tests Results
           github_token: ${{ secrets.GITHUB_TOKEN }}
           files: ${{ env.UNIT_TESTS_RESULTS_XML }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -106,6 +106,9 @@ jobs:
     container:
 #      image: matterlabs/llvm_runner:latest
       image: matterlabs/llvm_runner_jammy:latest
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USER }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -24,63 +24,63 @@ env:
   RUSTC_BOOTSTRAP: 1 # Use rustc in bootstrap mode allowing cargo2junit to use experimental --json feature
 
 jobs:
-#  unit-tests-macos:
-#    strategy:
-#      matrix:
-#        include:
-#          - name: "MacOS x86"
-#            runner: macos-12-large
-#            solc-name: "solc-macosx-amd64"
-#          - name: "MacOS arm64"
-#            runner: [self-hosted, macOS, ARM64]
-#            solc-name: "solc-macosx-arm64"
-#    runs-on: ${{ matrix.runner }}
-#    name: ${{ matrix.name }}
-#    defaults:
-#      run:
-#        shell: zsh {0} # For MacOS hosts, .zprofile is pre-configured
-#    steps:
-#      # TODO: This step should be done as part of github runners hooks
-#      # Users should always expect clean workspace when a new job starts
-#      # https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/
-#      - name: Cleanup workspace
-#        if: ${{ matrix.name }} == "MacOS ARM64"
-#        run: |
-#          setopt rmstarsilent
-#          setopt +o nomatch
-#          rm -rf ${{ github.workspace }}/*
-#      - name: Checkout source
-#        uses: actions/checkout@v4
-#      - name: Prepare environment
-#        run: |
-#          brew install cmake ninja
-#      - name: Build LLVM framework
-#        run: |
-#          cargo install compiler-llvm-builder
-#          zkevm-llvm clone
-#          zkevm-llvm build
-#      - name: Install solc compiler
-#        run: |
-#          curl --verbose \
-#            --location -o "${PWD}/solc" "${SOLC_URL}/${SOLC_VERSION}/${{ matrix.solc-name }}-${SOLC_VERSION}" && \
-#            chmod a+x "${PWD}/solc"
-#          echo "${PWD}" >> "${GITHUB_PATH}"
-#      - name: Build zksolc
-#        run: |
-#          cargo build --release
-#          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
-#      - name: Run unit tests
-#        continue-on-error: true
-#        run: |
-#          cargo install cargo2junit
-#          cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
-#      - name: Upload test results
-#        uses: EnricoMi/publish-unit-test-result-action/composite@v2
-#        with:
-#          check_name: ${{ matrix.name }} Unit Tests Results
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-#          action_fail_on_inconclusive: true
+  unit-tests-macos:
+    strategy:
+      matrix:
+        include:
+          - name: "MacOS x86"
+            runner: macos-12-large
+            solc-name: "solc-macosx-amd64"
+          - name: "MacOS arm64"
+            runner: [self-hosted, macOS, ARM64]
+            solc-name: "solc-macosx-arm64"
+    runs-on: ${{ matrix.runner }}
+    name: ${{ matrix.name }}
+    defaults:
+      run:
+        shell: zsh {0} # For MacOS hosts, .zprofile is pre-configured
+    steps:
+      # TODO: This step should be done as part of github runners hooks
+      # Users should always expect clean workspace when a new job starts
+      # https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/
+      - name: Cleanup workspace
+        if: ${{ matrix.name }} == "MacOS ARM64"
+        run: |
+          setopt rmstarsilent
+          setopt +o nomatch
+          rm -rf ${{ github.workspace }}/*
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Prepare environment
+        run: |
+          brew install cmake ninja
+      - name: Build LLVM framework
+        run: |
+          cargo install compiler-llvm-builder
+          zkevm-llvm clone
+          zkevm-llvm build
+      - name: Install solc compiler
+        run: |
+          curl --verbose \
+            --location -o "${PWD}/solc" "${SOLC_URL}/${SOLC_VERSION}/${{ matrix.solc-name }}-${SOLC_VERSION}" && \
+            chmod a+x "${PWD}/solc"
+          echo "${PWD}" >> "${GITHUB_PATH}"
+      - name: Build zksolc
+        run: |
+          cargo build -vv --release
+          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
+      - name: Run unit tests
+        run: |
+          cargo install cargo2junit
+          cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+      - name: Upload test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        with:
+          check_name: ${{ matrix.name }} Unit Tests Results
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+          action_fail_on_inconclusive: true
 
   unit-tests-linux:
     strategy:
@@ -123,8 +123,6 @@ jobs:
           zkevm-llvm build
       - name: Build zksolc
         run: |
-          set -x
-          echo "RUSTFLAGS=${RUSTFLAGS}"
           cargo build -vv --release --target ${{ matrix.target }}
           echo "${PWD}/target/${{ matrix.target }}/release" >> "${GITHUB_PATH}"
       - name: Run unit tests
@@ -141,57 +139,57 @@ jobs:
           files: ${{ env.UNIT_TESTS_RESULTS_XML }}
           action_fail_on_inconclusive: true
 
-#  unit-tests-windows:
-#    name: "Windows"
-#    runs-on: windows-2022-github-hosted-16core
-#    env:
-#      LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
-#    defaults:
-#      run:
-#        shell: msys2 {0}
-#    steps:
-#      - name: Checkout source
-#        uses: actions/checkout@v4
-#      - name: Prepare msys2
-#        uses: msys2/setup-msys2@v2
-#      - name: Prepare env
-#        run: |
-#          pacman-key --refresh
-#          pacman -Sy
-#          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-#          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-#          pacman --noconfirm -S --needed --overwrite \
-#          base-devel \
-#          git \
-#          ninja \
-#          mingw-w64-x86_64-clang \
-#          mingw-w64-x86_64-lld \
-#          mingw-w64-x86_64-rust \
-#          mingw-w64-x86_64-gcc-libs \
-#          mingw-w64-x86_64-gcc
-#      - name: Install solc compiler
-#        run: |
-#          curl --verbose --location -o solc.exe "${SOLC_URL}/${SOLC_VERSION}/solc-windows-amd64-${SOLC_VERSION}.exe"
-#      - name: Build LLVM framework
-#        run: |
-#          cargo install compiler-llvm-builder
-#          export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"
-#          zkevm-llvm clone
-#          zkevm-llvm build
-#      - name: Build compiler
-#        run: |
-#          cargo build --release
-#      - name: Run unit tests
-#        continue-on-error: true
-#        run: |
-#          cargo install cargo2junit
-#          export PATH="$PWD/target/release:$PWD:$PATH:/c/Users/runneradmin/.cargo/bin/"
-#          cargo test --verbose -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
-#          cat "${UNIT_TESTS_RESULTS_XML}"
-#      - name: Upload test results
-#        uses: EnricoMi/publish-unit-test-result-action/composite@v2
-#        with:
-#          check_name: Windows Unit Tests Results
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-#          action_fail_on_inconclusive: true
+  unit-tests-windows:
+    name: "Windows"
+    runs-on: windows-2022-github-hosted-16core
+    env:
+      LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Prepare msys2
+        uses: msys2/setup-msys2@v2
+      - name: Prepare env
+        run: |
+          pacman-key --refresh
+          pacman -Sy
+          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+          pacman --noconfirm -S --needed --overwrite \
+          base-devel \
+          git \
+          ninja \
+          mingw-w64-x86_64-clang \
+          mingw-w64-x86_64-lld \
+          mingw-w64-x86_64-rust \
+          mingw-w64-x86_64-gcc-libs \
+          mingw-w64-x86_64-gcc
+      - name: Install solc compiler
+        run: |
+          curl --verbose --location -o solc.exe "${SOLC_URL}/${SOLC_VERSION}/solc-windows-amd64-${SOLC_VERSION}.exe"
+      - name: Build LLVM framework
+        run: |
+          cargo install compiler-llvm-builder
+          export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"
+          zkevm-llvm clone
+          zkevm-llvm build
+      - name: Build compiler
+        run: |
+          cargo build -vv --release
+      - name: Run unit tests
+        run: |
+          cargo install cargo2junit
+          export PATH="$PWD/target/release:$PWD:$PATH:/c/Users/runneradmin/.cargo/bin/"
+          cargo test --verbose -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+          cat "${UNIT_TESTS_RESULTS_XML}"
+      - name: Upload test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        with:
+          check_name: Windows Unit Tests Results
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+          action_fail_on_inconclusive: true

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -18,20 +18,30 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: true
       UNIT_TESTS_RESULTS_XML: unit-tests-results.xml
     steps:
+      - name: Cleanup workspace
+        shell: zsh {0}
+        run: |
+          setopt rmstarsilent
+          setopt +o nomatch
+          rm -rf ${{ github.workspace }}/*
+
       - name: Checkout source
         uses: actions/checkout@v4
 
       - name: Build LLVM framework
+        shell: zsh {0}
         run: |
           cargo install compiler-llvm-builder
           zkevm-llvm clone
           zkevm-llvm build
 
       - name: Build compiler
+        shell: zsh {0}
         run: |
           cargo build --release
 
       - name: Run unit tests
+        shell: zsh {0}
         run: |
           cargo install cargo2junit
           cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,47 @@
+name: Unit Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run-unit-tests:
+    runs-on: matterlabs-ci-runner
+    name: Unit Tests
+    container:
+      image: matterlabs/llvm_runner:latest
+    env:
+      CARGO_NET_GIT_FETCH_WITH_CLI: true
+      UNIT_TESTS_RESULTS_XML: unit-tests-results.xml
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Build LLVM framework
+        run: |
+          rustup target add x86_64-unknown-linux-musl
+          cargo install compiler-llvm-builder --target x86_64-unknown-linux-musl
+          zkevm-llvm clone
+          zkevm-llvm build
+
+      - name: Build compiler
+        run: |
+          cargo build --release --target x86_64-unknown-linux-musl
+
+      - name: Run unit tests
+        run: |
+          cargo install cargo2junit
+          cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+
+      - name: Upload test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          check_name: Unit Tests Results
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: ${{ env.UNIT_TESTS_RESULTS_XML }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -178,10 +178,9 @@ jobs:
           ./solc.exe --version
       - name: Build LLVM framework
         run: |
-          export PATH="${PATH}:{$PWD}"
+          export PATH="$PATH:$PWD"
           echo $PATH
           ls -la .
-          chmod a+x solc.exe
           solc.exe --version
           cargo install compiler-llvm-builder
           export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -123,13 +123,13 @@ jobs:
           zkevm-llvm build
       - name: Build zksolc
         run: |
-          cargo build --release --target ${{ matrix.target }}
+          cargo build --release --verbose --target ${{ matrix.target }}
           echo "${PWD}/target/release" >> "${GITHUB_PATH}"
       - name: Run unit tests
         continue-on-error: true
         run: |
           cargo install cargo2junit --target ${{ matrix.target }}
-          cargo test -- -Z unstable-options --format json --target ${{ matrix.target }} | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+          cargo test -- -Z unstable-options --format json --verbose --target ${{ matrix.target }} | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
       - name: Upload test results
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
         with:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -37,7 +37,7 @@ jobs:
         shell: zsh {0}
         continue-on-error: true
         run: |
-          curl -o "${PWD}/solc" https://github.com/matter-labs/era-solidity/releases/download/0.8.23-1.0.0/solc-macosx-arm64-0.8.23-1.0.0
+          curl --location -o "${PWD}/solc" https://github.com/matter-labs/era-solidity/releases/download/0.8.23-1.0.0/solc-macosx-arm64-0.8.23-1.0.0
           chmod a+x "${PWD}/solc"
           ls -la "${PWD}/solc"
           cargo install cargo2junit

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -124,7 +124,7 @@ jobs:
       - name: Build zksolc
         run: |
           cargo build --release --target ${{ matrix.target }}
-          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
+          echo "${PWD}/target/${{ matrix.target }}/release" >> "${GITHUB_PATH}"
       - name: Run unit tests
         continue-on-error: true
         run: |

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -123,15 +123,16 @@ jobs:
           zkevm-llvm build
       - name: Build zksolc
         run: |
-          cargo build --release --verbose --target ${{ matrix.target }}
+          cargo build --release -vv --target ${{ matrix.target }}
           echo "${PWD}/target/release" >> "${GITHUB_PATH}"
       - name: Run unit tests
         continue-on-error: true
         run: |
-          cargo install cargo2junit --target ${{ matrix.target }}
-          cargo test -- -Z unstable-options --format json --verbose --target ${{ matrix.target }} | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+#          cargo install cargo2junit --target ${{ matrix.target }}
+#          cargo test -- -Z unstable-options --format json --verbose --target ${{ matrix.target }} | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+           cargo test -vv --target ${{ matrix.target }}
       - name: Upload test results
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           check_name: ${{ matrix.name }} Unit Tests Results
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -38,15 +38,17 @@ jobs:
 
       - name: Run unit tests
         shell: zsh {0}
+        continue-on-error: true
         run: |
           cargo install cargo2junit
           cargo build --release
+          export PATH="${PWD}/target/release:${PATH}"
           which zksolc
           cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
           cat "${UNIT_TESTS_RESULTS_XML}"
 
       - name: Upload test results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action/composite@v2
         with:
           check_name: Unit Tests Results
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -29,13 +29,6 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
-#      - name: Build LLVM framework
-#        shell: zsh {0}
-#        run: |
-#          cargo install compiler-llvm-builder
-#          zkevm-llvm clone
-#          zkevm-llvm build
-
       - name: Run unit tests
         shell: zsh {0}
         continue-on-error: true

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -129,7 +129,7 @@ jobs:
         continue-on-error: true
         run: |
           cargo install cargo2junit
-          cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+          cargo test -- -Z unstable-options --format json --target ${{ matrix.target }} | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
       - name: Upload test results
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
         with:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -86,14 +86,15 @@ jobs:
     strategy:
       matrix:
         include:
-#          - name: "Linux x86"
-#            runner: matterlabs-ci-runner
-#            solc-name: "solc-linux-amd64"
-#            target: "x86_64-unknown-linux-musl"
+          - name: "Linux x86"
+            runner: matterlabs-ci-runner
+            solc-name: "solc-linux-amd64"
+            target: "x86_64-unknown-linux-musl"
           - name: "Linux arm64"
             runner: matterlabs-ci-runner-arm
             solc-name: "solc-linux-arm64"
             target: "aarch64-unknown-linux-musl"
+            rustflags: "-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
     runs-on: ${{ matrix.runner }}
     name: ${{ matrix.name }}
     container:
@@ -101,6 +102,8 @@ jobs:
       credentials:
         username: ${{ secrets.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
+    env:
+      RUSTFLAGS: ${{ matrix.rustflags }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -121,19 +124,16 @@ jobs:
       - name: Build zksolc
         run: |
           set -x
-          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-musl" ]; then
-            export RUSTFLAGS="-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
-          fi
           echo "RUSTFLAGS=${RUSTFLAGS}"
           cargo build -vv --release --target ${{ matrix.target }}
           echo "${PWD}/target/${{ matrix.target }}/release" >> "${GITHUB_PATH}"
       - name: Run unit tests
-        continue-on-error: true
         run: |
           cargo install cargo2junit
           cargo test --verbose --target ${{ matrix.target }} -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
           cat "${UNIT_TESTS_RESULTS_XML}"
       - name: Upload test results
+        if: always()
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           check_name: ${{ matrix.name }} Unit Tests Results

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -27,16 +27,20 @@ jobs:
           rm -rf ${{ github.workspace }}/*
       - name: Checkout source
         uses: actions/checkout@v4
+      - name: Build LLVM framework
+        shell: zsh {0}
+        run: |
+          cargo install compiler-llvm-builder
+          zkevm-llvm clone
+          zkevm-llvm build
       - name: Run unit tests
         shell: zsh {0}
         continue-on-error: true
         run: |
-          wget https://github.com/matter-labs/era-solidity/releases/download/0.8.23-1.0.0/solc-macosx-arm64-0.8.23-1.0.0 -O "${PWD}/solc"
-          wget https://github.com/matter-labs/zksolc-bin/raw/main/macosx-arm64/zksolc-macosx-arm64-v1.3.22 -O "${PWD}/zksolc"
-          cargo install compiler-llvm-builder
-          zkevm-llvm clone
+          wget https://github.com/matter-labs/era-solidity/releases/download/0.8.23-1.0.0/solc-macosx-arm64-0.8.23-1.0.0 -O "${PWD}/solc"          
           cargo install cargo2junit
-          export PATH="${PWD}:${PATH}"
+          cargo build --release
+          export PATH="${PWD}/target/release:${PWD}:${PATH}"
           which solc
           which zksolc
           cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -24,72 +24,72 @@ env:
   RUSTC_BOOTSTRAP: 1 # Use rustc in bootstrap mode allowing cargo2junit to use experimental --json feature
 
 jobs:
-  unit-tests-macos:
-    strategy:
-      matrix:
-        include:
-          - name: "MacOS x86"
-            runner: macos-12-large
-            solc-name: "solc-macosx-amd64"
-          - name: "MacOS arm64"
-            runner: [self-hosted, macOS, ARM64]
-            solc-name: "solc-macosx-arm64"
-    runs-on: ${{ matrix.runner }}
-    name: ${{ matrix.name }}
-    defaults:
-      run:
-        shell: zsh {0} # For MacOS hosts, .zprofile is pre-configured
-    steps:
-      # TODO: This step should be done as part of github runners hooks
-      # Users should always expect clean workspace when a new job starts
-      # https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/
-      - name: Cleanup workspace
-        if: ${{ matrix.name }} == "MacOS ARM64"
-        run: |
-          setopt rmstarsilent
-          setopt +o nomatch
-          rm -rf ${{ github.workspace }}/*
-      - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Prepare environment
-        run: |
-          brew install cmake ninja
-      - name: Build LLVM framework
-        run: |
-          cargo install compiler-llvm-builder
-          zkevm-llvm clone
-          zkevm-llvm build
-      - name: Install solc compiler
-        run: |
-          curl --verbose \
-            --location -o "${PWD}/solc" "${SOLC_URL}/${SOLC_VERSION}/${{ matrix.solc-name }}-${SOLC_VERSION}" && \
-            chmod a+x "${PWD}/solc"
-          echo "${PWD}" >> "${GITHUB_PATH}"
-      - name: Build zksolc
-        run: |
-          cargo build --release
-          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
-      - name: Run unit tests
-        continue-on-error: true
-        run: |
-          cargo install cargo2junit
-          cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
-      - name: Upload test results
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
-        with:
-          check_name: ${{ matrix.name }} Unit Tests Results
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-          action_fail_on_inconclusive: true
+#  unit-tests-macos:
+#    strategy:
+#      matrix:
+#        include:
+#          - name: "MacOS x86"
+#            runner: macos-12-large
+#            solc-name: "solc-macosx-amd64"
+#          - name: "MacOS arm64"
+#            runner: [self-hosted, macOS, ARM64]
+#            solc-name: "solc-macosx-arm64"
+#    runs-on: ${{ matrix.runner }}
+#    name: ${{ matrix.name }}
+#    defaults:
+#      run:
+#        shell: zsh {0} # For MacOS hosts, .zprofile is pre-configured
+#    steps:
+#      # TODO: This step should be done as part of github runners hooks
+#      # Users should always expect clean workspace when a new job starts
+#      # https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/
+#      - name: Cleanup workspace
+#        if: ${{ matrix.name }} == "MacOS ARM64"
+#        run: |
+#          setopt rmstarsilent
+#          setopt +o nomatch
+#          rm -rf ${{ github.workspace }}/*
+#      - name: Checkout source
+#        uses: actions/checkout@v4
+#      - name: Prepare environment
+#        run: |
+#          brew install cmake ninja
+#      - name: Build LLVM framework
+#        run: |
+#          cargo install compiler-llvm-builder
+#          zkevm-llvm clone
+#          zkevm-llvm build
+#      - name: Install solc compiler
+#        run: |
+#          curl --verbose \
+#            --location -o "${PWD}/solc" "${SOLC_URL}/${SOLC_VERSION}/${{ matrix.solc-name }}-${SOLC_VERSION}" && \
+#            chmod a+x "${PWD}/solc"
+#          echo "${PWD}" >> "${GITHUB_PATH}"
+#      - name: Build zksolc
+#        run: |
+#          cargo build --release
+#          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
+#      - name: Run unit tests
+#        continue-on-error: true
+#        run: |
+#          cargo install cargo2junit
+#          cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+#      - name: Upload test results
+#        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+#        with:
+#          check_name: ${{ matrix.name }} Unit Tests Results
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+#          action_fail_on_inconclusive: true
 
   unit-tests-linux:
     strategy:
       matrix:
         include:
-          - name: "Linux x86"
-            runner: matterlabs-ci-runner
-            solc-name: "solc-linux-amd64"
-            target: "x86_64-unknown-linux-musl"
+#          - name: "Linux x86"
+#            runner: matterlabs-ci-runner
+#            solc-name: "solc-linux-amd64"
+#            target: "x86_64-unknown-linux-musl"
           - name: "Linux arm64"
             runner: matterlabs-ci-runner-arm
             solc-name: "solc-linux-arm64"
@@ -120,10 +120,12 @@ jobs:
           zkevm-llvm build
       - name: Build zksolc
         run: |
-          if [[ ${{ matrix.target }} == aarch64-unknown-linux-musl ]]; then
+          set -x
+          if [[ "${{ matrix.target }}" == "aarch64-unknown-linux-musl" ]]; then
             export RUSTFLAGS="-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
           fi
-          cargo build --release --target ${{ matrix.target }}
+          echo "RUSTFLAGS=${RUSTFLAGS}"
+          cargo build -vv --release --target ${{ matrix.target }}
           echo "${PWD}/target/${{ matrix.target }}/release" >> "${GITHUB_PATH}"
       - name: Run unit tests
         continue-on-error: true
@@ -139,56 +141,57 @@ jobs:
           files: ${{ env.UNIT_TESTS_RESULTS_XML }}
           action_fail_on_inconclusive: true
 
-  build_windows_amd64:
-    runs-on: windows-2022-github-hosted-16core
-    env:
-      LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
-    defaults:
-      run:
-        shell: msys2 {0}
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Prepare msys2
-        uses: msys2/setup-msys2@v2
-      - name: Prepare env
-        run: |
-          pacman-key --refresh
-          pacman -Sy
-          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-          pacman --noconfirm -S --needed --overwrite \
-          base-devel \
-          git \
-          ninja \
-          mingw-w64-x86_64-clang \
-          mingw-w64-x86_64-lld \
-          mingw-w64-x86_64-rust \
-          mingw-w64-x86_64-gcc-libs \
-          mingw-w64-x86_64-gcc
-      - name: Install solc compiler
-        run: |
-          curl --verbose --location -o solc.exe "${SOLC_URL}/${SOLC_VERSION}/solc-windows-amd64-${SOLC_VERSION}.exe"
-      - name: Build LLVM framework
-        run: |
-          cargo install compiler-llvm-builder
-          export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"
-          zkevm-llvm clone
-          zkevm-llvm build
-      - name: Build compiler
-        run: |
-          cargo build --release
-      - name: Run unit tests
-        continue-on-error: true
-        run: |
-          cargo install cargo2junit
-          export PATH="$PWD/target/release:$PWD:$PATH:/c/Users/runneradmin/.cargo/bin/"
-          cargo test --verbose -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
-          cat "${UNIT_TESTS_RESULTS_XML}"
-      - name: Upload test results
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
-        with:
-          check_name: Windows Unit Tests Results
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-          action_fail_on_inconclusive: true
+#  unit-tests-windows:
+#    name: "Windows"
+#    runs-on: windows-2022-github-hosted-16core
+#    env:
+#      LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
+#    defaults:
+#      run:
+#        shell: msys2 {0}
+#    steps:
+#      - name: Checkout source
+#        uses: actions/checkout@v4
+#      - name: Prepare msys2
+#        uses: msys2/setup-msys2@v2
+#      - name: Prepare env
+#        run: |
+#          pacman-key --refresh
+#          pacman -Sy
+#          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+#          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+#          pacman --noconfirm -S --needed --overwrite \
+#          base-devel \
+#          git \
+#          ninja \
+#          mingw-w64-x86_64-clang \
+#          mingw-w64-x86_64-lld \
+#          mingw-w64-x86_64-rust \
+#          mingw-w64-x86_64-gcc-libs \
+#          mingw-w64-x86_64-gcc
+#      - name: Install solc compiler
+#        run: |
+#          curl --verbose --location -o solc.exe "${SOLC_URL}/${SOLC_VERSION}/solc-windows-amd64-${SOLC_VERSION}.exe"
+#      - name: Build LLVM framework
+#        run: |
+#          cargo install compiler-llvm-builder
+#          export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"
+#          zkevm-llvm clone
+#          zkevm-llvm build
+#      - name: Build compiler
+#        run: |
+#          cargo build --release
+#      - name: Run unit tests
+#        continue-on-error: true
+#        run: |
+#          cargo install cargo2junit
+#          export PATH="$PWD/target/release:$PWD:$PATH:/c/Users/runneradmin/.cargo/bin/"
+#          cargo test --verbose -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+#          cat "${UNIT_TESTS_RESULTS_XML}"
+#      - name: Upload test results
+#        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+#        with:
+#          check_name: Windows Unit Tests Results
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+#          action_fail_on_inconclusive: true

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -190,10 +190,14 @@ jobs:
         continue-on-error: true
         run: |
           cargo install cargo2junit
-          cargo test --verbose -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+          export PATH="$PWD/target/release:$PATH"
+          echo $PATH
+          ls -la "$PWD/target/release"
+          zksolc.exe --version
+          cargo test --verbose -- -Z unstable-options --format json
           cat "${UNIT_TESTS_RESULTS_XML}"
       - name: Upload test results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action/composite@v2
         with:
           check_name: ${{ matrix.name }} Unit Tests Results
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# What ❔

Fixes [CPR-1274](https://linear.app/matterlabs/issue/CPR-1274/github-action-for-zksolc-unit-tests)

Add unit tests execution in CI with each PR and merge to the trunk.

Supported targets:
* Macos x86_64
* Macos ARM64
* Linux x86_64
* Linux ARM64
* Windows Mingw64

Results are reported as PR checks, e.g.:
<img width="646" alt="image" src="https://github.com/matter-labs/era-compiler-solidity/assets/22070213/79166653-aeed-4aab-8084-edbfceeca807">

As well as PR auto-updated comments:
<img width="906" alt="image" src="https://github.com/matter-labs/era-compiler-solidity/assets/22070213/7c31a5b7-1008-491e-8891-389bb1072cf9">

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

In order to keep the trunk always stable, introduce unit tests quality gates on the PR level as well as make sure that unit tests in the `main` branch are always working after the merge.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
