### PR TITLE
Add noinline+optnone attributes in M0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ dependencies = [
 [[package]]
 name = "compiler-llvm-context"
 version = "1.3.3"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-cpr-1506-add-optnonenoinline-attributes-to-function-in-m0#5d0f025611eb64a2ba46a2501123d3ff8e08a83e"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-cpr-1506-add-optnonenoinline-attributes-to-function-in-m0#fc39144564e5f5cd3fee2e0dbb56f3d87fab7bb6"
 dependencies = [
  "anyhow",
  "compiler-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ dependencies = [
 [[package]]
 name = "compiler-llvm-context"
 version = "1.3.3"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-cpr-1506-add-optnonenoinline-attributes-to-function-in-m0#fad3ed60b43866939d66a2619d9ecc5179759dfe"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-cpr-1506-add-optnonenoinline-attributes-to-function-in-m0#5d0f025611eb64a2ba46a2501123d3ff8e08a83e"
 dependencies = [
  "anyhow",
  "compiler-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ dependencies = [
 [[package]]
 name = "compiler-llvm-context"
 version = "1.3.3"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#bd51eeeeef9dd2d36ed8ba0af04623a7356ccb97"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-cpr-1506-add-optnonenoinline-attributes-to-function-in-m0#fad3ed60b43866939d66a2619d9ecc5179759dfe"
 dependencies = [
  "anyhow",
  "compiler-common",
@@ -971,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
 dependencies = [
  "either",
  "rayon-core",
@@ -981,9 +981,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -1195,9 +1195,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2593d31f82ead8df961d8bd23a64c2ccf2eb5dd34b0a34bfb4dd54011c72009e"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "spki"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ dependencies = [
 [[package]]
 name = "compiler-llvm-context"
 version = "1.3.3"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-cpr-1506-add-optnonenoinline-attributes-to-function-in-m0#fc39144564e5f5cd3fee2e0dbb56f3d87fab7bb6"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#1bc74598266af3961650602e66aa81a2a67bb980"
 dependencies = [
  "anyhow",
  "compiler-common",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "compiler-solidity"
-version = "1.3.22"
+version = "1.3.23"
 dependencies = [
  "anyhow",
  "colored",
@@ -908,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ md5 = "0.7"
 zkevm-assembly = { git = "https://github.com/matter-labs/era-zkEVM-assembly", branch = "v1.3.2" }
 
 compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
+compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-cpr-1506-add-optnonenoinline-attributes-to-function-in-m0" }
 
 [dependencies.inkwell]
 git = "https://github.com/matter-labs-forks/inkwell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler-solidity"
-version = "1.3.22"
+version = "1.3.23"
 authors = [
     "Oleksandr Zarudnyi <a.zarudnyy@matterlabs.dev>",
 ]
@@ -38,7 +38,7 @@ md5 = "0.7"
 zkevm-assembly = { git = "https://github.com/matter-labs/era-zkEVM-assembly", branch = "v1.3.2" }
 
 compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-cpr-1506-add-optnonenoinline-attributes-to-function-in-m0" }
+compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
 
 [dependencies.inkwell]
 git = "https://github.com/matter-labs-forks/inkwell"

--- a/src/yul/parser/statement/function_definition.rs
+++ b/src/yul/parser/statement/function_definition.rs
@@ -258,10 +258,11 @@ where
             self.result.len(),
             Some(inkwell::module::Linkage::Private),
         )?;
-        compiler_llvm_context::EraVMFunction::set_function_attributes(
+        compiler_llvm_context::EraVMFunction::set_attributes(
             context.llvm(),
             function.borrow().declaration(),
             self.attributes.clone().into_iter().collect(),
+            true,
         );
         function
             .borrow_mut()


### PR DESCRIPTION
# What ❔

Adds `optnone` and `noinline` attributes to all functions if middle-end optimizations are disabled.

## Why ❔

It should disable some RAM-demanding LLVM passes which cause OOM on large unoptimized codebases.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
