### PR TITLE
Add the deployer_call for both heaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "elliptic-curve"
@@ -299,7 +299,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 [[package]]
 name = "era-compiler-common"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#c947120df4f41dcaca17d307cb974d2ca1995a03"
+source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#f11a4d027c6b75e78669257fd1cdada6a9d05ed1"
 dependencies = [
  "anyhow",
  "serde",
@@ -310,7 +310,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.4.1"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#a933844124d1d0b601c553c179e913df2693d672"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#5ed14b4617bfd3d3c7baa740e0097433ed5455ca"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -549,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -739,28 +739,27 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
+checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -781,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
 ]
@@ -1292,18 +1291,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1362,9 +1361,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
@@ -1562,9 +1561,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.37"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cad8365489051ae9f054164e459304af2e7e9bb407c958076c8bf4aef52da5"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]

--- a/src/evmla/assembly/mod.rs
+++ b/src/evmla/assembly/mod.rs
@@ -210,9 +210,7 @@ where
         let mut entry = era_compiler_llvm_context::EraVMEntryFunction::default();
         entry.declare(context)?;
 
-        let mut runtime = era_compiler_llvm_context::EraVMRuntime::new(
-            era_compiler_llvm_context::EraVMAddressSpace::Heap,
-        );
+        let mut runtime = era_compiler_llvm_context::EraVMRuntime::default();
         runtime.declare(context)?;
 
         era_compiler_llvm_context::EraVMDeployCodeFunction::new(

--- a/src/evmla/ethereal_ir/function/block/element/mod.rs
+++ b/src/evmla/ethereal_ir/function/block/element/mod.rs
@@ -1123,6 +1123,7 @@ where
 
                 era_compiler_llvm_context::eravm_evm_create::create(
                     context,
+                    era_compiler_llvm_context::EraVMAddressSpace::Heap,
                     value,
                     input_offset,
                     input_length,
@@ -1139,6 +1140,7 @@ where
 
                 era_compiler_llvm_context::eravm_evm_create::create2(
                     context,
+                    era_compiler_llvm_context::EraVMAddressSpace::Heap,
                     value,
                     input_offset,
                     input_length,

--- a/src/yul/parser/statement/expression/function_call/mod.rs
+++ b/src/yul/parser/statement/expression/function_call/mod.rs
@@ -927,6 +927,7 @@ impl FunctionCall {
 
                 era_compiler_llvm_context::eravm_evm_create::create(
                     context,
+                    era_compiler_llvm_context::EraVMAddressSpace::Heap,
                     value,
                     input_offset,
                     input_length,
@@ -943,6 +944,7 @@ impl FunctionCall {
 
                 era_compiler_llvm_context::eravm_evm_create::create2(
                     context,
+                    era_compiler_llvm_context::EraVMAddressSpace::Heap,
                     value,
                     input_offset,
                     input_length,

--- a/src/yul/parser/statement/object.rs
+++ b/src/yul/parser/statement/object.rs
@@ -194,9 +194,7 @@ where
         let mut entry = era_compiler_llvm_context::EraVMEntryFunction::default();
         entry.declare(context)?;
 
-        let mut runtime = era_compiler_llvm_context::EraVMRuntime::new(
-            era_compiler_llvm_context::EraVMAddressSpace::Heap,
-        );
+        let mut runtime = era_compiler_llvm_context::EraVMRuntime::default();
         runtime.declare(context)?;
 
         era_compiler_llvm_context::EraVMDeployCodeFunction::new(
@@ -244,9 +242,7 @@ where
                 object.into_llvm(context)?;
             }
             None => {
-                let runtime = era_compiler_llvm_context::EraVMRuntime::new(
-                    era_compiler_llvm_context::EraVMAddressSpace::Heap,
-                );
+                let runtime = era_compiler_llvm_context::EraVMRuntime::default();
                 runtime.into_llvm(context)?;
             }
         }


### PR DESCRIPTION
# What ❔

Now it is possible to use `deployer_call` using both heap and auxiliary heap from the same contract.

## Why ❔

Vyper contracts can be using `create_minimal_proxy_to` with the auxiliary heap, and `create_from_blueprint` with the ordinary heap.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
