### PR TITLE
test: test shows the issue-difference in the bin output

### DIFF
--- a/cli-tests/src/helper.ts
+++ b/cli-tests/src/helper.ts
@@ -77,3 +77,14 @@ export const pathToSolAsmOutputFile = (destination: string): string  => {
 export const pathToLlvmContractsFile = (destination: string): string  => {
   return path.join(destination, paths.contractLlvmFilename + paths.llvmExtension);
 };
+
+export const isOutputTheSame = (file: string, cliOutput: string): boolean => {
+    const fileOutput = fs.readFileSync(file, 'utf-8');
+    console.log("fileOutput: \n" + fileOutput);
+    console.log("cliOutput: \n" + cliOutput);
+    if (cliOutput.includes(fileOutput) || fileOutput.includes(cliOutput)) {
+        return true
+    } else {
+        return false
+    }
+}

--- a/cli-tests/tests/common.test.ts
+++ b/cli-tests/tests/common.test.ts
@@ -1,4 +1,4 @@
-import {executeCommand, isDestinationExist, isFileEmpty, createTmpDirectory, pathToSolBinOutputFile, pathToSolAsmOutputFile} from "../src/helper";
+import {executeCommand, isDestinationExist, isFileEmpty, createTmpDirectory, pathToSolBinOutputFile, pathToSolAsmOutputFile, isOutputTheSame} from "../src/helper";
 import { paths } from '../src/entities';
 
 
@@ -96,6 +96,42 @@ describe("Common tests", () => {
         });
         it("No 'Error'/'Warning'/'Fail' in the output", () => {
             expect(result.output).not.toMatch(/([Ee]rror|[Ww]arning|[Ff]ail)/i);
+            tmpDirZkSolc.removeCallback();
+        });
+    });
+
+    //#issue CPR-1498 Different --bin output for a file and cli
+    describe(`--bin output is the same for in a file and in a cli`, () => {
+        const tmpDirZkSolc = createTmpDirectory();
+        const args = [
+            `"${paths.pathToBasicSolContract}"`,
+            `-O3`,
+            `--bin`,
+            `--output-dir`,
+            `"${tmpDirZkSolc.name}"`
+        ]; // potential issue on zksolc with full path on Windows cmd
+        const result = executeCommand(zksolcCommand, args);
+        
+        it("Compiler run successful", () => {
+            expect(result.output).toMatch(/(Compiler run successful.)/i);
+        });
+
+        it("Exit code = 0", () => {
+            expect(result.exitCode).toBe(0);
+        });
+
+        it("Output file is created", () => { // a bug on windows
+            expect(isDestinationExist(pathToSolBinOutputFile(tmpDirZkSolc.name))).toBe(true);
+        });
+
+        it("Output file == cli output", () => { // a bug on windows
+            const args = [
+                `"${paths.pathToBasicSolContract}"`,
+                `-O3`,
+                `--bin`
+            ]; // potential issue on zksolc with full path on Windows cmd
+            const resultCli = executeCommand(zksolcCommand, args);
+            expect(isOutputTheSame(pathToSolBinOutputFile(tmpDirZkSolc.name), resultCli.output)).toBe(true);
             tmpDirZkSolc.removeCallback();
         });
     });


### PR DESCRIPTION
# What ❔

CPR-1498/[zksolc-1322]-different-bin-output-for-a-file-and-cli

## Why ❔

```
>> npx jest --verbose --testPathPattern=common.test.ts
  console.log
    fileOutput: 
     �
      a=�9@?K
             �= 9C CA.02.0@�`���2�:R���ѵV�Ng�Z�b��#�v��bl

      at isOutputTheSame (src/helper.ts:25:13)

  console.log
    cliOutput: 
    Contract `/home/user/WebstormProjects/era-compiler-solidity/cli-tests/src/contracts/solidity/contract.sol:C` bytecode: 0x00000001012001900000000c0000613d0000008001000039000000400010043f0000000001000416000000000101004b0000000c0000c13d00000020010000390000010000100443000001200000044300000005010000410000000f0001042e000000000100001900000010000104300000000e000004320000000f0001042e00000010000104300000000000000000000000000000000000000000000000000000000200000000000000000000000000000040000001000000000000000000a060cdeb87c032973a528ab5ded1b556f34e67b85add62d2d823f076b2e0626c

      at isOutputTheSame (src/helper.ts:26:13)

 FAIL  tests/common.test.ts
```

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
