### PR TITLE
ci: fix unit tests results parsing for macos arm64

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 # Cancel the workflow if any new changes pushed to a feature branch or the trunk
 #
@@ -80,7 +81,7 @@ jobs:
           cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
       - name: Upload test results
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        uses: EnricoMi/publish-unit-test-result-action/composite@v2.12.0
         with:
           check_name: ${{ matrix.name }} Unit Tests Results
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -134,7 +135,7 @@ jobs:
           cat "${UNIT_TESTS_RESULTS_XML}"
       - name: Upload test results
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@v2.12.0
         with:
           check_name: ${{ matrix.name }} Unit Tests Results
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -189,7 +190,7 @@ jobs:
           cat "${UNIT_TESTS_RESULTS_XML}"
       - name: Upload test results
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        uses: EnricoMi/publish-unit-test-result-action/composite@v2.12.0
         with:
           check_name: Windows Unit Tests Results
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# What ❔

Fix CI unit tests results parsing error caused by `lxml` libraries on MacOS ARM64 host:
```
dlopen(/Users/hetzner/actions-runner/_work/era-compiler-solidity/era-compiler-solidity/enricomi-publish-action-venv/lib/python3.8/site-packages/lxml/etree.cpython-38-darwin.so, 0x0002): symbol not found in flat namespace (_exsltDateXpathCtxtRegister)
```

The fix for now is to use the previous action version before `lxml` was updated to `5.1.0` causing these issues on MacOS ARM64 hosts.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To restore unit tests and CI checks back to normal.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
