### PR TITLE
Replace memcpy with memmove

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.4.1"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#5ed14b4617bfd3d3c7baa740e0097433ed5455ca"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-cpr-1530-support-emitting-of-memmove-for-the-same-address-space-in#b92bc1f25ba7a7c378a773901446d0840f1327dc"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -1123,7 +1123,7 @@ checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -1256,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "915aea9e586f80826ee59f8453c1101f9d1c4b3964cd2460185ee8e299ada496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1306,7 +1306,7 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ md5 = "0.7"
 zkevm-assembly = { git = "https://github.com/matter-labs/era-zkEVM-assembly", branch = "v1.4.1" }
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
+era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-cpr-1530-support-emitting-of-memmove-for-the-same-address-space-in" }
 
 [dependencies.inkwell]
 git = "https://github.com/matter-labs-forks/inkwell"

--- a/src/evmla/ethereal_ir/function/block/element/mod.rs
+++ b/src/evmla/ethereal_ir/function/block/element/mod.rs
@@ -724,7 +724,7 @@ where
                 );
 
                 context.build_memcpy(
-                    context.intrinsics().memory_copy,
+                    context.intrinsics().memory_move,
                     destination,
                     source,
                     arguments[2].into_int_value(),

--- a/src/yul/parser/statement/expression/function_call/mod.rs
+++ b/src/yul/parser/statement/expression/function_call/mod.rs
@@ -532,7 +532,7 @@ impl FunctionCall {
                 );
 
                 context.build_memcpy(
-                    context.intrinsics().memory_copy,
+                    context.intrinsics().memory_move,
                     destination,
                     source,
                     arguments[2].into_int_value(),


### PR DESCRIPTION
# What ❔

Uses memmove for same address spaces.

## Why ❔

memcpy doesn't work with overlapping memory regions.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
