### PR TITLE
Support swapping 16 active pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # The `zksolc` changelog
 
+## [Unreleased]
+
+### Added
+
+- Simulations to forward return data pointers
+- Simulations to manipulate multiple active pointers
+
 ## [1.4.0] - 2024-02-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,9 +114,9 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cc"
-version = "1.0.86"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9fa1897e4325be0d68d48df6aa1a71ac2ed4d27723887e7754192705350730"
+checksum = "02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc"
 
 [[package]]
 name = "cfg-if"
@@ -296,7 +296,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 [[package]]
 name = "era-compiler-common"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#6375adfc241500959795635f4338cb014324362e"
+source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#6781681145a37d9809057cf6fc3fa667abd545af"
 dependencies = [
  "anyhow",
  "serde",
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.4.1"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#47bb46eef283d897cf98f2afd92fd44b7610f742"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-cpr-1566-support-two-active-pointers#b93a92d45864a815c6121656202ffcddd819d903"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -973,9 +973,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
+checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
 dependencies = [
  "either",
  "rayon-core",
@@ -1120,7 +1120,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -1253,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.50"
+version = "2.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+checksum = "6ab617d94515e94ae53b8406c628598680aa0c9587474ecbe58188f7b345d66c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1303,7 +1303,7 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.51",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,7 +1439,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.3",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -1459,17 +1459,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d380ba1dc7187569a8a9e91ed34b8ccfc33123bbacb8c0aed2d1ad7f3ef2dc5f"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.3",
- "windows_aarch64_msvc 0.52.3",
- "windows_i686_gnu 0.52.3",
- "windows_i686_msvc 0.52.3",
- "windows_x86_64_gnu 0.52.3",
- "windows_x86_64_gnullvm 0.52.3",
- "windows_x86_64_msvc 0.52.3",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -1480,9 +1480,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e5dcfb9413f53afd9c8f86e56a7b4d86d9a2fa26090ea2dc9e40fba56c6ec6"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1492,9 +1492,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dab469ebbc45798319e69eebf92308e541ce46760b49b18c6b3fe5e8965b30f"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1504,9 +1504,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4e9b6a7cac734a8b4138a4e1044eac3404d8326b6c0f939276560687a033fb"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1516,9 +1516,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b0ec9c422ca95ff34a78755cfa6ad4a51371da2a5ace67500cf7ca5f232c58"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1528,9 +1528,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704131571ba93e89d7cd43482277d6632589b18ecf4468f591fbae0a8b101614"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1540,9 +1540,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42079295511643151e98d61c38c0acc444e52dd42ab456f7ccfd5152e8ecf21c"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1552,9 +1552,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0770833d60a970638e989b3fa9fd2bb1aaadcf88963d1659fd7d9990196ed2d6"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.4.1"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-cpr-1566-support-two-active-pointers#b93a92d45864a815c6121656202ffcddd819d903"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#0dc021522d1d6ff41c34e4b8ef8c0bd0714a87d4"
 dependencies = [
  "anyhow",
  "era-compiler-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ md5 = "0.7"
 zkevm-assembly = { git = "https://github.com/matter-labs/era-zkEVM-assembly", branch = "v1.4.1" }
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-cpr-1566-support-two-active-pointers" }
+era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
 
 [dependencies.inkwell]
 git = "https://github.com/matter-labs-forks/inkwell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ md5 = "0.7"
 zkevm-assembly = { git = "https://github.com/matter-labs/era-zkEVM-assembly", branch = "v1.4.1" }
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
+era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-cpr-1566-support-two-active-pointers" }
 
 [dependencies.inkwell]
 git = "https://github.com/matter-labs-forks/inkwell"

--- a/src/yul/parser/statement/expression/function_call/mod.rs
+++ b/src/yul/parser/statement/expression/function_call/mod.rs
@@ -1210,16 +1210,14 @@ impl FunctionCall {
             }
             Name::ZkMimicCallByRef => {
                 let [address, mimic] = self.pop_arguments_llvm::<D, 2>(context)?;
-                let abi_data = context.get_global_value(
-                    era_compiler_llvm_context::eravm_const::GLOBAL_ACTIVE_POINTER,
-                )?;
+                let abi_data = context.get_active_pointer(context.field_const(0))?;
 
                 era_compiler_llvm_context::eravm_call::mimic(
                     context,
                     context.llvm_runtime().mimic_call_byref,
                     address.into_int_value(),
                     mimic.into_int_value(),
-                    abi_data,
+                    abi_data.as_basic_value_enum(),
                     vec![],
                 )
                 .map(Some)
@@ -1227,16 +1225,14 @@ impl FunctionCall {
             Name::ZkSystemMimicCallByRef => {
                 let [address, mimic, extra_value_1, extra_value_2] =
                     self.pop_arguments_llvm::<D, 4>(context)?;
-                let abi_data = context.get_global_value(
-                    era_compiler_llvm_context::eravm_const::GLOBAL_ACTIVE_POINTER,
-                )?;
+                let abi_data = context.get_active_pointer(context.field_const(0))?;
 
                 era_compiler_llvm_context::eravm_call::mimic(
                     context,
                     context.llvm_runtime().mimic_call_byref,
                     address.into_int_value(),
                     mimic.into_int_value(),
-                    abi_data,
+                    abi_data.as_basic_value_enum(),
                     vec![
                         extra_value_1.into_int_value(),
                         extra_value_2.into_int_value(),
@@ -1261,15 +1257,13 @@ impl FunctionCall {
             Name::ZkRawCallByRef => {
                 let [address, output_offset, output_length] =
                     self.pop_arguments_llvm::<D, 3>(context)?;
-                let abi_data = context.get_global_value(
-                    era_compiler_llvm_context::eravm_const::GLOBAL_ACTIVE_POINTER,
-                )?;
+                let abi_data = context.get_active_pointer(context.field_const(0))?;
 
                 era_compiler_llvm_context::eravm_call::raw_far(
                     context,
                     context.llvm_runtime().far_call_byref,
                     address.into_int_value(),
-                    abi_data,
+                    abi_data.as_basic_value_enum(),
                     output_offset.into_int_value(),
                     output_length.into_int_value(),
                 )
@@ -1298,15 +1292,13 @@ impl FunctionCall {
             Name::ZkSystemCallByRef => {
                 let [address, extra_value_1, extra_value_2, extra_value_3, extra_value_4] =
                     self.pop_arguments_llvm::<D, 5>(context)?;
-                let abi_data = context.get_global_value(
-                    era_compiler_llvm_context::eravm_const::GLOBAL_ACTIVE_POINTER,
-                )?;
+                let abi_data = context.get_active_pointer(context.field_const(0))?;
 
                 era_compiler_llvm_context::eravm_call::system(
                     context,
                     context.llvm_runtime().far_call_byref,
                     address.into_int_value(),
-                    abi_data,
+                    abi_data.as_basic_value_enum(),
                     context.field_const(0),
                     context.field_const(0),
                     vec![
@@ -1335,15 +1327,13 @@ impl FunctionCall {
             Name::ZkStaticRawCallByRef => {
                 let [address, output_offset, output_length] =
                     self.pop_arguments_llvm::<D, 3>(context)?;
-                let abi_data = context.get_global_value(
-                    era_compiler_llvm_context::eravm_const::GLOBAL_ACTIVE_POINTER,
-                )?;
+                let abi_data = context.get_active_pointer(context.field_const(0))?;
 
                 era_compiler_llvm_context::eravm_call::raw_far(
                     context,
                     context.llvm_runtime().static_call_byref,
                     address.into_int_value(),
-                    abi_data,
+                    abi_data.as_basic_value_enum(),
                     output_offset.into_int_value(),
                     output_length.into_int_value(),
                 )
@@ -1372,15 +1362,13 @@ impl FunctionCall {
             Name::ZkStaticSystemCallByRef => {
                 let [address, extra_value_1, extra_value_2, extra_value_3, extra_value_4] =
                     self.pop_arguments_llvm::<D, 5>(context)?;
-                let abi_data = context.get_global_value(
-                    era_compiler_llvm_context::eravm_const::GLOBAL_ACTIVE_POINTER,
-                )?;
+                let abi_data = context.get_active_pointer(context.field_const(0))?;
 
                 era_compiler_llvm_context::eravm_call::system(
                     context,
                     context.llvm_runtime().static_call_byref,
                     address.into_int_value(),
-                    abi_data,
+                    abi_data.as_basic_value_enum(),
                     context.field_const(0),
                     context.field_const(0),
                     vec![
@@ -1409,15 +1397,13 @@ impl FunctionCall {
             Name::ZkDelegateRawCallByRef => {
                 let [address, output_offset, output_length] =
                     self.pop_arguments_llvm::<D, 3>(context)?;
-                let abi_data = context.get_global_value(
-                    era_compiler_llvm_context::eravm_const::GLOBAL_ACTIVE_POINTER,
-                )?;
+                let abi_data = context.get_active_pointer(context.field_const(0))?;
 
                 era_compiler_llvm_context::eravm_call::raw_far(
                     context,
                     context.llvm_runtime().delegate_call_byref,
                     address.into_int_value(),
-                    abi_data,
+                    abi_data.as_basic_value_enum(),
                     output_offset.into_int_value(),
                     output_length.into_int_value(),
                 )
@@ -1446,15 +1432,13 @@ impl FunctionCall {
             Name::ZkDelegateSystemCallByRef => {
                 let [address, extra_value_1, extra_value_2, extra_value_3, extra_value_4] =
                     self.pop_arguments_llvm::<D, 5>(context)?;
-                let abi_data = context.get_global_value(
-                    era_compiler_llvm_context::eravm_const::GLOBAL_ACTIVE_POINTER,
-                )?;
+                let abi_data = context.get_active_pointer(context.field_const(0))?;
 
                 era_compiler_llvm_context::eravm_call::system(
                     context,
                     context.llvm_runtime().delegate_call_byref,
                     address.into_int_value(),
-                    abi_data,
+                    abi_data.as_basic_value_enum(),
                     context.field_const(0),
                     context.field_const(0),
                     vec![

--- a/src/yul/parser/statement/expression/function_call/verbatim.rs
+++ b/src/yul/parser/statement/expression/function_call/verbatim.rs
@@ -2,7 +2,7 @@
 //! Translates the verbatim simulations.
 //!
 
-use anyhow::Ok;
+use inkwell::values::BasicValue;
 
 use crate::yul::parser::statement::expression::function_call::FunctionCall;
 
@@ -141,9 +141,9 @@ where
                 context.llvm_runtime().mimic_call_byref,
                 arguments[0].into_int_value(),
                 arguments[1].into_int_value(),
-                context.get_global_value(
-                    era_compiler_llvm_context::eravm_const::GLOBAL_ACTIVE_POINTER,
-                )?,
+                context
+                    .get_active_pointer(context.field_const(0))?
+                    .as_basic_value_enum(),
                 vec![context.field_const(0), context.field_const(0)],
             )
             .map(Some)
@@ -194,9 +194,9 @@ where
                 context.llvm_runtime().mimic_call_byref,
                 arguments[0].into_int_value(),
                 arguments[1].into_int_value(),
-                context.get_global_value(
-                    era_compiler_llvm_context::eravm_const::GLOBAL_ACTIVE_POINTER,
-                )?,
+                context
+                    .get_active_pointer(context.field_const(0))?
+                    .as_basic_value_enum(),
                 vec![
                     arguments[2].into_int_value(),
                     arguments[3].into_int_value(),
@@ -246,9 +246,9 @@ where
                 context,
                 context.llvm_runtime().far_call_byref,
                 arguments[0].into_int_value(),
-                context.get_global_value(
-                    era_compiler_llvm_context::eravm_const::GLOBAL_ACTIVE_POINTER,
-                )?,
+                context
+                    .get_active_pointer(context.field_const(0))?
+                    .as_basic_value_enum(),
                 arguments[1].into_int_value(),
                 arguments[2].into_int_value(),
             )
@@ -300,9 +300,9 @@ where
                 context,
                 context.llvm_runtime().far_call_byref,
                 arguments[0].into_int_value(),
-                context.get_global_value(
-                    era_compiler_llvm_context::eravm_const::GLOBAL_ACTIVE_POINTER,
-                )?,
+                context
+                    .get_active_pointer(context.field_const(0))?
+                    .as_basic_value_enum(),
                 context.field_const(0),
                 context.field_const(0),
                 vec![
@@ -354,9 +354,9 @@ where
                 context,
                 context.llvm_runtime().static_call_byref,
                 arguments[0].into_int_value(),
-                context.get_global_value(
-                    era_compiler_llvm_context::eravm_const::GLOBAL_ACTIVE_POINTER,
-                )?,
+                context
+                    .get_active_pointer(context.field_const(0))?
+                    .as_basic_value_enum(),
                 arguments[1].into_int_value(),
                 arguments[2].into_int_value(),
             )
@@ -403,9 +403,9 @@ where
                 context,
                 context.llvm_runtime().static_call_byref,
                 arguments[0].into_int_value(),
-                context.get_global_value(
-                    era_compiler_llvm_context::eravm_const::GLOBAL_ACTIVE_POINTER,
-                )?,
+                context
+                    .get_active_pointer(context.field_const(0))?
+                    .as_basic_value_enum(),
                 arguments[3].into_int_value(),
                 arguments[4].into_int_value(),
                 vec![arguments[1].into_int_value(), arguments[2].into_int_value()],
@@ -452,9 +452,9 @@ where
                 context,
                 context.llvm_runtime().delegate_call_byref,
                 arguments[0].into_int_value(),
-                context.get_global_value(
-                    era_compiler_llvm_context::eravm_const::GLOBAL_ACTIVE_POINTER,
-                )?,
+                context
+                    .get_active_pointer(context.field_const(0))?
+                    .as_basic_value_enum(),
                 arguments[1].into_int_value(),
                 arguments[2].into_int_value(),
             )
@@ -501,9 +501,9 @@ where
                 context,
                 context.llvm_runtime().delegate_call_byref,
                 arguments[0].into_int_value(),
-                context.get_global_value(
-                    era_compiler_llvm_context::eravm_const::GLOBAL_ACTIVE_POINTER,
-                )?,
+                context
+                    .get_active_pointer(context.field_const(0))?
+                    .as_basic_value_enum(),
                 arguments[3].into_int_value(),
                 arguments[4].into_int_value(),
                 vec![arguments[1].into_int_value(), arguments[2].into_int_value()],


### PR DESCRIPTION
# What ❔

Adds a simulation to swap active pointers.

## Why ❔

We are allowing 16 saved pointers now, where 0th will be the active one.

## Checklist

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
