### PR TITLE
test: compare exit codes for output-dir with ro permission

### DIFF
--- a/cli-tests/tests/output-dir.test.ts
+++ b/cli-tests/tests/output-dir.test.ts
@@ -109,7 +109,6 @@ describe("Set of --output-dir tests", () => {
   });
 
   //id1812 - different behaviour on CI on Linux
-  if (os.platform() !== 'linux') {
     describe(`Run ${zksolcCommand} with --output-dir - output-dir - wrong permissions`, () => {
       const tmpDirZkSolc = createTmpDirectory();
 
@@ -136,5 +135,4 @@ describe("Set of --output-dir tests", () => {
       });
       
     });
-  }
 });

--- a/cli-tests/tests/output-dir.test.ts
+++ b/cli-tests/tests/output-dir.test.ts
@@ -113,8 +113,7 @@ describe("Set of --output-dir tests", () => {
     describe(`Run ${zksolcCommand} with --output-dir - output-dir - wrong permissions`, () => {
       const tmpDirZkSolc = createTmpDirectory();
 
-      // TODO: uncomment after CPR-1588 is fixed
-      // const tmpDirSolc = createTmpDirectory();
+      const tmpDirSolc = createTmpDirectory();
       changeDirectoryPermissions(tmpDirZkSolc.name, 'r');
       const args = [`${paths.pathToBasicSolContract}`, `--bin`, `--output-dir`, `${tmpDirZkSolc.name}`];
       const result = executeCommand(zksolcCommand, args);
@@ -128,14 +127,13 @@ describe("Set of --output-dir tests", () => {
         tmpDirZkSolc.removeCallback();
       });
 
-      // TODO: uncomment after CPR-1588 is fixed
       // Exit code should be the same
-      // xit("solc exit code == zksolc exit code", () => {
-      //   const args = [`${paths.pathToBasicSolContract}`, `--bin`, `--output-dir`, `${tmpDirSolc.name}`];
-      //   const solcResult = executeCommand(solcCommand, args);
-      //   expect(solcResult.exitCode).toBe(result.exitCode);
-      //   tmpDirSolc.removeCallback();
-      // });
+      it("solc exit code == zksolc exit code", () => {
+        const args = [`${paths.pathToBasicSolContract}`, `--bin`, `--output-dir`, `${tmpDirSolc.name}`];
+        const solcResult = executeCommand(solcCommand, args);
+        expect(solcResult.exitCode).toBe(result.exitCode);
+        tmpDirSolc.removeCallback();
+      });
       
     });
   }


### PR DESCRIPTION
# What ❔

Uncommented test step id1812 "solc exit code == zksolc exit code" 

 This case works well on **win** and **osx** on CI. For **linux** locally I see an error that is expected because we cannot write to Read Only directory. But on CI compiler finish with exit code 0 that is unexpected for this case. That if why we use `if (os.platform() !== 'linux') {}`

## Why ❔

it returns different exit codes

## Checklist



- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
