### PR TITLE
ci: run cli tests in band to fix race conditions

### DIFF
--- a/.github/actions/cli-tests/action.yml
+++ b/.github/actions/cli-tests/action.yml
@@ -53,7 +53,7 @@ runs:
       working-directory: cli-tests
       run: |
         npm install
-        npx jest --ci --reporters=default --reporters=jest-junit
+        npx jest --ci --runInBand --reporters=default --reporters=jest-junit
 
     - name: Upload results (MacOS and Windows)
       if: runner.os != 'Linux'


### PR DESCRIPTION
# What ❔

Fix for race conditions issues for CLI tests

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

CLI tests are working with the same outputDirectory for zksolc that different test sets are removing at the same time as other test sets are using it that results in tests errors.

Tests should not be designed like that, but for now, as a workaround, set up consequential tests execution.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
