### PR TITLE
Validate solc only for Solidity/Yul input

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ use std::path::PathBuf;
 ///
 pub fn yul(
     input_files: &[PathBuf],
-    solc: &mut SolcCompiler,
+    solc: Option<String>,
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
     is_system_mode: bool,
     include_metadata_hash: bool,
@@ -70,6 +70,9 @@ pub fn yul(
     let solc_validator = if is_system_mode {
         None
     } else {
+        let mut solc = SolcCompiler::new(
+            solc.unwrap_or_else(|| SolcCompiler::DEFAULT_EXECUTABLE_NAME.to_owned()),
+        )?;
         if solc.version()?.default != SolcCompiler::LAST_SUPPORTED_VERSION {
             anyhow::bail!(
                 "The Yul mode is only supported with the most recent version of the Solidity compiler: {}",
@@ -77,10 +80,10 @@ pub fn yul(
             );
         }
 
-        Some(&*solc)
+        Some(solc)
     };
 
-    let project = Project::try_from_yul_path(path, solc_validator)?;
+    let project = Project::try_from_yul_path(path, solc_validator.as_ref())?;
 
     let build = project.compile(
         optimizer_settings,

--- a/src/zksolc/main.rs
+++ b/src/zksolc/main.rs
@@ -75,10 +75,6 @@ fn main_inner() -> anyhow::Result<()> {
         None => None,
     };
 
-    let mut solc = era_compiler_solidity::SolcCompiler::new(arguments.solc.unwrap_or_else(|| {
-        era_compiler_solidity::SolcCompiler::DEFAULT_EXECUTABLE_NAME.to_owned()
-    }))?;
-
     let evm_version = match arguments.evm_version {
         Some(evm_version) => Some(era_compiler_common::EVMVersion::try_from(
             evm_version.as_str(),
@@ -111,7 +107,7 @@ fn main_inner() -> anyhow::Result<()> {
     let build = if arguments.yul {
         era_compiler_solidity::yul(
             input_files.as_slice(),
-            &mut solc,
+            arguments.solc,
             optimizer_settings,
             arguments.is_system_mode,
             include_metadata_hash,
@@ -128,6 +124,10 @@ fn main_inner() -> anyhow::Result<()> {
     } else if arguments.zkasm {
         era_compiler_solidity::zkasm(input_files.as_slice(), include_metadata_hash, debug_config)
     } else if arguments.standard_json {
+        let mut solc =
+            era_compiler_solidity::SolcCompiler::new(arguments.solc.unwrap_or_else(|| {
+                era_compiler_solidity::SolcCompiler::DEFAULT_EXECUTABLE_NAME.to_owned()
+            }))?;
         era_compiler_solidity::standard_json(
             &mut solc,
             arguments.detect_missing_libraries,
@@ -140,6 +140,10 @@ fn main_inner() -> anyhow::Result<()> {
         )?;
         return Ok(());
     } else if let Some(format) = arguments.combined_json {
+        let mut solc =
+            era_compiler_solidity::SolcCompiler::new(arguments.solc.unwrap_or_else(|| {
+                era_compiler_solidity::SolcCompiler::DEFAULT_EXECUTABLE_NAME.to_owned()
+            }))?;
         era_compiler_solidity::combined_json(
             format,
             input_files.as_slice(),
@@ -162,6 +166,10 @@ fn main_inner() -> anyhow::Result<()> {
         )?;
         return Ok(());
     } else {
+        let mut solc =
+            era_compiler_solidity::SolcCompiler::new(arguments.solc.unwrap_or_else(|| {
+                era_compiler_solidity::SolcCompiler::DEFAULT_EXECUTABLE_NAME.to_owned()
+            }))?;
         era_compiler_solidity::standard_output(
             input_files.as_slice(),
             arguments.libraries,


### PR DESCRIPTION
# What ❔

Checks for the `solc` binary only in Solidity/Yul modes.

## Why ❔

The `solc` binary was checked even in `--zkasm` mode.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
