### PR TITLE
Update for solc v0.8.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - The jump table density threshold optimization parameter
 - Simulations to forward return data pointers
 - Simulations to manipulate multiple active pointers
+- The solc v0.8.25 support
 
 ## [1.4.0] - 2024-02-19
 

--- a/src/solc/mod.rs
+++ b/src/solc/mod.rs
@@ -41,7 +41,7 @@ impl Compiler {
     pub const FIRST_VIA_IR_VERSION: semver::Version = semver::Version::new(0, 8, 13);
 
     /// The last supported version of `solc`.
-    pub const LAST_SUPPORTED_VERSION: semver::Version = semver::Version::new(0, 8, 24);
+    pub const LAST_SUPPORTED_VERSION: semver::Version = semver::Version::new(0, 8, 25);
 
     ///
     /// A shortcut constructor.


### PR DESCRIPTION
# What ❔

Updates the Solidity tests for solc v0.8.25.

## Why ❔

solc v0.8.25 has been released.

## Checklist

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
