### PR TITLE
bug: add files from --libraries to sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Simulations to manipulate multiple active pointers
 - The solc v0.8.25 support
 
+### Fixed
+
+- Libraries passed with `--libraries` and now added to input files
+
 ## [1.4.0] - 2024-02-19
 
 ### Added

--- a/src/const.rs
+++ b/src/const.rs
@@ -2,8 +2,6 @@
 //! Solidity to EraVM compiler constants.
 //!
 
-#![allow(dead_code)]
-
 /// The default executable name.
 pub static DEFAULT_EXECUTABLE_NAME: &str = "zksolc";
 

--- a/src/evmla/assembly/instruction/name.rs
+++ b/src/evmla/assembly/instruction/name.rs
@@ -9,8 +9,6 @@ use serde::Serialize;
 /// The EVM instruction name.
 ///
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
-#[allow(non_camel_case_types)]
-#[allow(clippy::upper_case_acronyms)]
 pub enum Name {
     /// The eponymous EVM instruction.
     PUSH,

--- a/src/evmla/ethereal_ir/function/mod.rs
+++ b/src/evmla/ethereal_ir/function/mod.rs
@@ -240,7 +240,6 @@ impl Function {
     /// The blocks with an invalid stack state are considered being partially unreachable, and
     /// the invalid part is truncated after terminating with an `INVALID` instruction.
     ///
-    #[allow(clippy::too_many_arguments)]
     fn handle_instruction(
         blocks: &HashMap<era_compiler_llvm_context::BlockKey, Block>,
         functions: &mut BTreeMap<era_compiler_llvm_context::BlockKey, Self>,
@@ -1028,7 +1027,6 @@ impl Function {
     ///
     /// Handles the recursive function call.
     ///
-    #[allow(clippy::too_many_arguments)]
     fn handle_recursive_function_call(
         recursive_function: &RecursiveFunction,
         blocks: &HashMap<era_compiler_llvm_context::BlockKey, Block>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,12 @@
 //! Solidity to EraVM compiler library.
 //!
 
+#![allow(non_camel_case_types)]
+#![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::enum_variant_names)]
+#![allow(clippy::too_many_arguments)]
+#![allow(clippy::should_implement_trait)]
+
 pub(crate) mod build_eravm;
 pub(crate) mod build_evm;
 pub(crate) mod r#const;
@@ -227,7 +233,6 @@ pub fn eravm_assembly(
 ///
 /// Runs the standard output mode for EraVM.
 ///
-#[allow(clippy::too_many_arguments)]
 pub fn standard_output_eravm(
     input_files: &[PathBuf],
     libraries: Vec<String>,
@@ -321,7 +326,6 @@ pub fn standard_output_eravm(
 ///
 /// Runs the standard output mode for EVM.
 ///
-#[allow(clippy::too_many_arguments)]
 pub fn standard_output_evm(
     input_files: &[PathBuf],
     libraries: Vec<String>,
@@ -407,7 +411,6 @@ pub fn standard_output_evm(
 ///
 /// Runs the standard JSON mode for EVM.
 ///
-#[allow(clippy::too_many_arguments)]
 pub fn standard_json_eravm(
     solc: &mut SolcCompiler,
     detect_missing_libraries: bool,
@@ -553,7 +556,6 @@ pub fn standard_json_evm(
 ///
 /// Runs the combined JSON mode for EraVM.
 ///
-#[allow(clippy::too_many_arguments)]
 pub fn combined_json_eravm(
     format: String,
     input_files: &[PathBuf],
@@ -616,7 +618,6 @@ pub fn combined_json_eravm(
 ///
 /// Runs the combined JSON mode for EVM.
 ///
-#[allow(clippy::too_many_arguments)]
 pub fn combined_json_evm(
     format: String,
     input_files: &[PathBuf],

--- a/src/project/contract/ir/evmla.rs
+++ b/src/project/contract/ir/evmla.rs
@@ -14,8 +14,6 @@ use crate::solc::standard_json::output::contract::evm::extra_metadata::ExtraMeta
 /// The contract EVM legacy assembly source code.
 ///
 #[derive(Debug, Serialize, Deserialize, Clone)]
-#[allow(non_camel_case_types)]
-#[allow(clippy::upper_case_acronyms)]
 pub struct EVMLA {
     /// The EVM legacy assembly source code.
     pub assembly: Assembly,

--- a/src/project/contract/ir/llvm_ir.rs
+++ b/src/project/contract/ir/llvm_ir.rs
@@ -9,7 +9,6 @@ use serde::Serialize;
 /// The contract LLVM IR source code.
 ///
 #[derive(Debug, Serialize, Deserialize, Clone)]
-#[allow(clippy::upper_case_acronyms)]
 pub struct LLVMIR {
     /// The LLVM IR file path.
     pub path: String,

--- a/src/project/contract/ir/mod.rs
+++ b/src/project/contract/ir/mod.rs
@@ -25,9 +25,6 @@ use self::zkasm::ZKASM;
 /// The contract source code.
 ///
 #[derive(Debug, Serialize, Deserialize, Clone)]
-#[allow(non_camel_case_types)]
-#[allow(clippy::upper_case_acronyms)]
-#[allow(clippy::enum_variant_names)]
 pub enum IR {
     /// The Yul source code.
     Yul(Yul),

--- a/src/project/contract/ir/zkasm.rs
+++ b/src/project/contract/ir/zkasm.rs
@@ -9,7 +9,6 @@ use serde::Serialize;
 /// The contract EraVM assembly source code.
 ///
 #[derive(Debug, Serialize, Deserialize, Clone)]
-#[allow(clippy::upper_case_acronyms)]
 pub struct ZKASM {
     /// The EraVM assembly file path.
     pub path: String,

--- a/src/solc/pipeline.rs
+++ b/src/solc/pipeline.rs
@@ -9,8 +9,6 @@ use crate::solc::Compiler as SolcCompiler;
 /// The Solidity compiler pipeline type.
 ///
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[allow(non_camel_case_types)]
-#[allow(clippy::upper_case_acronyms)]
 pub enum Pipeline {
     /// The Yul IR.
     Yul,

--- a/src/solc/standard_json/input/mod.rs
+++ b/src/solc/standard_json/input/mod.rs
@@ -59,7 +59,6 @@ impl Input {
     ///
     /// A shortcut constructor from paths.
     ///
-    #[allow(clippy::too_many_arguments)]
     pub fn try_from_paths(
         language: Language,
         evm_version: Option<era_compiler_common::EVMVersion>,
@@ -72,6 +71,12 @@ impl Input {
         via_ir: bool,
         suppressed_warnings: Option<Vec<Warning>>,
     ) -> anyhow::Result<Self> {
+        let mut paths: BTreeSet<PathBuf> = paths.iter().cloned().collect();
+        let libraries = Settings::parse_libraries(library_map)?;
+        for library_file in libraries.keys() {
+            paths.insert(PathBuf::from(library_file));
+        }
+
         let sources = paths
             .into_par_iter()
             .map(|path| {
@@ -81,8 +86,6 @@ impl Input {
                 (path.to_string_lossy().to_string(), source)
             })
             .collect();
-
-        let libraries = Settings::parse_libraries(library_map)?;
 
         Ok(Self {
             language,
@@ -105,7 +108,6 @@ impl Input {
     ///
     /// Only for the integration test purposes.
     ///
-    #[allow(clippy::too_many_arguments)]
     pub fn try_from_sources(
         evm_version: Option<era_compiler_common::EVMVersion>,
         sources: BTreeMap<String, String>,

--- a/src/solc/standard_json/input/settings/selection/file/flag.rs
+++ b/src/solc/standard_json/input/settings/selection/file/flag.rs
@@ -11,8 +11,6 @@ use crate::solc::pipeline::Pipeline as SolcPipeline;
 /// The `solc --standard-json` expected output selection flag.
 ///
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash)]
-#[allow(non_camel_case_types)]
-#[allow(clippy::upper_case_acronyms)]
 pub enum Flag {
     /// The ABI JSON.
     #[serde(rename = "abi")]

--- a/src/yul/lexer/mod.rs
+++ b/src/yul/lexer/mod.rs
@@ -50,7 +50,6 @@ impl Lexer {
     ///
     /// Advances the lexer, returning the next lexeme.
     ///
-    #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> Result<Token, Error> {
         if let Some(peeked) = self.peeked.take() {
             return Ok(peeked);

--- a/src/yul/lexer/token/lexeme/comment/mod.rs
+++ b/src/yul/lexer/token/lexeme/comment/mod.rs
@@ -14,13 +14,7 @@ use self::single_line::Comment as SingleLineComment;
 /// The comment lexeme.
 ///
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)]
-pub enum Comment {
-    /// The single-line comment.
-    SingleLine(SingleLineComment),
-    /// The multi-line comment.
-    MultiLine(MultiLineComment),
-}
+pub enum Comment {}
 
 impl Comment {
     ///

--- a/src/zksolc/arguments.rs
+++ b/src/zksolc/arguments.rs
@@ -205,7 +205,6 @@ impl Arguments {
     ///
     /// Validates the arguments.
     ///
-    #[allow(clippy::collapsible_if)]
     pub fn validate(&self) -> anyhow::Result<()> {
         if self.version && std::env::args().count() > 2 {
             anyhow::bail!("No other options are allowed while getting the compiler version.");
@@ -299,12 +298,10 @@ impl Arguments {
             }
         }
 
-        if self.combined_json.is_some() {
-            if self.output_assembly || self.output_binary {
-                anyhow::bail!(
-                    "Cannot output assembly or binary outside of JSON in combined JSON mode."
-                );
-            }
+        if self.combined_json.is_some() && (self.output_assembly || self.output_binary) {
+            anyhow::bail!(
+                "Cannot output assembly or binary outside of JSON in combined JSON mode."
+            );
         }
 
         if self.standard_json {


### PR DESCRIPTION
# What ❔

Adds files from --libraries to input sources.

## Why ❔

Unlike `solc`, `zksolc` used to not to include these files to inputs, so `Source code for library X.sol` errors were emitted.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
