### PR TITLE
Missing `--overwrite` now returns an error

### DIFF
--- a/.github/actions/install-solc/action.yml
+++ b/.github/actions/install-solc/action.yml
@@ -4,7 +4,7 @@ inputs:
   solc-version:
     description: 'Version of solc compiler to download.'
     required: false
-    default: '0.8.24-1.0.0'
+    default: '0.8.25-1.0.0'
 runs:
   using: "composite"
   steps:
@@ -12,7 +12,7 @@ runs:
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       env:
         SOLC_URL: "https://github.com/matter-labs/era-solidity/releases/download"
-        SOLC_VERSION: ${{ inputs.solc-version || '0.8.24-1.0.0' }}
+        SOLC_VERSION: ${{ inputs.solc-version || '0.8.25-1.0.0' }}
       run: |
         OUTPUT=solc
         case "${RUNNER_OS}-${RUNNER_ARCH}" in

--- a/.github/workflows/test-cli.yaml
+++ b/.github/workflows/test-cli.yaml
@@ -13,7 +13,7 @@ on:
         type: string
         description: "solc version, (repo: https://github.com/matter-labs/era-solidity/releases)"
         required: true
-        default: "0.8.24-1.0.0"
+        default: "0.8.25-1.0.0"
   pull_request:
     paths:
       - 'cli-tests/**'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ on:
         type: string
         description: "solc version, (repo: https://github.com/matter-labs/era-solidity/releases)"
         required: true
-        default: "0.8.24-1.0.0"
+        default: "0.8.25-1.0.0"
   pull_request:
     paths-ignore:
       - 'cli-tests/**'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Libraries passed with `--libraries` and now added to input files
 - Printing `--help` if not arguments are provided
+- Missing `--overwrite` flag now triggers an error
 
 ## [1.4.0] - 2024-02-19
 

--- a/src/build_eravm/contract.rs
+++ b/src/build_eravm/contract.rs
@@ -72,7 +72,7 @@ impl Contract {
             file_path.push(file_name);
 
             if file_path.exists() && !overwrite {
-                eprintln!(
+                anyhow::bail!(
                     "Refusing to overwrite an existing file {file_path:?} (use --overwrite to force)."
                 );
             } else {
@@ -97,7 +97,7 @@ impl Contract {
             file_path.push(file_name);
 
             if file_path.exists() && !overwrite {
-                eprintln!(
+                anyhow::bail!(
                     "Refusing to overwrite an existing file {file_path:?} (use --overwrite to force)."
                 );
             } else {

--- a/src/build_evm/contract.rs
+++ b/src/build_evm/contract.rs
@@ -81,7 +81,7 @@ impl Contract {
                 file_path.push(file_name);
 
                 if file_path.exists() && !overwrite {
-                    eprintln!(
+                    anyhow::bail!(
                         "Refusing to overwrite an existing file {file_path:?} (use --overwrite to force)."
                     );
                 } else {

--- a/src/solc/combined_json/mod.rs
+++ b/src/solc/combined_json/mod.rs
@@ -92,7 +92,7 @@ impl CombinedJson {
         file_path.push(format!("combined.{}", era_compiler_common::EXTENSION_JSON));
 
         if file_path.exists() && !overwrite {
-            eprintln!(
+            anyhow::bail!(
                 "Refusing to overwrite an existing file {file_path:?} (use --overwrite to force)."
             );
             return Ok(());


### PR DESCRIPTION
# What ❔

Missing `--overwrite` now returns an error.

## Why ❔

Earlier, it would print an error and return exit code 0.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
