### PR TITLE
Print bytecode to --output-dir as a hex string

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,3 +17,4 @@
 - [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
 - [ ] Tests for the changes have been added / updated.
 - [ ] Documentation comments have been added / updated.
+- [ ] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Libraries passed with `--libraries` and now added to input files
 - Printing `--help` if not arguments are provided
 - Missing `--overwrite` flag now triggers an error
+- Bytecode is now printed to `--output-dir` as a hex string
 
 ## [1.4.0] - 2024-02-19
 

--- a/src/build_eravm/contract.rs
+++ b/src/build_eravm/contract.rs
@@ -105,7 +105,9 @@ impl Contract {
                     .map_err(|error| {
                         anyhow::anyhow!("File {:?} creating error: {}", file_path, error)
                     })?
-                    .write_all(self.build.bytecode.as_slice())
+                    .write_all(
+                        format!("0x{}", hex::encode(self.build.bytecode.as_slice())).as_bytes(),
+                    )
                     .map_err(|error| {
                         anyhow::anyhow!("File {:?} writing error: {}", file_path, error)
                     })?;

--- a/src/build_evm/contract.rs
+++ b/src/build_evm/contract.rs
@@ -89,7 +89,7 @@ impl Contract {
                         .map_err(|error| {
                             anyhow::anyhow!("File {:?} creating error: {}", file_path, error)
                         })?
-                        .write_all(bytecode.as_slice())
+                        .write_all(format!("0x{}", hex::encode(bytecode.as_slice())).as_bytes())
                         .map_err(|error| {
                             anyhow::anyhow!("File {:?} writing error: {}", file_path, error)
                         })?;

--- a/src/solc/combined_json/mod.rs
+++ b/src/solc/combined_json/mod.rs
@@ -95,7 +95,6 @@ impl CombinedJson {
             anyhow::bail!(
                 "Refusing to overwrite an existing file {file_path:?} (use --overwrite to force)."
             );
-            return Ok(());
         }
 
         File::create(&file_path)


### PR DESCRIPTION
# What ❔

Prints bytecode to --output-dir as a hex string.

## Why ❔

Binary format that was printed before, was unreadable and unusable by the tools.

## Checklist

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
