### PR TITLE
build: proper crt builtins linkage for aarch64-unknown-linux-musl

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,6 +16,13 @@ rustflags = [
     "-C", "link-arg=-mmacosx-version-min=11.0",
 ]
 
+[target.aarch64-unknown-linux-musl]
+linker = "rust-lld"
+
+[target.aarch64-unknown-linux-musl.compiler-rt]
+rustc-link-search = ["./target-llvm/target-host/lib/clang/17/lib/aarch64-unknown-linux-musl"]
+rustc-link-lib = ["clang_rt.builtins"]
+
 [profile.release]
 strip = true
 

--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Clone LLVM framework
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       run: |
-        cargo install compiler-llvm-builder
+        cargo install compiler-llvm-builder --git https://github.com/matter-labs/era-compiler-llvm-builder --branch aba-remove-wget-tar-requirements
         zkevm-llvm clone --target-env ${{ inputs.target-env }}
 
     - name: Define ccache key

--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Clone LLVM framework
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       run: |
-        cargo install compiler-llvm-builder --git https://github.com/matter-labs/era-compiler-llvm-builder --branch aba-remove-wget-tar-requirements
+        cargo install compiler-llvm-builder
         zkevm-llvm clone --target-env ${{ inputs.target-env }}
 
     - name: Define ccache key

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -5,10 +5,6 @@ inputs:
     description: 'Specific build target triplet.'
     required: false
     default: ''
-  rustflags:
-    description: 'Additional compilation flags to use for building.'
-    required: false
-    default: ''
   release-suffix:
     description: 'Suffix to use for release name.'
     required: false
@@ -26,8 +22,6 @@ runs:
 
     - name: Build zksolc
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
-      env:
-        RUSTFLAGS: ${{ inputs.rustflags }}
       run: |
         cargo build --release ${{ steps.build-target.outputs.target }}
         echo "${PWD}/target/${{ inputs.target }}/release" >> "${GITHUB_PATH}"

--- a/.github/actions/cli-tests/action.yml
+++ b/.github/actions/cli-tests/action.yml
@@ -8,7 +8,7 @@ inputs:
   zksolc-version:
     description: 'Prebuilt version of zksolc compiler to download and use in tests.'
     required: true
-    default: '1.4.0'
+    default: '1.4.1'
 runs:
   using: "composite"
   steps:

--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -9,10 +9,6 @@ inputs:
     description: 'Output unit tests results XML filename.'
     required: false
     default: 'unit-tests-results.xml'
-  rustflags:
-    description: 'Additional compilation flags to use for building.'
-    required: false
-    default: ''
 runs:
   using: "composite"
   steps:
@@ -31,7 +27,6 @@ runs:
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       env:
         RUSTC_BOOTSTRAP: "1"
-        RUSTFLAGS: ${{ inputs.rustflags }}
       run: |
         cargo install cargo2junit
         cargo test ${{ steps.build-target.outputs.target }} -- -Z unstable-options \

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -68,7 +68,6 @@ jobs:
             runner: matterlabs-ci-runner-arm
             image: matterlabs/llvm_runner:ubuntu22-llvm17-latest
             target: "aarch64-unknown-linux-musl"
-            rustflags: "-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-17/lib/clang/17/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
             release-suffix: linux-arm64-musl
             required: ${{ github.event.inputs.release_linux_arm64 }}
           - name: "Windows"
@@ -97,7 +96,6 @@ jobs:
         uses: ./.github/actions/build
         with:
           target: ${{ matrix.target }}
-          rustflags: ${{ matrix.rustflags }}
           release-suffix: ${{ matrix.release-suffix }}
 
   prepare-release:

--- a/.github/workflows/test-cli.yaml
+++ b/.github/workflows/test-cli.yaml
@@ -8,7 +8,7 @@ on:
         type: string
         description: "zksolc version, (repo: https://github.com/matter-labs/zksolc-bin/raw/main)"
         required: true
-        default: "1.4.0"
+        default: "1.4.1"
       solc-version:
         type: string
         description: "solc version, (repo: https://github.com/matter-labs/era-solidity/releases)"
@@ -34,7 +34,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ZKSOLC_PREBUILT_VERSION: ${{ github.event.inputs.zksolc-version || '1.4.0' }}
+  ZKSOLC_PREBUILT_VERSION: ${{ github.event.inputs.zksolc-version || '1.4.1' }}
 
 jobs:
   test:
@@ -54,7 +54,6 @@ jobs:
             runner: matterlabs-ci-runner-arm
             image: matterlabs/llvm_runner:ubuntu22-llvm17-latest
             target: "aarch64-unknown-linux-musl"
-            rustflags: "-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-17/lib/clang/17/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
           - name: "Windows"
             runner: windows-2022-github-hosted-16core
     runs-on: ${{ matrix.runner }}
@@ -78,7 +77,6 @@ jobs:
         uses: ./.github/actions/build
         with:
           target: ${{ matrix.target }}
-          rustflags: ${{ matrix.rustflags }}
 
       - name: Install solc compiler
         uses: ./.github/actions/install-solc

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ on:
         type: string
         description: "zksolc version, (repo: https://github.com/matter-labs/zksolc-bin/raw/main)"
         required: true
-        default: "1.4.0"
+        default: "1.4.1"
       solc-version:
         type: string
         description: "solc version, (repo: https://github.com/matter-labs/era-solidity/releases)"
@@ -48,7 +48,6 @@ jobs:
             runner: matterlabs-ci-runner-arm
             image: matterlabs/llvm_runner:ubuntu22-llvm17-latest
             target: "aarch64-unknown-linux-musl"
-            rustflags: "-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-17/lib/clang/17/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
           - name: "Windows"
             runner: windows-2022-github-hosted-16core
     runs-on: ${{ matrix.runner }}
@@ -70,7 +69,6 @@ jobs:
         uses: ./.github/actions/build
         with:
           target: ${{ matrix.target }}
-          rustflags: ${{ matrix.rustflags }}
 
       - name: Install solc compiler
         uses: ./.github/actions/install-solc
@@ -81,7 +79,6 @@ jobs:
         uses: ./.github/actions/unit-tests
         with:
           target: ${{ matrix.target || '' }}
-          rustflags: ${{ matrix.rustflags }}
 
       - name: Run CLI tests
         uses: ./.github/actions/cli-tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = [
 license = "MIT OR Apache-2.0"
 edition = "2021"
 description = "EraVM Solidity compiler"
+links = "compiler-rt"
 
 [[bin]]
 name = "zksolc"

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,10 @@
 //!
-//! Build script for the era-compiler-solidity
+//! The default build script for `zksolc`.
 //!
 
+///
+/// The default build script for `zksolc`.
+///
+/// Is required for `rust-link-lib` flags to work.
+///
 fn main() {}

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,5 @@
+//!
+//! Build script for the era-compiler-solidity
+//!
+
+fn main() {}


### PR DESCRIPTION
# What ❔

Fixes [CPR-1581](https://linear.app/matterlabs/issue/CPR-1581/undocumented-additional-zksolczkvyper-cross-compile-build-options)

Removes the necessity to add additional `RUSTFLAGS` for Linux Musl builds (`"-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"`).

Instead of using prebuilt system builtins (supported by https://github.com/matter-labs/era-compiler-llvm-builder/pull/26), we now use builtins from our host compiler built for stage 1. Additionally, we use `lld` linker.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To unify builds across all targets and be independent from clang installation on the host system that we do not control.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
