### PR TITLE
ci: pin version of the llvm builder

### DIFF
--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'Target environment (gnu or musl).'
     required: false
     default: 'musl'
+  llvm-builder-version:
+    description: 'Version of the LLVM builder to use.'
+    required: false
+    default: '1.0.24'
 runs:
   using: "composite"
   steps:
@@ -16,7 +20,7 @@ runs:
     - name: Clone LLVM framework
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       run: |
-        cargo install compiler-llvm-builder
+        cargo install compiler-llvm-builder@${{ inputs.llvm-builder-version }}
         zkevm-llvm clone --target-env ${{ inputs.target-env }}
 
     - name: Define ccache key


### PR DESCRIPTION
# What ❔

Pin the version of the LLVM builder tool instead of using latest from cargo crates.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Although it can be nice to always use the most recent builder, it is risky, because regardless of how well it is tested in the builder repository, there could be unexpected problems in CI caused by an update in the other repository.

It is also impossible right now to change the builder name if the version is not pinned. This PR makes this possible and puts the builder update process under control.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
