### PR TITLE
ci: remove tests comments from PRs keeping checks only

### DIFF
--- a/.github/actions/cli-tests/action.yml
+++ b/.github/actions/cli-tests/action.yml
@@ -62,6 +62,7 @@ runs:
         check_name: CLI Tests ${{ runner.os }} ${{ runner.arch }} (prebuilt - ${{ inputs.use-prebuilt-zksolc }})
         files: cli-tests/junit.xml
         action_fail_on_inconclusive: true
+        comment_mode: off
 
     - name: Upload results MacOS
       if: runner.os == 'macOS'
@@ -70,6 +71,7 @@ runs:
         check_name: CLI Tests Results ${{ runner.os }} ${{ runner.arch }} (prebuilt - ${{ inputs.use-prebuilt-zksolc }})
         files: cli-tests/junit.xml
         action_fail_on_inconclusive: true
+        comment_mode: off
 
     - name: Upload results Windows
       if: runner.os == 'Windows'
@@ -78,3 +80,4 @@ runs:
         check_name: CLI Tests Results ${{ runner.os }} ${{ runner.arch }} (prebuilt - ${{ inputs.use-prebuilt-zksolc }})
         files: cli-tests/junit.xml
         action_fail_on_inconclusive: true
+        comment_mode: off

--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -45,6 +45,7 @@ runs:
         check_name: ${{ runner.os }} ${{ runner.arch }} Unit Tests Results
         files: ${{ inputs.results-xml }}
         action_fail_on_inconclusive: true
+        comment_mode: off
 
     - name: Upload test results MacOS
       if: runner.os == 'macOS'
@@ -53,6 +54,7 @@ runs:
         check_name: ${{ runner.os }} ${{ runner.arch }} Unit Tests Results
         files: ${{ inputs.results-xml }}
         action_fail_on_inconclusive: true
+        comment_mode: off
 
     - name: Upload test results Windows
       if: runner.os == 'Windows'
@@ -61,3 +63,4 @@ runs:
         check_name: ${{ runner.os }} ${{ runner.arch }} Unit Tests Results
         files: ${{ inputs.results-xml }}
         action_fail_on_inconclusive: true
+        comment_mode: off

--- a/.github/workflows/cargo-license.yaml
+++ b/.github/workflows/cargo-license.yaml
@@ -4,5 +4,5 @@ jobs:
   cargo-deny:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: EmbarkStudios/cargo-deny-action@1e59595bed8fc55c969333d08d7817b36888f0c5 # v1.5.5
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v1


### PR DESCRIPTION
# What ❔

Removes 6 comments from PRs about test results.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To not flood too much in notifications keeping the same functional behavior.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
