### PR TITLE
fix: the culprit of data race in unit tests

### DIFF
--- a/src/solc/standard_json/input/mod.rs
+++ b/src/solc/standard_json/input/mod.rs
@@ -135,7 +135,7 @@ impl Input {
         suppressed_warnings: Option<Vec<Warning>>,
     ) -> anyhow::Result<Self> {
         let sources = sources
-            .into_par_iter()
+            .into_iter()
             .map(|(path, content)| (path, Source::from(content)))
             .collect();
 


### PR DESCRIPTION
# What ❔

Removes the parallel iterator when the project is created from a list of strings.

## Why ❔

1. The iterator has been causing data races in unit tests.
2. It is certainly redundant when collecting strings into a map.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
