### PR TITLE
fix: the global thread pool data race in unit tests

### DIFF
--- a/src/const.rs
+++ b/src/const.rs
@@ -5,6 +5,9 @@
 /// The default executable name.
 pub static DEFAULT_EXECUTABLE_NAME: &str = "zksolc";
 
+/// The rayon worker stack size.
+pub const RAYON_WORKER_STACK_SIZE: usize = 16 * 1024 * 1024;
+
 /// The `keccak256` scratch space offset.
 pub const OFFSET_SCRATCH_SPACE: usize = 0;
 

--- a/src/zksolc/main.rs
+++ b/src/zksolc/main.rs
@@ -10,9 +10,6 @@ use std::str::FromStr;
 
 use self::arguments::Arguments;
 
-/// The rayon worker stack size.
-const RAYON_WORKER_STACK_SIZE: usize = 16 * 1024 * 1024;
-
 #[cfg(target_env = "musl")]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
@@ -54,7 +51,7 @@ fn main_inner() -> anyhow::Result<()> {
     };
 
     rayon::ThreadPoolBuilder::new()
-        .stack_size(RAYON_WORKER_STACK_SIZE)
+        .stack_size(era_compiler_solidity::RAYON_WORKER_STACK_SIZE)
         .build_global()
         .expect("Thread pool configuration failure");
     inkwell::support::enable_llvm_pretty_stack_trace();


### PR DESCRIPTION
# What ❔

Another attempt to fix the data race in `rayon` by globally initializing the thread pool.

If it does not work, I'll put it into a thread-safe global variable.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
