### PR TITLE
fix: support one-part format of the ZKsync version of solc

### DIFF
--- a/src/solc/mod.rs
+++ b/src/solc/mod.rs
@@ -301,7 +301,7 @@ impl Compiler {
             .lines()
             .nth(2)
             .and_then(|line| line.split(' ').nth(1))
-            .and_then(|line| line.split('-').nth(1))
+            .and_then(|line| line.split('-').last())
             .and_then(|version| version.parse().ok());
 
         let version = Version::new(long, default, l2_revision);


### PR DESCRIPTION
# What ❔

Makes the `solc` version parser more flexible.

## Why ❔

We're fixing the devops mistake where `0.8.25-1.0.0` format is written as the ZKsync revision of `solc` instead of simply `1.0.0`.
Both new and old formats will be accepted.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
