### PR TITLE
feat: optimize Yul validation and add more unit tests

### DIFF
--- a/src/solc/mod.rs
+++ b/src/solc/mod.rs
@@ -98,7 +98,6 @@ impl Compiler {
         }
 
         let input_json = serde_json::to_vec(&input).expect("Always valid");
-        dbg!(&input);
 
         let process = command.spawn().map_err(|error| {
             anyhow::anyhow!("{} subprocess spawning error: {:?}", self.executable, error)
@@ -138,7 +137,6 @@ impl Compiler {
                 .unwrap_or_else(|_| String::from_utf8_lossy(output.stdout.as_slice()).to_string()),
             )
         })?;
-        dbg!(&output);
 
         if let Some(pipeline) = pipeline {
             let suppressed_warnings = input.suppressed_warnings.take().unwrap_or_default();

--- a/src/solc/standard_json/input/settings/mod.rs
+++ b/src/solc/standard_json/input/settings/mod.rs
@@ -75,7 +75,7 @@ impl Settings {
     }
 
     ///
-    /// Sets the necessary defaults.
+    /// Sets the necessary defaults for EraVM compilation.
     ///
     pub fn normalize(&mut self, version: &semver::Version, pipeline: Option<SolcPipeline>) {
         self.output_selection
@@ -83,6 +83,15 @@ impl Settings {
             .extend_with_required(pipeline);
 
         self.optimizer.normalize(version);
+    }
+
+    ///
+    /// Sets the necessary defaults for Yul validation.
+    ///
+    pub fn normalize_yul_validation(&mut self) {
+        self.output_selection
+            .get_or_insert_with(Selection::new_yul_validation)
+            .extend_with_yul_validation();
     }
 
     ///

--- a/src/solc/standard_json/input/settings/optimizer/mod.rs
+++ b/src/solc/standard_json/input/settings/optimizer/mod.rs
@@ -7,6 +7,8 @@ pub mod details;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::solc::Compiler as SolcCompiler;
+
 use self::details::Details;
 
 ///
@@ -50,11 +52,29 @@ impl Optimizer {
         Self {
             enabled,
             mode,
-            details: Some(Details::disabled(version)),
+            details: if version >= &semver::Version::new(0, 5, 5) {
+                Some(Details::disabled(version))
+            } else {
+                None
+            },
             fallback_to_optimizing_for_size: Some(fallback_to_optimizing_for_size),
             disable_system_request_memoization: Some(disable_system_request_memoization),
             jump_table_density_threshold,
         }
+    }
+
+    ///
+    /// A shortcut constructor for Yul validation.
+    ///
+    pub fn new_yul_validation() -> Self {
+        Self::new(
+            true,
+            None,
+            &SolcCompiler::LAST_SUPPORTED_VERSION,
+            false,
+            false,
+            None,
+        )
     }
 
     ///

--- a/src/solc/standard_json/input/settings/selection/file/flag.rs
+++ b/src/solc/standard_json/input/settings/selection/file/flag.rs
@@ -39,6 +39,9 @@ pub enum Flag {
     /// The EVM legacy assembly JSON.
     #[serde(rename = "evm.legacyAssembly")]
     EVMLA,
+    /// The EVM bytecode.
+    #[serde(rename = "evm")]
+    EVM,
 }
 
 impl From<SolcPipeline> for Flag {
@@ -62,6 +65,7 @@ impl std::fmt::Display for Flag {
             Self::AST => write!(f, "ast"),
             Self::Yul => write!(f, "irOptimized"),
             Self::EVMLA => write!(f, "evm.legacyAssembly"),
+            Self::EVM => write!(f, "evm"),
         }
     }
 }

--- a/src/solc/standard_json/input/settings/selection/file/mod.rs
+++ b/src/solc/standard_json/input/settings/selection/file/mod.rs
@@ -28,7 +28,7 @@ pub struct File {
 
 impl File {
     ///
-    /// Creates the selection required by our compilation process.
+    /// Creates the selection required by EraVM compilation process.
     ///
     pub fn new_required(pipeline: Option<SolcPipeline>) -> Self {
         let mut per_contract =
@@ -44,7 +44,17 @@ impl File {
     }
 
     ///
-    /// Extends the user's output selection with flag required by our compilation process.
+    /// Creates the selection required by Yul validation process.
+    ///
+    pub fn new_yul_validation() -> Self {
+        Self {
+            per_file: Some(HashSet::new()),
+            per_contract: Some(HashSet::from_iter([SelectionFlag::EVM])),
+        }
+    }
+
+    ///
+    /// Extends the output selection with flag required by EraVM compilation process.
     ///
     pub fn extend_with_required(&mut self, pipeline: Option<SolcPipeline>) -> &mut Self {
         let required = Self::new_required(pipeline);
@@ -54,6 +64,20 @@ impl File {
         self.per_contract
             .get_or_insert_with(HashSet::default)
             .extend(required.per_contract.unwrap_or_default());
+        self
+    }
+
+    ///
+    /// Extends the output selection with flag required by the Yul validation.
+    ///
+    pub fn extend_with_yul_validation(&mut self) -> &mut Self {
+        let yul_validation = Self::new_yul_validation();
+        self.per_file
+            .get_or_insert_with(HashSet::default)
+            .extend(yul_validation.per_file.unwrap_or_default());
+        self.per_contract
+            .get_or_insert_with(HashSet::default)
+            .extend(yul_validation.per_contract.unwrap_or_default());
         self
     }
 }

--- a/src/solc/standard_json/input/settings/selection/mod.rs
+++ b/src/solc/standard_json/input/settings/selection/mod.rs
@@ -23,7 +23,7 @@ pub struct Selection {
 
 impl Selection {
     ///
-    /// Creates the selection required by our compilation process.
+    /// Creates the selection required by EraVM compilation process.
     ///
     pub fn new_required(pipeline: Option<SolcPipeline>) -> Self {
         Self {
@@ -32,12 +32,31 @@ impl Selection {
     }
 
     ///
-    /// Extends the user's output selection with flag required by our compilation process.
+    /// Creates the selection required by Yul validation process.
+    ///
+    pub fn new_yul_validation() -> Self {
+        Self {
+            all: Some(FileSelection::new_yul_validation()),
+        }
+    }
+
+    ///
+    /// Extends the output selection with flag required by EraVM compilation process.
     ///
     pub fn extend_with_required(&mut self, pipeline: Option<SolcPipeline>) -> &mut Self {
         self.all
             .get_or_insert_with(|| FileSelection::new_required(pipeline))
             .extend_with_required(pipeline);
+        self
+    }
+
+    ///
+    /// Extends the output selection with flag required by the Yul validation.
+    ///
+    pub fn extend_with_yul_validation(&mut self) -> &mut Self {
+        self.all
+            .get_or_insert_with(FileSelection::new_yul_validation)
+            .extend_with_yul_validation();
         self
     }
 }

--- a/src/tests/standard_json.rs
+++ b/src/tests/standard_json.rs
@@ -7,6 +7,7 @@
 use std::path::PathBuf;
 
 use crate::solc::standard_json::input::Input as SolcStandardJsonInput;
+use crate::solc::Compiler as SolcCompiler;
 
 #[test]
 fn standard_json_yul_default() {
@@ -15,6 +16,34 @@ fn standard_json_yul_default() {
     ))
     .expect("Standard JSON reading error");
     let solc_output = super::build_yul_standard_json(solc_input, None).expect("Test failure");
+
+    assert!(!solc_output
+        .contracts
+        .expect("The `contracts` field is missing")
+        .get("Test")
+        .expect("The `Test` contract is missing")
+        .get("Test")
+        .expect("The `Test` contract is missing")
+        .evm
+        .as_ref()
+        .expect("The `evm` field is missing")
+        .bytecode
+        .as_ref()
+        .expect("The `bytecode` field is missing")
+        .object
+        .is_empty())
+}
+
+#[test]
+fn standard_json_yul_default_validated() {
+    let solc_input = SolcStandardJsonInput::try_from_reader(Some(
+        PathBuf::from("src/tests/examples/standard_json_input/yul_default.json").as_path(),
+    ))
+    .expect("Standard JSON reading error");
+    let solc_compiler = SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME.to_owned())
+        .expect("`solc` initialization error");
+    let solc_output =
+        super::build_yul_standard_json(solc_input, Some(solc_compiler)).expect("Test failure");
 
     assert!(!solc_output
         .contracts
@@ -59,6 +88,34 @@ fn standard_json_yul_default_urls() {
 }
 
 #[test]
+fn standard_json_yul_default_urls_validated() {
+    let solc_input = SolcStandardJsonInput::try_from_reader(Some(
+        PathBuf::from("src/tests/examples/standard_json_input/yul_default_urls.json").as_path(),
+    ))
+    .expect("Standard JSON reading error");
+    let solc_compiler = SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME.to_owned())
+        .expect("`solc` initialization error");
+    let solc_output =
+        super::build_yul_standard_json(solc_input, Some(solc_compiler)).expect("Test failure");
+
+    assert!(!solc_output
+        .contracts
+        .expect("The `contracts` field is missing")
+        .get("Test")
+        .expect("The `Test` contract is missing")
+        .get("Test")
+        .expect("The `Test` contract is missing")
+        .evm
+        .as_ref()
+        .expect("The `evm` field is missing")
+        .bytecode
+        .as_ref()
+        .expect("The `bytecode` field is missing")
+        .object
+        .is_empty())
+}
+
+#[test]
 fn standard_json_yul_eravm() {
     let solc_input = SolcStandardJsonInput::try_from_reader(Some(
         PathBuf::from("src/tests/examples/standard_json_input/yul_eravm.json").as_path(),
@@ -84,12 +141,68 @@ fn standard_json_yul_eravm() {
 }
 
 #[test]
+fn standard_json_yul_eravm_validated() {
+    let solc_input = SolcStandardJsonInput::try_from_reader(Some(
+        PathBuf::from("src/tests/examples/standard_json_input/yul_eravm.json").as_path(),
+    ))
+    .expect("Standard JSON reading error");
+    let solc_compiler = SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME.to_owned())
+        .expect("`solc` initialization error");
+    let solc_output =
+        super::build_yul_standard_json(solc_input, Some(solc_compiler)).expect("Test failure");
+
+    assert!(!solc_output
+        .contracts
+        .expect("The `contracts` field is missing")
+        .get("EventWriter.yul")
+        .expect("The `EventWriter.yul` contract is missing")
+        .get("EventWriter.yul")
+        .expect("The `EventWriter.yul` contract is missing")
+        .evm
+        .as_ref()
+        .expect("The `evm` field is missing")
+        .bytecode
+        .as_ref()
+        .expect("The `bytecode` field is missing")
+        .object
+        .is_empty())
+}
+
+#[test]
 fn standard_json_yul_eravm_urls() {
     let solc_input = SolcStandardJsonInput::try_from_reader(Some(
         PathBuf::from("src/tests/examples/standard_json_input/yul_eravm_urls.json").as_path(),
     ))
     .expect("Standard JSON reading error");
     let solc_output = super::build_yul_standard_json(solc_input, None).expect("Test failure");
+
+    assert!(!solc_output
+        .contracts
+        .expect("The `contracts` field is missing")
+        .get("EventWriter.yul")
+        .expect("The `EventWriter.yul` contract is missing")
+        .get("EventWriter.yul")
+        .expect("The `EventWriter.yul` contract is missing")
+        .evm
+        .as_ref()
+        .expect("The `evm` field is missing")
+        .bytecode
+        .as_ref()
+        .expect("The `bytecode` field is missing")
+        .object
+        .is_empty())
+}
+
+#[test]
+fn standard_json_yul_eravm_urls_validated() {
+    let solc_input = SolcStandardJsonInput::try_from_reader(Some(
+        PathBuf::from("src/tests/examples/standard_json_input/yul_eravm_urls.json").as_path(),
+    ))
+    .expect("Standard JSON reading error");
+    let solc_compiler = SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME.to_owned())
+        .expect("`solc` initialization error");
+    let solc_output =
+        super::build_yul_standard_json(solc_input, Some(solc_compiler)).expect("Test failure");
 
     assert!(!solc_output
         .contracts


### PR DESCRIPTION
# What ❔

1. Optimizes Yul validation with `solc` by using only one standard JSON request.
2. Add unit tests for all cases.

## Why ❔

1. Previously, a `solc --strict-assembly <file>` was used for each file.
2. Unit tests for `solc` validation were missing.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
