### PR TITLE
feat: make solc a singleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - The support for Yul, LLVM IR, and EraVM assembly languages in standard JSON mode
 - The support for `urls` to local files in standard JSON input
 - More LLVM optimizations
+- Caching of the underlying compiler's metadata, including `--version`
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,6 @@ dependencies = [
  "md5",
  "mimalloc",
  "num",
- "once_cell",
  "path-slash",
  "rand",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ rayon = "1.10"
 serde = { version = "1.0", "features" = [ "derive" ] }
 serde_json = { version = "1.0", features = [ "arbitrary_precision" ] }
 semver = { version = "1.0", features = [ "serde" ] }
-once_cell = "1.19"
 rand = "0.8"
 regex = "1.10"
 hex = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,13 +79,17 @@ pub fn yul_to_eravm(
             }
             let solc_compiler = SolcCompiler::new(solc_path.as_str())?;
             solc_compiler.validate_yul_paths(paths, libraries.clone())?;
-            Some(&solc_compiler.version)
+            Some(solc_compiler.version)
         }
         None => None,
     };
 
-    let project =
-        Project::try_from_yul_paths(paths, libraries, solc_version, debug_config.as_ref())?;
+    let project = Project::try_from_yul_paths(
+        paths,
+        libraries,
+        solc_version.as_ref(),
+        debug_config.as_ref(),
+    )?;
 
     let build = project.compile_to_eravm(
         optimizer_settings,
@@ -115,13 +119,17 @@ pub fn yul_to_evm(
         Some(solc_path) => {
             let solc_compiler = SolcCompiler::new(solc_path.as_str())?;
             solc_compiler.validate_yul_paths(paths, libraries.clone())?;
-            Some(&solc_compiler.version)
+            Some(solc_compiler.version)
         }
         None => None,
     };
 
-    let project =
-        Project::try_from_yul_paths(paths, libraries, solc_version, debug_config.as_ref())?;
+    let project = Project::try_from_yul_paths(
+        paths,
+        libraries,
+        solc_version.as_ref(),
+        debug_config.as_ref(),
+    )?;
 
     let build = project.compile_to_evm(optimizer_settings, include_metadata_hash, debug_config)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,9 +77,9 @@ pub fn yul_to_eravm(
             if is_system_mode {
                 anyhow::bail!("Yul validation cannot be done if EraVM extensions are enabled. Consider compiling without `solc`.")
             }
-            let mut solc_compiler = SolcCompiler::new(solc_path)?;
+            let solc_compiler = SolcCompiler::new(solc_path.as_str())?;
             solc_compiler.validate_yul_paths(paths, libraries.clone())?;
-            Some(solc_compiler.version()?)
+            Some(&solc_compiler.version)
         }
         None => None,
     };
@@ -113,9 +113,9 @@ pub fn yul_to_evm(
 
     let solc_version = match solc_path {
         Some(solc_path) => {
-            let mut solc_compiler = SolcCompiler::new(solc_path)?;
+            let solc_compiler = SolcCompiler::new(solc_path.as_str())?;
             solc_compiler.validate_yul_paths(paths, libraries.clone())?;
-            Some(solc_compiler.version()?)
+            Some(&solc_compiler.version)
         }
         None => None,
     };
@@ -195,7 +195,7 @@ pub fn eravm_assembly(
 pub fn standard_output_eravm(
     paths: &[PathBuf],
     libraries: Vec<String>,
-    solc_compiler: &mut SolcCompiler,
+    solc_compiler: &SolcCompiler,
     evm_version: Option<era_compiler_common::EVMVersion>,
     solc_optimizer_enabled: bool,
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
@@ -210,7 +210,7 @@ pub fn standard_output_eravm(
     suppressed_warnings: Option<Vec<Warning>>,
     debug_config: Option<era_compiler_llvm_context::DebugConfig>,
 ) -> anyhow::Result<EraVMBuild> {
-    let solc_version = solc_compiler.version()?;
+    let solc_version = solc_compiler.version.to_owned();
     let solc_pipeline = SolcPipeline::new(&solc_version, force_evmla);
 
     let solc_input = SolcStandardJsonInput::try_from_solidity_paths(
@@ -287,7 +287,7 @@ pub fn standard_output_eravm(
 pub fn standard_output_evm(
     paths: &[PathBuf],
     libraries: Vec<String>,
-    solc_compiler: &mut SolcCompiler,
+    solc_compiler: &SolcCompiler,
     evm_version: Option<era_compiler_common::EVMVersion>,
     solc_optimizer_enabled: bool,
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
@@ -300,7 +300,7 @@ pub fn standard_output_evm(
     remappings: Option<BTreeSet<String>>,
     debug_config: Option<era_compiler_llvm_context::DebugConfig>,
 ) -> anyhow::Result<EVMBuild> {
-    let solc_version = solc_compiler.version()?;
+    let solc_version = solc_compiler.version.to_owned();
     let solc_pipeline = SolcPipeline::new(&solc_version, force_evmla);
 
     let solc_input = SolcStandardJsonInput::try_from_solidity_paths(
@@ -369,7 +369,7 @@ pub fn standard_output_evm(
 /// Runs the standard JSON mode for EVM.
 ///
 pub fn standard_json_eravm(
-    solc_compiler: Option<&mut SolcCompiler>,
+    solc_compiler: Option<&SolcCompiler>,
     json_path: Option<PathBuf>,
     detect_missing_libraries: bool,
     force_evmla: bool,
@@ -396,9 +396,8 @@ pub fn standard_json_eravm(
 
     let (mut solc_output, solc_version, project) = match (language, solc_compiler) {
         (SolcStandardJsonInputLanguage::Solidity, Some(solc_compiler)) => {
-            let solc_version = solc_compiler.version()?;
-            let solc_pipeline = SolcPipeline::new(&solc_version, force_evmla);
-            solc_input.normalize(&solc_version.default, Some(solc_pipeline));
+            let solc_pipeline = SolcPipeline::new(&solc_compiler.version, force_evmla);
+            solc_input.normalize(&solc_compiler.version.default, Some(solc_pipeline));
 
             let mut solc_output = solc_compiler.standard_json(
                 solc_input,
@@ -430,23 +429,22 @@ pub fn standard_json_eravm(
                 debug_config.as_ref(),
             )?;
 
-            (solc_output, Some(solc_version), project)
+            (solc_output, Some(&solc_compiler.version), project)
         }
         (SolcStandardJsonInputLanguage::Solidity, None) => {
             anyhow::bail!("Compiling Solidity without `solc` is not supported")
         }
         (SolcStandardJsonInputLanguage::Yul, Some(solc_compiler)) => {
             let solc_output = solc_compiler.validate_yul_standard_json(solc_input)?;
-            let solc_version = solc_compiler.version()?;
 
             let project = Project::try_from_yul_sources(
                 sources,
                 libraries,
-                Some(solc_version.clone()),
+                Some(&solc_compiler.version),
                 debug_config.as_ref(),
             )?;
 
-            (solc_output, Some(solc_version), project)
+            (solc_output, Some(&solc_compiler.version), project)
         }
         (SolcStandardJsonInputLanguage::Yul, None) => {
             let solc_output = SolcStandardJsonOutput::new(&sources);
@@ -476,7 +474,7 @@ pub fn standard_json_eravm(
         let missing_libraries = project.get_missing_libraries();
         missing_libraries.write_to_standard_json(
             &mut solc_output,
-            solc_version.as_ref(),
+            solc_version,
             &zksolc_version,
         )?;
     } else {
@@ -487,7 +485,7 @@ pub fn standard_json_eravm(
             zkevm_assembly::RunningVmEncodingMode::Production,
             debug_config,
         )?;
-        build.write_to_standard_json(&mut solc_output, solc_version.as_ref(), &zksolc_version)?;
+        build.write_to_standard_json(&mut solc_output, solc_version, &zksolc_version)?;
     }
     serde_json::to_writer(std::io::stdout(), &solc_output)?;
     std::process::exit(era_compiler_common::EXIT_CODE_SUCCESS);
@@ -497,7 +495,7 @@ pub fn standard_json_eravm(
 /// Runs the standard JSON mode for EVM.
 ///
 pub fn standard_json_evm(
-    solc_compiler: Option<&mut SolcCompiler>,
+    solc_compiler: Option<&SolcCompiler>,
     json_path: Option<PathBuf>,
     force_evmla: bool,
     base_path: Option<String>,
@@ -522,9 +520,8 @@ pub fn standard_json_evm(
 
     let (mut solc_output, solc_version, project) = match (language, solc_compiler) {
         (SolcStandardJsonInputLanguage::Solidity, Some(solc_compiler)) => {
-            let solc_version = solc_compiler.version()?;
-            let solc_pipeline = SolcPipeline::new(&solc_version, force_evmla);
-            solc_input.normalize(&solc_version.default, Some(solc_pipeline));
+            let solc_pipeline = SolcPipeline::new(&solc_compiler.version, force_evmla);
+            solc_input.normalize(&solc_compiler.version.default, Some(solc_pipeline));
 
             let mut solc_output = solc_compiler.standard_json(
                 solc_input,
@@ -556,23 +553,22 @@ pub fn standard_json_evm(
                 debug_config.as_ref(),
             )?;
 
-            (solc_output, Some(solc_version), project)
+            (solc_output, Some(&solc_compiler.version), project)
         }
         (SolcStandardJsonInputLanguage::Solidity, None) => {
             anyhow::bail!("Compiling Solidity without `solc` is not supported")
         }
         (SolcStandardJsonInputLanguage::Yul, Some(solc_compiler)) => {
             let solc_output = solc_compiler.validate_yul_standard_json(solc_input)?;
-            let solc_version = solc_compiler.version()?;
 
             let project = Project::try_from_yul_sources(
                 sources,
                 libraries,
-                Some(solc_version.clone()),
+                Some(&solc_compiler.version),
                 debug_config.as_ref(),
             )?;
 
-            (solc_output, Some(solc_version), project)
+            (solc_output, Some(&solc_compiler.version), project)
         }
         (SolcStandardJsonInputLanguage::Yul, None) => {
             let solc_output = SolcStandardJsonOutput::new(&sources);
@@ -594,7 +590,7 @@ pub fn standard_json_evm(
     };
 
     let build = project.compile_to_evm(optimizer_settings, include_metadata_hash, debug_config)?;
-    build.write_to_standard_json(&mut solc_output, solc_version.as_ref(), &zksolc_version)?;
+    build.write_to_standard_json(&mut solc_output, solc_version, &zksolc_version)?;
     serde_json::to_writer(std::io::stdout(), &solc_output)?;
     std::process::exit(era_compiler_common::EXIT_CODE_SUCCESS);
 }
@@ -606,7 +602,7 @@ pub fn combined_json_eravm(
     format: String,
     paths: &[PathBuf],
     libraries: Vec<String>,
-    solc_compiler: &mut SolcCompiler,
+    solc_compiler: &SolcCompiler,
     evm_version: Option<era_compiler_common::EVMVersion>,
     solc_optimizer_enabled: bool,
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
@@ -671,7 +667,7 @@ pub fn combined_json_evm(
     format: String,
     paths: &[PathBuf],
     libraries: Vec<String>,
-    solc_compiler: &mut SolcCompiler,
+    solc_compiler: &SolcCompiler,
     evm_version: Option<era_compiler_common::EVMVersion>,
     solc_optimizer_enabled: bool,
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -10,8 +10,7 @@ pub mod output_evm;
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
-
-use once_cell::sync::OnceCell;
+use std::sync::OnceLock;
 
 use self::input_eravm::Input as EraVMInput;
 use self::input_evm::Input as EVMInput;
@@ -19,7 +18,7 @@ use self::output_eravm::Output as EraVMOutput;
 use self::output_evm::Output as EVMOutput;
 
 /// The overriden executable name used when the compiler is run as a library.
-pub static EXECUTABLE: OnceCell<PathBuf> = OnceCell::new();
+pub static EXECUTABLE: OnceLock<PathBuf> = OnceLock::new();
 
 ///
 /// Read input from `stdin`, compile a contract, and write the output to `stdout`.

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -88,7 +88,7 @@ impl Project {
         sources: BTreeMap<String, String>,
         libraries: BTreeMap<String, BTreeMap<String, String>>,
         pipeline: SolcPipeline,
-        solc_compiler: &mut SolcCompiler,
+        solc_compiler: &SolcCompiler,
         debug_config: Option<&era_compiler_llvm_context::DebugConfig>,
     ) -> anyhow::Result<Self> {
         if let SolcPipeline::EVMLA = pipeline {
@@ -110,7 +110,7 @@ impl Project {
         };
         let mut project_contracts = BTreeMap::new();
 
-        let solc_version = solc_compiler.version()?;
+        let solc_version = solc_compiler.version.to_owned();
 
         for (path, contracts) in files.iter() {
             for (name, contract) in contracts.iter() {
@@ -185,7 +185,7 @@ impl Project {
     pub fn try_from_yul_paths(
         paths: &[PathBuf],
         libraries: BTreeMap<String, BTreeMap<String, String>>,
-        solc_version: Option<SolcVersion>,
+        solc_version: Option<&SolcVersion>,
         debug_config: Option<&era_compiler_llvm_context::DebugConfig>,
     ) -> anyhow::Result<Self> {
         let sources = paths
@@ -205,7 +205,7 @@ impl Project {
     pub fn try_from_yul_sources(
         sources: BTreeMap<String, String>,
         libraries: BTreeMap<String, BTreeMap<String, String>>,
-        solc_version: Option<SolcVersion>,
+        solc_version: Option<&SolcVersion>,
         debug_config: Option<&era_compiler_llvm_context::DebugConfig>,
     ) -> anyhow::Result<Self> {
         let project_contracts = sources
@@ -227,7 +227,7 @@ impl Project {
                     IR::new_yul(source_code.to_owned(), object),
                     None,
                     hash,
-                    solc_version.as_ref(),
+                    solc_version,
                 );
 
                 Ok((path, contract))
@@ -236,7 +236,7 @@ impl Project {
 
         Ok(Self::new(
             SolcStandardJsonInputLanguage::Yul,
-            solc_version,
+            solc_version.cloned(),
             project_contracts,
             libraries,
         ))

--- a/src/solc/mod.rs
+++ b/src/solc/mod.rs
@@ -66,6 +66,7 @@ impl Compiler {
         {
             return Ok(executable);
         }
+        let mut executables = Self::executables().write().expect("Sync");
 
         if let Err(error) = which::which(executable) {
             anyhow::bail!(
@@ -79,16 +80,8 @@ impl Compiler {
             version,
         };
 
-        Self::executables()
-            .write()
-            .expect("Sync")
-            .insert(executable.to_owned(), compiler);
-        Ok(Self::executables()
-            .read()
-            .expect("Sync")
-            .get(executable)
-            .cloned()
-            .expect("Always exists"))
+        executables.insert(executable.to_owned(), compiler.clone());
+        Ok(compiler)
     }
 
     ///

--- a/src/solc/version.rs
+++ b/src/solc/version.rs
@@ -2,13 +2,10 @@
 //! The Solidity compiler version.
 //!
 
-use serde::Deserialize;
-use serde::Serialize;
-
 ///
 /// The Solidity compiler version.
 ///
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Version {
     /// The long version string.
     pub long: String,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -44,8 +44,7 @@ pub fn build_solidity(
     era_compiler_llvm_context::initialize_target(era_compiler_llvm_context::Target::EraVM);
     let _ = crate::process::EXECUTABLE.set(PathBuf::from(crate::r#const::DEFAULT_EXECUTABLE_NAME));
 
-    let mut solc_compiler = SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME.to_owned())?;
-    let solc_version = solc_compiler.version()?;
+    let solc_compiler = SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME)?;
 
     let solc_input = SolcStandardJsonInput::try_from_solidity_sources(
         None,
@@ -56,7 +55,7 @@ pub fn build_solidity(
         SolcStandardJsonInputSettingsOptimizer::new(
             true,
             None,
-            &solc_version.default,
+            &solc_compiler.version.default,
             false,
             false,
             None,
@@ -74,7 +73,7 @@ pub fn build_solidity(
         sources,
         libraries,
         pipeline,
-        &mut solc_compiler,
+        solc_compiler,
         None,
     )?;
 
@@ -87,7 +86,7 @@ pub fn build_solidity(
     )?;
     build.write_to_standard_json(
         &mut solc_output,
-        Some(&solc_version),
+        Some(&solc_compiler.version),
         &semver::Version::from_str(env!("CARGO_PKG_VERSION"))?,
     )?;
 
@@ -108,8 +107,7 @@ pub fn build_solidity_and_detect_missing_libraries(
     era_compiler_llvm_context::initialize_target(era_compiler_llvm_context::Target::EraVM);
     let _ = crate::process::EXECUTABLE.set(PathBuf::from(crate::r#const::DEFAULT_EXECUTABLE_NAME));
 
-    let mut solc_compiler = SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME.to_owned())?;
-    let solc_version = solc_compiler.version()?;
+    let solc_compiler = SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME)?;
 
     let solc_input = SolcStandardJsonInput::try_from_solidity_sources(
         None,
@@ -120,7 +118,7 @@ pub fn build_solidity_and_detect_missing_libraries(
         SolcStandardJsonInputSettingsOptimizer::new(
             true,
             None,
-            &solc_version.default,
+            &solc_compiler.version.default,
             false,
             false,
             None,
@@ -138,14 +136,14 @@ pub fn build_solidity_and_detect_missing_libraries(
         sources,
         libraries,
         pipeline,
-        &mut solc_compiler,
+        solc_compiler,
         None,
     )?;
 
     let missing_libraries = project.get_missing_libraries();
     missing_libraries.write_to_standard_json(
         &mut solc_output,
-        Some(&solc_compiler.version()?),
+        Some(&solc_compiler.version),
         &semver::Version::from_str(env!("CARGO_PKG_VERSION"))?,
     )?;
 
@@ -187,7 +185,7 @@ pub fn build_yul(sources: BTreeMap<String, String>) -> anyhow::Result<SolcStanda
 ///
 pub fn build_yul_standard_json(
     solc_input: SolcStandardJsonInput,
-    mut solc_compiler: Option<SolcCompiler>,
+    solc_compiler: Option<&SolcCompiler>,
 ) -> anyhow::Result<SolcStandardJsonOutput> {
     check_dependencies();
 
@@ -201,17 +199,15 @@ pub fn build_yul_standard_json(
     )?;
 
     let sources = solc_input.sources()?;
-    let (solc_version, mut solc_output) = match solc_compiler.as_mut() {
+    let (solc_version, mut solc_output) = match solc_compiler {
         Some(solc_compiler) => {
-            let solc_version = solc_compiler.version()?;
             let solc_output = solc_compiler.validate_yul_standard_json(solc_input)?;
-            (Some(solc_version), solc_output)
+            (Some(&solc_compiler.version), solc_output)
         }
         None => (None, SolcStandardJsonOutput::new(&sources)),
     };
 
-    let project =
-        Project::try_from_yul_sources(sources, BTreeMap::new(), solc_version.clone(), None)?;
+    let project = Project::try_from_yul_sources(sources, BTreeMap::new(), solc_version, None)?;
     let build = project.compile_to_eravm(
         optimizer_settings,
         solc_compiler.is_none(),
@@ -219,7 +215,7 @@ pub fn build_yul_standard_json(
         zkevm_assembly::RunningVmEncodingMode::Production,
         None,
     )?;
-    build.write_to_standard_json(&mut solc_output, solc_version.as_ref(), &zksolc_version)?;
+    build.write_to_standard_json(&mut solc_output, solc_version, &zksolc_version)?;
 
     Ok(solc_output)
 }
@@ -303,8 +299,8 @@ pub fn check_solidity_warning(
 ) -> anyhow::Result<bool> {
     check_dependencies();
 
-    let mut solc = SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME.to_owned())?;
-    let solc_version = solc.version()?;
+    let solc = SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME)?;
+    let solc_version = solc.version.to_owned();
     if skip_for_zkvm_edition && solc_version.l2_revision.is_some() {
         return Ok(true);
     }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -73,7 +73,7 @@ pub fn build_solidity(
         sources,
         libraries,
         pipeline,
-        solc_compiler,
+        &solc_compiler,
         None,
     )?;
 
@@ -136,7 +136,7 @@ pub fn build_solidity_and_detect_missing_libraries(
         sources,
         libraries,
         pipeline,
-        solc_compiler,
+        &solc_compiler,
         None,
     )?;
 

--- a/src/tests/standard_json.rs
+++ b/src/tests/standard_json.rs
@@ -43,7 +43,7 @@ fn standard_json_yul_default_validated() {
     let solc_compiler = SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME)
         .expect("`solc` initialization error");
     let solc_output =
-        super::build_yul_standard_json(solc_input, Some(solc_compiler)).expect("Test failure");
+        super::build_yul_standard_json(solc_input, Some(&solc_compiler)).expect("Test failure");
 
     assert!(!solc_output
         .contracts
@@ -96,7 +96,7 @@ fn standard_json_yul_default_urls_validated() {
     let solc_compiler = SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME)
         .expect("`solc` initialization error");
     let solc_output =
-        super::build_yul_standard_json(solc_input, Some(solc_compiler)).expect("Test failure");
+        super::build_yul_standard_json(solc_input, Some(&solc_compiler)).expect("Test failure");
 
     assert!(!solc_output
         .contracts
@@ -149,7 +149,7 @@ fn standard_json_yul_eravm_validated() {
     let solc_compiler = SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME)
         .expect("`solc` initialization error");
     let solc_output =
-        super::build_yul_standard_json(solc_input, Some(solc_compiler)).expect("Test failure");
+        super::build_yul_standard_json(solc_input, Some(&solc_compiler)).expect("Test failure");
 
     assert!(!solc_output
         .contracts
@@ -202,7 +202,7 @@ fn standard_json_yul_eravm_urls_validated() {
     let solc_compiler = SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME)
         .expect("`solc` initialization error");
     let solc_output =
-        super::build_yul_standard_json(solc_input, Some(solc_compiler)).expect("Test failure");
+        super::build_yul_standard_json(solc_input, Some(&solc_compiler)).expect("Test failure");
 
     assert!(!solc_output
         .contracts

--- a/src/tests/standard_json.rs
+++ b/src/tests/standard_json.rs
@@ -40,7 +40,7 @@ fn standard_json_yul_default_validated() {
         PathBuf::from("src/tests/examples/standard_json_input/yul_default.json").as_path(),
     ))
     .expect("Standard JSON reading error");
-    let solc_compiler = SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME.to_owned())
+    let solc_compiler = SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME)
         .expect("`solc` initialization error");
     let solc_output =
         super::build_yul_standard_json(solc_input, Some(solc_compiler)).expect("Test failure");
@@ -93,7 +93,7 @@ fn standard_json_yul_default_urls_validated() {
         PathBuf::from("src/tests/examples/standard_json_input/yul_default_urls.json").as_path(),
     ))
     .expect("Standard JSON reading error");
-    let solc_compiler = SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME.to_owned())
+    let solc_compiler = SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME)
         .expect("`solc` initialization error");
     let solc_output =
         super::build_yul_standard_json(solc_input, Some(solc_compiler)).expect("Test failure");
@@ -146,7 +146,7 @@ fn standard_json_yul_eravm_validated() {
         PathBuf::from("src/tests/examples/standard_json_input/yul_eravm.json").as_path(),
     ))
     .expect("Standard JSON reading error");
-    let solc_compiler = SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME.to_owned())
+    let solc_compiler = SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME)
         .expect("`solc` initialization error");
     let solc_output =
         super::build_yul_standard_json(solc_input, Some(solc_compiler)).expect("Test failure");
@@ -199,7 +199,7 @@ fn standard_json_yul_eravm_urls_validated() {
         PathBuf::from("src/tests/examples/standard_json_input/yul_eravm_urls.json").as_path(),
     ))
     .expect("Standard JSON reading error");
-    let solc_compiler = SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME.to_owned())
+    let solc_compiler = SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME)
         .expect("`solc` initialization error");
     let solc_output =
         super::build_yul_standard_json(solc_input, Some(solc_compiler)).expect("Test failure");

--- a/src/zksolc/main.rs
+++ b/src/zksolc/main.rs
@@ -145,12 +145,12 @@ fn main_inner() -> anyhow::Result<()> {
                     debug_config,
                 )
             } else if let Some(standard_json) = arguments.standard_json {
-                let mut solc = match arguments.solc {
+                let solc = match arguments.solc.as_deref() {
                     Some(executable) => Some(era_compiler_solidity::SolcCompiler::new(executable)?),
                     None => None,
                 };
                 era_compiler_solidity::standard_json_eravm(
-                    solc.as_mut(),
+                    solc,
                     standard_json.map(PathBuf::from),
                     arguments.detect_missing_libraries,
                     arguments.force_evmla,
@@ -162,15 +162,17 @@ fn main_inner() -> anyhow::Result<()> {
                 )?;
                 return Ok(());
             } else if let Some(format) = arguments.combined_json {
-                let mut solc =
-                    era_compiler_solidity::SolcCompiler::new(arguments.solc.unwrap_or_else(
-                        || era_compiler_solidity::SolcCompiler::DEFAULT_EXECUTABLE_NAME.to_owned(),
-                    ))?;
+                let solc = era_compiler_solidity::SolcCompiler::new(
+                    arguments
+                        .solc
+                        .as_deref()
+                        .unwrap_or(era_compiler_solidity::SolcCompiler::DEFAULT_EXECUTABLE_NAME),
+                )?;
                 era_compiler_solidity::combined_json_eravm(
                     format,
                     input_files.as_slice(),
                     arguments.libraries,
-                    &mut solc,
+                    solc,
                     evm_version,
                     !arguments.disable_solc_optimizer,
                     optimizer_settings,
@@ -189,14 +191,16 @@ fn main_inner() -> anyhow::Result<()> {
                 )?;
                 return Ok(());
             } else {
-                let mut solc =
-                    era_compiler_solidity::SolcCompiler::new(arguments.solc.unwrap_or_else(
-                        || era_compiler_solidity::SolcCompiler::DEFAULT_EXECUTABLE_NAME.to_owned(),
-                    ))?;
+                let solc = era_compiler_solidity::SolcCompiler::new(
+                    arguments
+                        .solc
+                        .as_deref()
+                        .unwrap_or(era_compiler_solidity::SolcCompiler::DEFAULT_EXECUTABLE_NAME),
+                )?;
                 era_compiler_solidity::standard_output_eravm(
                     input_files.as_slice(),
                     arguments.libraries,
-                    &mut solc,
+                    solc,
                     evm_version,
                     !arguments.disable_solc_optimizer,
                     optimizer_settings,
@@ -271,12 +275,12 @@ fn main_inner() -> anyhow::Result<()> {
                     debug_config,
                 )
             } else if let Some(standard_json) = arguments.standard_json {
-                let mut solc = match arguments.solc {
+                let solc = match arguments.solc.as_deref() {
                     Some(executable) => Some(era_compiler_solidity::SolcCompiler::new(executable)?),
                     None => None,
                 };
                 era_compiler_solidity::standard_json_evm(
-                    solc.as_mut(),
+                    solc,
                     standard_json.map(PathBuf::from),
                     arguments.force_evmla,
                     arguments.base_path,
@@ -286,15 +290,17 @@ fn main_inner() -> anyhow::Result<()> {
                 )?;
                 return Ok(());
             } else if let Some(format) = arguments.combined_json {
-                let mut solc =
-                    era_compiler_solidity::SolcCompiler::new(arguments.solc.unwrap_or_else(
-                        || era_compiler_solidity::SolcCompiler::DEFAULT_EXECUTABLE_NAME.to_owned(),
-                    ))?;
+                let solc = era_compiler_solidity::SolcCompiler::new(
+                    arguments
+                        .solc
+                        .as_deref()
+                        .unwrap_or(era_compiler_solidity::SolcCompiler::DEFAULT_EXECUTABLE_NAME),
+                )?;
                 era_compiler_solidity::combined_json_evm(
                     format,
                     input_files.as_slice(),
                     arguments.libraries,
-                    &mut solc,
+                    solc,
                     evm_version,
                     !arguments.disable_solc_optimizer,
                     optimizer_settings,
@@ -311,14 +317,16 @@ fn main_inner() -> anyhow::Result<()> {
                 )?;
                 return Ok(());
             } else {
-                let mut solc =
-                    era_compiler_solidity::SolcCompiler::new(arguments.solc.unwrap_or_else(
-                        || era_compiler_solidity::SolcCompiler::DEFAULT_EXECUTABLE_NAME.to_owned(),
-                    ))?;
+                let solc = era_compiler_solidity::SolcCompiler::new(
+                    arguments
+                        .solc
+                        .as_deref()
+                        .unwrap_or(era_compiler_solidity::SolcCompiler::DEFAULT_EXECUTABLE_NAME),
+                )?;
                 era_compiler_solidity::standard_output_evm(
                     input_files.as_slice(),
                     arguments.libraries,
-                    &mut solc,
+                    solc,
                     evm_version,
                     !arguments.disable_solc_optimizer,
                     optimizer_settings,

--- a/src/zksolc/main.rs
+++ b/src/zksolc/main.rs
@@ -145,12 +145,12 @@ fn main_inner() -> anyhow::Result<()> {
                     debug_config,
                 )
             } else if let Some(standard_json) = arguments.standard_json {
-                let solc = match arguments.solc.as_deref() {
+                let solc_compiler = match arguments.solc.as_deref() {
                     Some(executable) => Some(era_compiler_solidity::SolcCompiler::new(executable)?),
                     None => None,
                 };
                 era_compiler_solidity::standard_json_eravm(
-                    solc,
+                    solc_compiler.as_ref(),
                     standard_json.map(PathBuf::from),
                     arguments.detect_missing_libraries,
                     arguments.force_evmla,
@@ -162,7 +162,7 @@ fn main_inner() -> anyhow::Result<()> {
                 )?;
                 return Ok(());
             } else if let Some(format) = arguments.combined_json {
-                let solc = era_compiler_solidity::SolcCompiler::new(
+                let solc_compiler = era_compiler_solidity::SolcCompiler::new(
                     arguments
                         .solc
                         .as_deref()
@@ -172,7 +172,7 @@ fn main_inner() -> anyhow::Result<()> {
                     format,
                     input_files.as_slice(),
                     arguments.libraries,
-                    solc,
+                    &solc_compiler,
                     evm_version,
                     !arguments.disable_solc_optimizer,
                     optimizer_settings,
@@ -191,7 +191,7 @@ fn main_inner() -> anyhow::Result<()> {
                 )?;
                 return Ok(());
             } else {
-                let solc = era_compiler_solidity::SolcCompiler::new(
+                let solc_compiler = era_compiler_solidity::SolcCompiler::new(
                     arguments
                         .solc
                         .as_deref()
@@ -200,7 +200,7 @@ fn main_inner() -> anyhow::Result<()> {
                 era_compiler_solidity::standard_output_eravm(
                     input_files.as_slice(),
                     arguments.libraries,
-                    solc,
+                    &solc_compiler,
                     evm_version,
                     !arguments.disable_solc_optimizer,
                     optimizer_settings,
@@ -275,12 +275,12 @@ fn main_inner() -> anyhow::Result<()> {
                     debug_config,
                 )
             } else if let Some(standard_json) = arguments.standard_json {
-                let solc = match arguments.solc.as_deref() {
+                let solc_compiler = match arguments.solc.as_deref() {
                     Some(executable) => Some(era_compiler_solidity::SolcCompiler::new(executable)?),
                     None => None,
                 };
                 era_compiler_solidity::standard_json_evm(
-                    solc,
+                    solc_compiler.as_ref(),
                     standard_json.map(PathBuf::from),
                     arguments.force_evmla,
                     arguments.base_path,
@@ -290,7 +290,7 @@ fn main_inner() -> anyhow::Result<()> {
                 )?;
                 return Ok(());
             } else if let Some(format) = arguments.combined_json {
-                let solc = era_compiler_solidity::SolcCompiler::new(
+                let solc_compiler = era_compiler_solidity::SolcCompiler::new(
                     arguments
                         .solc
                         .as_deref()
@@ -300,7 +300,7 @@ fn main_inner() -> anyhow::Result<()> {
                     format,
                     input_files.as_slice(),
                     arguments.libraries,
-                    solc,
+                    &solc_compiler,
                     evm_version,
                     !arguments.disable_solc_optimizer,
                     optimizer_settings,
@@ -326,7 +326,7 @@ fn main_inner() -> anyhow::Result<()> {
                 era_compiler_solidity::standard_output_evm(
                     input_files.as_slice(),
                     arguments.libraries,
-                    solc,
+                    &solc,
                     evm_version,
                     !arguments.disable_solc_optimizer,
                     optimizer_settings,


### PR DESCRIPTION
# What ❔

Makes `solc` a singleton, initializing it and requesting `version` only once.

## Why ❔

It must reduce the number of spawned child processes, improving the general performance.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
