### PR TITLE
feat: support solc v0.8.26

### DIFF
--- a/.github/actions/install-solc/action.yml
+++ b/.github/actions/install-solc/action.yml
@@ -4,7 +4,7 @@ inputs:
   solc-version:
     description: 'Version of solc compiler to download.'
     required: false
-    default: '0.8.25-1.0.0'
+    default: '0.8.26-1.0.0'
 runs:
   using: "composite"
   steps:
@@ -12,7 +12,7 @@ runs:
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       env:
         SOLC_URL: "https://github.com/matter-labs/era-solidity/releases/download"
-        SOLC_VERSION: ${{ inputs.solc-version || '0.8.25-1.0.0' }}
+        SOLC_VERSION: ${{ inputs.solc-version || '0.8.26-1.0.0' }}
       run: |
         OUTPUT=solc
         case "${RUNNER_OS}-${RUNNER_ARCH}" in

--- a/.github/actions/install-solc/action.yml
+++ b/.github/actions/install-solc/action.yml
@@ -4,7 +4,7 @@ inputs:
   solc-version:
     description: 'Version of solc compiler to download.'
     required: false
-    default: '0.8.26-1.0.0'
+    default: '0.8.26-1.0.1'
 runs:
   using: "composite"
   steps:
@@ -12,7 +12,7 @@ runs:
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       env:
         SOLC_URL: "https://github.com/matter-labs/era-solidity/releases/download"
-        SOLC_VERSION: ${{ inputs.solc-version || '0.8.26-1.0.0' }}
+        SOLC_VERSION: ${{ inputs.solc-version || '0.8.26-1.0.1' }}
       run: |
         OUTPUT=solc
         case "${RUNNER_OS}-${RUNNER_ARCH}" in

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ on:
         type: string
         description: "Prebuilt solc version, (repo: https://github.com/matter-labs/era-solidity/releases)"
         required: true
-        default: "0.8.26-1.0.0"
+        default: "0.8.26-1.0.1"
   pull_request:
     paths-ignore:
       - '.gitignore'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ on:
         type: string
         description: "Prebuilt solc version, (repo: https://github.com/matter-labs/era-solidity/releases)"
         required: true
-        default: "0.8.25-1.0.0"
+        default: "0.8.26-1.0.0"
   pull_request:
     paths-ignore:
       - '.gitignore'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - The support for compiling multiple files in Yul, LLVM IR, and EraVM assembly modes
 - The support for Yul, LLVM IR, and EraVM assembly languages in standard JSON mode
 - The support for `urls` to local files in standard JSON input
+- The solc v0.8.26 support
 - More LLVM optimizations
 - Caching of the underlying compiler's metadata, including `--version`
 

--- a/src/solc/mod.rs
+++ b/src/solc/mod.rs
@@ -48,7 +48,7 @@ impl Compiler {
     pub const FIRST_CANCUN_VERSION: semver::Version = semver::Version::new(0, 8, 24);
 
     /// The last supported version of `solc`.
-    pub const LAST_SUPPORTED_VERSION: semver::Version = semver::Version::new(0, 8, 25);
+    pub const LAST_SUPPORTED_VERSION: semver::Version = semver::Version::new(0, 8, 26);
 
     ///
     /// A shortcut constructor lazily using a thread-safe cell.


### PR DESCRIPTION
# What ❔

Adds support for solc v0.8.26.

## Why ❔

solc v0.8.26 has been released.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
