### PR TITLE
feat: pass arbitrary options to LLVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,18 @@
 - The support for `urls` to local files in standard JSON input
 - The solc v0.8.26 support
 - More LLVM optimizations
+- The `--llvm-options` parameter to pass arbitrary options to LLVM
+- The `--threads` parameter to control the number of threads
 - Caching of the underlying compiler's metadata, including `--version`
+
+### Changed
+
+- Updated to EraVM v1.5.0
 
 ### Fixed
 
-- Excessive RAM usage with some projects
+- Excessive RAM usage and compilation time with some projects
+- Redundancy in error printing
 
 ## [1.4.1] - 2024-04-24
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-cpr-1731-allow-passing-arbitrary-llvm-arguments-in-fe#b541b97c619c67bf321a5296b5b6e1e559acb220"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-cpr-1731-allow-passing-arbitrary-llvm-arguments-in-fe#edd404d95cd4e8507c02b2a1e1735bc83c21d653"
 dependencies = [
  "anyhow",
  "era-compiler-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#06ab4ba440469129da02cb578e3ebd06feb380d3"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-cpr-1731-allow-passing-arbitrary-llvm-arguments-in-fe#b541b97c619c67bf321a5296b5b6e1e559acb220"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -937,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b33eb56c327dec362a9e55b3ad14f9d2f0904fb5a5b03b513ab5465399e9f43"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -1138,18 +1138,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1397,9 +1397,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "version_check"
@@ -1621,9 +1621,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zkevm-assembly"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-cpr-1731-allow-passing-arbitrary-llvm-arguments-in-fe#dc5fcb596edadd9bd8fee26ffaa5d3bf0567f69c"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#029dfd1f144d62774950ad014fbad3cb84fb93b3"
 dependencies = [
  "anyhow",
  "era-compiler-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-cpr-1731-allow-passing-arbitrary-llvm-arguments-in-fe#edd404d95cd4e8507c02b2a1e1735bc83c21d653"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-cpr-1731-allow-passing-arbitrary-llvm-arguments-in-fe#dc5fcb596edadd9bd8fee26ffaa5d3bf0567f69c"
 dependencies = [
  "anyhow",
  "era-compiler-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ md5 = "0.7"
 zkevm-assembly = { git = "https://github.com/matter-labs/era-zkEVM-assembly", branch = "v1.5.0" }
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-cpr-1731-allow-passing-arbitrary-llvm-arguments-in-fe" }
+era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
 
 [dependencies.inkwell]
 git = "https://github.com/matter-labs-forks/inkwell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ md5 = "0.7"
 zkevm-assembly = { git = "https://github.com/matter-labs/era-zkEVM-assembly", branch = "v1.5.0" }
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
+era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-cpr-1731-allow-passing-arbitrary-llvm-arguments-in-fe" }
 
 [dependencies.inkwell]
 git = "https://github.com/matter-labs-forks/inkwell"

--- a/cli-tests/tests/eravm-assembly.test.ts
+++ b/cli-tests/tests/eravm-assembly.test.ts
@@ -58,7 +58,7 @@ describe("Set of --zkasm tests", () => {
     });
 
     it("--zkasm error is presented", () => {
-        expect(result.output).toMatch(/(Only one modes is allowed at the same time: Yul, LLVM IR, EraVM assembly, combined JSON, standard JSON.)/i);
+        expect(result.output).toMatch(/(Only one mode is allowed at the same time: Yul, LLVM IR, EraVM assembly, combined JSON, standard JSON.)/i);
     });
   });
 });

--- a/cli-tests/tests/llvm-ir.test.ts
+++ b/cli-tests/tests/llvm-ir.test.ts
@@ -73,7 +73,7 @@ describe("Set of --llvm-ir tests", () => {
     });
 
     it("--llvm-ir error is presented", () => {
-      expect(result.output).toMatch(/(Only one modes is allowed at the same time:)/i);
+      expect(result.output).toMatch(/(Only one mode is allowed at the same time:)/i);
     });
 
     it("solc exit code == zksolc exit code", () => {
@@ -92,7 +92,7 @@ describe("Set of --llvm-ir tests", () => {
     });
 
     it("--llvm-ir error is presented", () => {
-      expect(result.output).toMatch(/(Only one modes is allowed at the same time:)/i);
+      expect(result.output).toMatch(/(Only one mode is allowed at the same time:)/i);
     });
 
     it("solc exit code == zksolc exit code", () => {

--- a/cli-tests/tests/yul.test.ts
+++ b/cli-tests/tests/yul.test.ts
@@ -86,7 +86,7 @@ describe("Set of --yul tests", () => {
     });
 
     it("--yul error is presented", () => {
-      expect(result.output).toMatch(/(Only one modes is allowed at the same time:)/i);
+      expect(result.output).toMatch(/(Only one mode is allowed at the same time:)/i);
     });
 
     it("solc exit code == zksolc exit code", () => {
@@ -105,7 +105,7 @@ describe("Set of --yul tests", () => {
     });
 
     it("--yul error is presented", () => {
-      expect(result.output).toMatch(/(Only one modes is allowed at the same time:)/i);
+      expect(result.output).toMatch(/(Only one mode is allowed at the same time:)/i);
     });
 
     it("solc exit code == zksolc exit code", () => {

--- a/src/evmla/assembly/instruction/jump.rs
+++ b/src/evmla/assembly/instruction/jump.rs
@@ -18,7 +18,7 @@ where
 {
     let code_type = context
         .code_type()
-        .ok_or_else(|| anyhow::anyhow!("The contract code part type is undefined"))?;
+        .ok_or_else(|| anyhow::anyhow!("Contract code part type is undefined"))?;
     let block_key = match code_type {
         era_compiler_llvm_context::CodeType::Deploy
             if destination > num::BigUint::from(u32::MAX) =>
@@ -54,7 +54,7 @@ where
 {
     let code_type = context
         .code_type()
-        .ok_or_else(|| anyhow::anyhow!("The contract code part type is undefined"))?;
+        .ok_or_else(|| anyhow::anyhow!("Contract code part type is undefined"))?;
     let block_key = match code_type {
         era_compiler_llvm_context::CodeType::Deploy
             if destination > num::BigUint::from(u32::MAX) =>

--- a/src/evmla/assembly/mod.rs
+++ b/src/evmla/assembly/mod.rs
@@ -87,10 +87,10 @@ impl Assembly {
         {
             Data::Assembly(assembly) => Ok(assembly),
             Data::Hash(hash) => {
-                anyhow::bail!("Expected runtime code, found hash `{}`", hash);
+                anyhow::bail!("Expected runtime code, found hash `{hash}`");
             }
             Data::Path(path) => {
-                anyhow::bail!("Expected runtime code, found path `{}`", path);
+                anyhow::bail!("Expected runtime code, found path `{path}`");
             }
         }
     }
@@ -281,10 +281,10 @@ where
                 .code
                 .ok_or_else(|| anyhow::anyhow!("Runtime code instructions not found"))?,
             Data::Hash(hash) => {
-                anyhow::bail!("Expected runtime code instructions, found hash `{}`", hash)
+                anyhow::bail!("Expected runtime code instructions, found hash `{hash}`")
             }
             Data::Path(path) => {
-                anyhow::bail!("Expected runtime code instructions, found path `{}`", path)
+                anyhow::bail!("Expected runtime code instructions, found path `{path}`")
             }
         };
         let runtime_code_blocks = EtherealIR::get_blocks(

--- a/src/evmla/ethereal_ir/function/block/element/mod.rs
+++ b/src/evmla/ethereal_ir/function/block/element/mod.rs
@@ -831,7 +831,7 @@ where
             InstructionName::CALLDATALOAD => {
                 match context
                     .code_type()
-                    .ok_or_else(|| anyhow::anyhow!("The contract code part type is undefined"))?
+                    .ok_or_else(|| anyhow::anyhow!("Contract code part type is undefined"))?
                 {
                     era_compiler_llvm_context::CodeType::Deploy => {
                         Ok(Some(context.field_const(0).as_basic_value_enum()))
@@ -849,7 +849,7 @@ where
             InstructionName::CALLDATASIZE => {
                 match context
                     .code_type()
-                    .ok_or_else(|| anyhow::anyhow!("The contract code part type is undefined"))?
+                    .ok_or_else(|| anyhow::anyhow!("Contract code part type is undefined"))?
                 {
                     era_compiler_llvm_context::CodeType::Deploy => {
                         Ok(Some(context.field_const(0).as_basic_value_enum()))
@@ -864,7 +864,7 @@ where
 
                 match context
                     .code_type()
-                    .ok_or_else(|| anyhow::anyhow!("The contract code part type is undefined"))?
+                    .ok_or_else(|| anyhow::anyhow!("Contract code part type is undefined"))?
                 {
                     era_compiler_llvm_context::CodeType::Deploy => {
                         let calldata_size =
@@ -892,7 +892,7 @@ where
             InstructionName::CODESIZE => {
                 match context
                     .code_type()
-                    .ok_or_else(|| anyhow::anyhow!("The contract code part type is undefined"))?
+                    .ok_or_else(|| anyhow::anyhow!("Contract code part type is undefined"))?
                 {
                     era_compiler_llvm_context::CodeType::Deploy => {
                         era_compiler_llvm_context::eravm_evm_calldata::size(context).map(Some)
@@ -934,7 +934,7 @@ where
                     ),
                     _ => {
                         match context.code_type().ok_or_else(|| {
-                            anyhow::anyhow!("The contract code part type is undefined")
+                            anyhow::anyhow!("Contract code part type is undefined")
                         })? {
                             era_compiler_llvm_context::CodeType::Deploy => {
                                 era_compiler_llvm_context::eravm_evm_calldata::copy(

--- a/src/evmla/ethereal_ir/function/block/element/stack/mod.rs
+++ b/src/evmla/ethereal_ir/function/block/element/stack/mod.rs
@@ -89,7 +89,7 @@ impl Stack {
     pub fn pop_tag(&mut self) -> anyhow::Result<num::BigUint> {
         match self.elements.pop() {
             Some(Element::Tag(tag)) => Ok(tag),
-            Some(element) => anyhow::bail!("Expected tag, found {}", element),
+            Some(element) => anyhow::bail!("Expected tag, found {element}"),
             None => anyhow::bail!("Stack underflow"),
         }
     }

--- a/src/evmla/ethereal_ir/function/mod.rs
+++ b/src/evmla/ethereal_ir/function/mod.rs
@@ -1047,7 +1047,7 @@ impl Function {
                 block_key.code_type,
                 return_address.to_owned(),
             ),
-            ref element => anyhow::bail!("Expected the function return address, found {}", element),
+            ref element => anyhow::bail!("Expected the function return address, found {element}"),
         };
         let mut stack = Stack::with_capacity(1 + recursive_function.input_size);
         stack.push(StackElement::ReturnAddress(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ pub fn yul_to_eravm(
     libraries: Vec<String>,
     solc_path: Option<String>,
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+    llvm_options: &[String],
     is_system_mode: bool,
     include_metadata_hash: bool,
     debug_config: Option<era_compiler_llvm_context::DebugConfig>,
@@ -93,6 +94,7 @@ pub fn yul_to_eravm(
 
     let build = project.compile_to_eravm(
         optimizer_settings,
+        llvm_options,
         is_system_mode,
         include_metadata_hash,
         zkevm_assembly::RunningVmEncodingMode::Production,
@@ -110,6 +112,7 @@ pub fn yul_to_evm(
     libraries: Vec<String>,
     solc_path: Option<String>,
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+    llvm_options: &[String],
     include_metadata_hash: bool,
     debug_config: Option<era_compiler_llvm_context::DebugConfig>,
 ) -> anyhow::Result<EVMBuild> {
@@ -131,7 +134,12 @@ pub fn yul_to_evm(
         debug_config.as_ref(),
     )?;
 
-    let build = project.compile_to_evm(optimizer_settings, include_metadata_hash, debug_config)?;
+    let build = project.compile_to_evm(
+        optimizer_settings,
+        llvm_options,
+        include_metadata_hash,
+        debug_config,
+    )?;
 
     Ok(build)
 }
@@ -142,6 +150,7 @@ pub fn yul_to_evm(
 pub fn llvm_ir_to_eravm(
     paths: &[PathBuf],
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+    llvm_options: &[String],
     is_system_mode: bool,
     include_metadata_hash: bool,
     debug_config: Option<era_compiler_llvm_context::DebugConfig>,
@@ -150,6 +159,7 @@ pub fn llvm_ir_to_eravm(
 
     let build = project.compile_to_eravm(
         optimizer_settings,
+        llvm_options,
         is_system_mode,
         include_metadata_hash,
         zkevm_assembly::RunningVmEncodingMode::Production,
@@ -165,12 +175,18 @@ pub fn llvm_ir_to_eravm(
 pub fn llvm_ir_to_evm(
     paths: &[PathBuf],
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+    llvm_options: &[String],
     include_metadata_hash: bool,
     debug_config: Option<era_compiler_llvm_context::DebugConfig>,
 ) -> anyhow::Result<EVMBuild> {
     let project = Project::try_from_llvm_ir_paths(paths)?;
 
-    let build = project.compile_to_evm(optimizer_settings, include_metadata_hash, debug_config)?;
+    let build = project.compile_to_evm(
+        optimizer_settings,
+        llvm_options,
+        include_metadata_hash,
+        debug_config,
+    )?;
 
     Ok(build)
 }
@@ -180,6 +196,7 @@ pub fn llvm_ir_to_evm(
 ///
 pub fn eravm_assembly(
     paths: &[PathBuf],
+    llvm_options: &[String],
     include_metadata_hash: bool,
     debug_config: Option<era_compiler_llvm_context::DebugConfig>,
 ) -> anyhow::Result<EraVMBuild> {
@@ -188,6 +205,7 @@ pub fn eravm_assembly(
     let optimizer_settings = era_compiler_llvm_context::OptimizerSettings::none();
     let build = project.compile_to_eravm(
         optimizer_settings,
+        llvm_options,
         false,
         include_metadata_hash,
         zkevm_assembly::RunningVmEncodingMode::Production,
@@ -207,6 +225,7 @@ pub fn standard_output_eravm(
     evm_version: Option<era_compiler_common::EVMVersion>,
     solc_optimizer_enabled: bool,
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+    llvm_options: &[String],
     force_evmla: bool,
     is_system_mode: bool,
     include_metadata_hash: bool,
@@ -280,6 +299,7 @@ pub fn standard_output_eravm(
 
     let build = project.compile_to_eravm(
         optimizer_settings,
+        llvm_options,
         is_system_mode,
         include_metadata_hash,
         zkevm_assembly::RunningVmEncodingMode::Production,
@@ -299,6 +319,7 @@ pub fn standard_output_evm(
     evm_version: Option<era_compiler_common::EVMVersion>,
     solc_optimizer_enabled: bool,
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+    llvm_options: &[String],
     force_evmla: bool,
     include_metadata_hash: bool,
     use_literal_content: bool,
@@ -368,7 +389,12 @@ pub fn standard_output_evm(
         debug_config.as_ref(),
     )?;
 
-    let build = project.compile_to_evm(optimizer_settings, include_metadata_hash, debug_config)?;
+    let build = project.compile_to_evm(
+        optimizer_settings,
+        llvm_options,
+        include_metadata_hash,
+        debug_config,
+    )?;
 
     Ok(build)
 }
@@ -378,6 +404,7 @@ pub fn standard_output_evm(
 ///
 pub fn standard_json_eravm(
     solc_compiler: Option<&SolcCompiler>,
+    llvm_options: &[String],
     json_path: Option<PathBuf>,
     detect_missing_libraries: bool,
     force_evmla: bool,
@@ -488,6 +515,7 @@ pub fn standard_json_eravm(
     } else {
         let build = project.compile_to_eravm(
             optimizer_settings,
+            llvm_options,
             is_system_mode,
             include_metadata_hash,
             zkevm_assembly::RunningVmEncodingMode::Production,
@@ -504,6 +532,7 @@ pub fn standard_json_eravm(
 ///
 pub fn standard_json_evm(
     solc_compiler: Option<&SolcCompiler>,
+    llvm_options: &[String],
     json_path: Option<PathBuf>,
     force_evmla: bool,
     base_path: Option<String>,
@@ -597,7 +626,12 @@ pub fn standard_json_evm(
         }
     };
 
-    let build = project.compile_to_evm(optimizer_settings, include_metadata_hash, debug_config)?;
+    let build = project.compile_to_evm(
+        optimizer_settings,
+        llvm_options,
+        include_metadata_hash,
+        debug_config,
+    )?;
     build.write_to_standard_json(&mut solc_output, solc_version, &zksolc_version)?;
     serde_json::to_writer(std::io::stdout(), &solc_output)?;
     std::process::exit(era_compiler_common::EXIT_CODE_SUCCESS);
@@ -614,6 +648,7 @@ pub fn combined_json_eravm(
     evm_version: Option<era_compiler_common::EVMVersion>,
     solc_optimizer_enabled: bool,
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+    llvm_options: &[String],
     force_evmla: bool,
     is_system_mode: bool,
     include_metadata_hash: bool,
@@ -636,6 +671,7 @@ pub fn combined_json_eravm(
         evm_version,
         solc_optimizer_enabled,
         optimizer_settings,
+        llvm_options,
         force_evmla,
         is_system_mode,
         include_metadata_hash,
@@ -679,6 +715,7 @@ pub fn combined_json_evm(
     evm_version: Option<era_compiler_common::EVMVersion>,
     solc_optimizer_enabled: bool,
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+    llvm_options: &[String],
     force_evmla: bool,
     include_metadata_hash: bool,
     use_literal_content: bool,
@@ -699,6 +736,7 @@ pub fn combined_json_evm(
         evm_version,
         solc_optimizer_enabled,
         optimizer_settings,
+        llvm_options,
         force_evmla,
         include_metadata_hash,
         use_literal_content,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub fn yul_to_eravm(
     libraries: Vec<String>,
     solc_path: Option<String>,
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
-    llvm_options: &[String],
+    llvm_options: &[&str],
     is_system_mode: bool,
     include_metadata_hash: bool,
     debug_config: Option<era_compiler_llvm_context::DebugConfig>,
@@ -112,7 +112,7 @@ pub fn yul_to_evm(
     libraries: Vec<String>,
     solc_path: Option<String>,
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
-    llvm_options: &[String],
+    llvm_options: &[&str],
     include_metadata_hash: bool,
     debug_config: Option<era_compiler_llvm_context::DebugConfig>,
 ) -> anyhow::Result<EVMBuild> {
@@ -150,7 +150,7 @@ pub fn yul_to_evm(
 pub fn llvm_ir_to_eravm(
     paths: &[PathBuf],
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
-    llvm_options: &[String],
+    llvm_options: &[&str],
     is_system_mode: bool,
     include_metadata_hash: bool,
     debug_config: Option<era_compiler_llvm_context::DebugConfig>,
@@ -175,7 +175,7 @@ pub fn llvm_ir_to_eravm(
 pub fn llvm_ir_to_evm(
     paths: &[PathBuf],
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
-    llvm_options: &[String],
+    llvm_options: &[&str],
     include_metadata_hash: bool,
     debug_config: Option<era_compiler_llvm_context::DebugConfig>,
 ) -> anyhow::Result<EVMBuild> {
@@ -196,7 +196,7 @@ pub fn llvm_ir_to_evm(
 ///
 pub fn eravm_assembly(
     paths: &[PathBuf],
-    llvm_options: &[String],
+    llvm_options: &[&str],
     include_metadata_hash: bool,
     debug_config: Option<era_compiler_llvm_context::DebugConfig>,
 ) -> anyhow::Result<EraVMBuild> {
@@ -225,7 +225,7 @@ pub fn standard_output_eravm(
     evm_version: Option<era_compiler_common::EVMVersion>,
     solc_optimizer_enabled: bool,
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
-    llvm_options: &[String],
+    llvm_options: &[&str],
     force_evmla: bool,
     is_system_mode: bool,
     include_metadata_hash: bool,
@@ -319,7 +319,7 @@ pub fn standard_output_evm(
     evm_version: Option<era_compiler_common::EVMVersion>,
     solc_optimizer_enabled: bool,
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
-    llvm_options: &[String],
+    llvm_options: &[&str],
     force_evmla: bool,
     include_metadata_hash: bool,
     use_literal_content: bool,
@@ -404,7 +404,7 @@ pub fn standard_output_evm(
 ///
 pub fn standard_json_eravm(
     solc_compiler: Option<&SolcCompiler>,
-    llvm_options: &[String],
+    llvm_options: &[&str],
     json_path: Option<PathBuf>,
     detect_missing_libraries: bool,
     force_evmla: bool,
@@ -532,7 +532,7 @@ pub fn standard_json_eravm(
 ///
 pub fn standard_json_evm(
     solc_compiler: Option<&SolcCompiler>,
-    llvm_options: &[String],
+    llvm_options: &[&str],
     json_path: Option<PathBuf>,
     force_evmla: bool,
     base_path: Option<String>,
@@ -648,7 +648,7 @@ pub fn combined_json_eravm(
     evm_version: Option<era_compiler_common::EVMVersion>,
     solc_optimizer_enabled: bool,
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
-    llvm_options: &[String],
+    llvm_options: &[&str],
     force_evmla: bool,
     is_system_mode: bool,
     include_metadata_hash: bool,
@@ -715,7 +715,7 @@ pub fn combined_json_evm(
     evm_version: Option<era_compiler_common::EVMVersion>,
     solc_optimizer_enabled: bool,
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
-    llvm_options: &[String],
+    llvm_options: &[&str],
     force_evmla: bool,
     include_metadata_hash: bool,
     use_literal_content: bool,

--- a/src/process/input_eravm.rs
+++ b/src/process/input_eravm.rs
@@ -29,6 +29,8 @@ pub struct Input<'a> {
     pub enable_test_encoding: bool,
     /// The optimizer settings.
     pub optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+    /// The extra LLVM arguments.
+    pub llvm_options: Vec<String>,
     /// The debug output config.
     pub debug_config: Option<era_compiler_llvm_context::DebugConfig>,
 }
@@ -44,6 +46,7 @@ impl<'a> Input<'a> {
         include_metadata_hash: bool,
         enable_test_encoding: bool,
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+        llvm_options: Vec<String>,
         debug_config: Option<era_compiler_llvm_context::DebugConfig>,
     ) -> Self {
         Self {
@@ -53,6 +56,7 @@ impl<'a> Input<'a> {
             include_metadata_hash,
             enable_test_encoding,
             optimizer_settings,
+            llvm_options,
             debug_config,
         }
     }

--- a/src/process/input_evm.rs
+++ b/src/process/input_evm.rs
@@ -25,6 +25,8 @@ pub struct Input<'a> {
     pub include_metadata_hash: bool,
     /// The optimizer settings.
     pub optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+    /// The extra LLVM arguments.
+    pub llvm_options: Vec<String>,
     /// The debug output config.
     pub debug_config: Option<era_compiler_llvm_context::DebugConfig>,
 }
@@ -38,6 +40,7 @@ impl<'a> Input<'a> {
         project: Cow<'a, Project>,
         include_metadata_hash: bool,
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+        llvm_options: Vec<String>,
         debug_config: Option<era_compiler_llvm_context::DebugConfig>,
     ) -> Self {
         Self {
@@ -45,6 +48,7 @@ impl<'a> Input<'a> {
             project,
             include_metadata_hash,
             optimizer_settings,
+            llvm_options,
             debug_config,
         }
     }

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -136,7 +136,7 @@ where
         anyhow::bail!("{stderr_message}");
     }
     let output = match era_compiler_common::deserialize_from_slice::<O>(result.stdout.as_slice()) {
-        Ok(combined_json) => combined_json,
+        Ok(output) => output,
         Err(error) => {
             anyhow::bail!("{executable:?} subprocess stdout parsing error: {error:?} (stderr: {stderr_message})");
         }

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -37,6 +37,7 @@ pub fn run(target: era_compiler_llvm_context::Target) -> anyhow::Result<()> {
             let result = input.contract.into_owned().compile_to_eravm(
                 input.project.into_owned(),
                 input.optimizer_settings,
+                input.llvm_options.as_slice(),
                 input.is_system_mode,
                 input.include_metadata_hash,
                 input.debug_config,
@@ -66,6 +67,7 @@ pub fn run(target: era_compiler_llvm_context::Target) -> anyhow::Result<()> {
             let result = input.contract.into_owned().compile_to_evm(
                 input.project.into_owned(),
                 input.optimizer_settings,
+                input.llvm_options.as_slice(),
                 input.include_metadata_hash,
                 input.debug_config,
             );

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -133,7 +133,7 @@ where
     })?;
     let stderr_message = String::from_utf8_lossy(result.stderr.as_slice());
     if !result.status.success() {
-        anyhow::bail!("{executable:?} error: {stderr_message}");
+        anyhow::bail!("{stderr_message}");
     }
     let output = match era_compiler_common::deserialize_from_slice::<O>(result.stdout.as_slice()) {
         Ok(combined_json) => combined_json,

--- a/src/project/contract/metadata.rs
+++ b/src/project/contract/metadata.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 /// Is used to append the metadata hash to the contract bytecode.
 ///
 #[derive(Debug, Serialize)]
-pub struct Metadata {
+pub struct Metadata<'a> {
     /// The `solc` metadata.
     pub solc_metadata: serde_json::Value,
     /// The `solc` version if used.
@@ -21,9 +21,11 @@ pub struct Metadata {
     pub zk_version: semver::Version,
     /// The EraVM compiler optimizer settings.
     pub optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+    /// The LLVM extra arguments.
+    pub llvm_options: &'a [String],
 }
 
-impl Metadata {
+impl<'a> Metadata<'a> {
     ///
     /// A shortcut constructor.
     ///
@@ -33,6 +35,7 @@ impl Metadata {
         solc_zkvm_edition: Option<semver::Version>,
         zk_version: semver::Version,
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+        llvm_options: &'a [String],
     ) -> Self {
         Self {
             solc_metadata,
@@ -40,6 +43,7 @@ impl Metadata {
             solc_zkvm_edition,
             zk_version,
             optimizer_settings,
+            llvm_options,
         }
     }
 }

--- a/src/project/contract/mod.rs
+++ b/src/project/contract/mod.rs
@@ -98,6 +98,7 @@ impl Contract {
         mut self,
         project: Project,
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+        llvm_options: &[String],
         is_system_mode: bool,
         include_metadata_hash: bool,
         debug_config: Option<era_compiler_llvm_context::DebugConfig>,
@@ -160,6 +161,7 @@ impl Contract {
         let mut context = era_compiler_llvm_context::EraVMContext::new(
             &llvm,
             module,
+            llvm_options.to_owned(),
             optimizer,
             Some(project),
             include_metadata_hash,
@@ -223,6 +225,7 @@ impl Contract {
         mut self,
         project: Project,
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+        llvm_options: &[String],
         include_metadata_hash: bool,
         debug_config: Option<era_compiler_llvm_context::DebugConfig>,
     ) -> anyhow::Result<EVMContractBuild> {
@@ -271,6 +274,7 @@ impl Contract {
                     let mut context = era_compiler_llvm_context::EVMContext::new(
                         &llvm,
                         module,
+                        llvm_options.to_owned(),
                         code_type,
                         optimizer.clone(),
                         Some(project.clone()),
@@ -329,6 +333,7 @@ impl Contract {
                     let mut context = era_compiler_llvm_context::EVMContext::new(
                         &llvm,
                         module,
+                        llvm_options.to_owned(),
                         code_type,
                         optimizer.clone(),
                         Some(project.clone()),
@@ -380,6 +385,7 @@ impl Contract {
                 let context = era_compiler_llvm_context::EVMContext::new(
                     &llvm,
                     module,
+                    llvm_options.to_owned(),
                     era_compiler_llvm_context::CodeType::Runtime,
                     optimizer,
                     Some(project),

--- a/src/project/contract/mod.rs
+++ b/src/project/contract/mod.rs
@@ -121,6 +121,7 @@ impl Contract {
                 .and_then(|version| version.l2_revision.to_owned()),
             semver::Version::parse(env!("CARGO_PKG_VERSION")).expect("Always valid"),
             optimizer.settings().to_owned(),
+            llvm_options,
         );
         let metadata_json = serde_json::to_value(&metadata).expect("Always valid");
         let metadata_hash: Option<[u8; era_compiler_common::BYTE_LENGTH_FIELD]> =
@@ -237,6 +238,7 @@ impl Contract {
                 .and_then(|version| version.l2_revision.to_owned()),
             semver::Version::parse(env!("CARGO_PKG_VERSION")).expect("Always valid"),
             optimizer.settings().to_owned(),
+            llvm_options,
         );
         let metadata_json = serde_json::to_value(&metadata).expect("Always valid");
         let metadata_hash: Option<[u8; era_compiler_common::BYTE_LENGTH_FIELD]> =

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -340,6 +340,7 @@ impl Project {
     pub fn compile_to_eravm(
         self,
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+        llvm_options: &[String],
         is_system_mode: bool,
         include_metadata_hash: bool,
         bytecode_encoding: zkevm_assembly::RunningVmEncodingMode,
@@ -357,6 +358,7 @@ impl Project {
                         include_metadata_hash,
                         bytecode_encoding == zkevm_assembly::RunningVmEncodingMode::Testing,
                         optimizer_settings.clone(),
+                        llvm_options.to_owned(),
                         debug_config.clone(),
                     ),
                     era_compiler_llvm_context::Target::EraVM,
@@ -422,6 +424,7 @@ impl Project {
     pub fn compile_to_evm(
         self,
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+        llvm_options: &[String],
         include_metadata_hash: bool,
         debug_config: Option<era_compiler_llvm_context::DebugConfig>,
     ) -> anyhow::Result<EVMBuild> {
@@ -435,6 +438,7 @@ impl Project {
                         Cow::Borrowed(&self),
                         include_metadata_hash,
                         optimizer_settings.clone(),
+                        llvm_options.to_owned(),
                         debug_config.clone(),
                     ),
                     era_compiler_llvm_context::Target::EVM,
@@ -495,6 +499,7 @@ impl era_compiler_llvm_context::EraVMDependency for Project {
         project: Self,
         identifier: &str,
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+        llvm_options: &[String],
         is_system_mode: bool,
         include_metadata_hash: bool,
         debug_config: Option<era_compiler_llvm_context::DebugConfig>,
@@ -515,6 +520,7 @@ impl era_compiler_llvm_context::EraVMDependency for Project {
             .compile_to_eravm(
                 project,
                 optimizer_settings,
+                llvm_options,
                 is_system_mode,
                 include_metadata_hash,
                 debug_config,
@@ -560,6 +566,7 @@ impl era_compiler_llvm_context::EVMDependency for Project {
         _project: Self,
         _identifier: &str,
         _optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+        _llvm_options: &[String],
         _include_metadata_hash: bool,
         _debug_config: Option<era_compiler_llvm_context::DebugConfig>,
     ) -> anyhow::Result<String> {

--- a/src/solc/combined_json/mod.rs
+++ b/src/solc/combined_json/mod.rs
@@ -98,9 +98,9 @@ impl CombinedJson {
         }
 
         File::create(&file_path)
-            .map_err(|error| anyhow::anyhow!("File {:?} creating error: {}", file_path, error))?
+            .map_err(|error| anyhow::anyhow!("File {:?} creating: {}", file_path, error))?
             .write_all(serde_json::to_vec(&self).expect("Always valid").as_slice())
-            .map_err(|error| anyhow::anyhow!("File {:?} writing error: {}", file_path, error))?;
+            .map_err(|error| anyhow::anyhow!("File {:?} writing: {}", file_path, error))?;
 
         Ok(())
     }

--- a/src/solc/mod.rs
+++ b/src/solc/mod.rs
@@ -69,10 +69,7 @@ impl Compiler {
         let mut executables = Self::executables().write().expect("Sync");
 
         if let Err(error) = which::which(executable) {
-            anyhow::bail!(
-                "The `{executable}` executable not found in ${{PATH}}: {}",
-                error,
-            );
+            anyhow::bail!("The `{executable}` executable not found in ${{PATH}}: {error}");
         }
         let version = Self::parse_version(executable)?;
         let compiler = Self {
@@ -316,7 +313,7 @@ impl Compiler {
             .map_err(|error| anyhow::anyhow!("{} subprocess error: {:?}", executable, error))?;
         if !output.status.success() {
             anyhow::bail!(
-                "{} error: {}",
+                "{} version getting error: {}",
                 executable,
                 String::from_utf8_lossy(output.stderr.as_slice()).to_string()
             );

--- a/src/solc/standard_json/input/mod.rs
+++ b/src/solc/standard_json/input/mod.rs
@@ -56,12 +56,12 @@ impl Input {
                 std::fs::File::open(path)
                     .map(std::io::BufReader::new)
                     .map_err(|error| {
-                        anyhow::anyhow!("Standard JSON file {path:?} opening error: {error}")
+                        anyhow::anyhow!("Standard JSON file {path:?} opening: {error}")
                     })?,
             ),
             None => serde_json::from_reader(std::io::BufReader::new(std::io::stdin())),
         }
-        .map_err(|error| anyhow::anyhow!("Standard JSON reading error: {error}"))
+        .map_err(|error| anyhow::anyhow!("Standard JSON reading: {error}"))
     }
 
     ///
@@ -88,9 +88,8 @@ impl Input {
         let sources = paths
             .into_par_iter()
             .map(|path| {
-                let source = Source::try_read(path.as_path()).unwrap_or_else(|error| {
-                    panic!("Source code file {path:?} reading error: {error}")
-                });
+                let source = Source::try_read(path.as_path())
+                    .unwrap_or_else(|error| panic!("Source code file {path:?} reading: {error}"));
                 (path.to_string_lossy().to_string(), source)
             })
             .collect();
@@ -235,7 +234,7 @@ impl Input {
                 let source: String = source
                     .to_owned()
                     .try_into()
-                    .map_err(|error| anyhow::anyhow!("Source `{path}` error: {error}"))?;
+                    .map_err(|error| anyhow::anyhow!("Source `{path}`: {error}"))?;
                 Ok((path.to_owned(), source))
             })
             .collect()

--- a/src/solc/standard_json/input/source.rs
+++ b/src/solc/standard_json/input/source.rs
@@ -32,11 +32,11 @@ impl Source {
             let mut solidity_code = String::with_capacity(16384);
             std::io::stdin()
                 .read_to_string(&mut solidity_code)
-                .map_err(|error| anyhow::anyhow!("<stdin> reading error: {}", error))?;
+                .map_err(|error| anyhow::anyhow!("<stdin> reading error: {error}"))?;
             solidity_code
         } else {
             std::fs::read_to_string(path)
-                .map_err(|error| anyhow::anyhow!("File {:?} reading error: {}", path, error))?
+                .map_err(|error| anyhow::anyhow!("File {path:?} reading error: {error}"))?
         };
 
         Ok(Self {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -79,6 +79,7 @@ pub fn build_solidity(
 
     let build = project.compile_to_eravm(
         optimizer_settings,
+        &[],
         false,
         false,
         zkevm_assembly::RunningVmEncodingMode::Production,
@@ -168,6 +169,7 @@ pub fn build_yul(sources: BTreeMap<String, String>) -> anyhow::Result<SolcStanda
     let project = Project::try_from_yul_sources(sources, BTreeMap::new(), None, None)?;
     let build = project.compile_to_eravm(
         optimizer_settings,
+        &[],
         false,
         false,
         zkevm_assembly::RunningVmEncodingMode::Production,
@@ -210,6 +212,7 @@ pub fn build_yul_standard_json(
     let project = Project::try_from_yul_sources(sources, BTreeMap::new(), solc_version, None)?;
     let build = project.compile_to_eravm(
         optimizer_settings,
+        &[],
         solc_compiler.is_none(),
         false,
         zkevm_assembly::RunningVmEncodingMode::Production,
@@ -243,6 +246,7 @@ pub fn build_llvm_ir_standard_json(
     let project = Project::try_from_llvm_ir_sources(sources)?;
     let build = project.compile_to_eravm(
         optimizer_settings,
+        &[],
         true,
         false,
         zkevm_assembly::RunningVmEncodingMode::Production,
@@ -276,6 +280,7 @@ pub fn build_eravm_assembly_standard_json(
     let project = Project::try_from_eravm_assembly_sources(sources)?;
     let build = project.compile_to_eravm(
         optimizer_settings,
+        &[],
         true,
         false,
         zkevm_assembly::RunningVmEncodingMode::Production,

--- a/src/yul/parser/statement/block.rs
+++ b/src/yul/parser/statement/block.rs
@@ -200,9 +200,8 @@ where
                     break;
                 }
                 statement => anyhow::bail!(
-                    "{} Unexpected local statement: {:?}",
+                    "{} Unexpected local statement: {statement:?}",
                     statement.location(),
-                    statement
                 ),
             }
         }
@@ -273,9 +272,8 @@ where
                     break;
                 }
                 statement => anyhow::bail!(
-                    "{} Unexpected local statement: {:?}",
+                    "{} Unexpected local statement: {statement:?}",
                     statement.location(),
-                    statement
                 ),
             }
         }

--- a/src/yul/parser/statement/expression/function_call/mod.rs
+++ b/src/yul/parser/statement/expression/function_call/mod.rs
@@ -176,10 +176,7 @@ impl FunctionCall {
                     function.borrow().declaration().value.count_params() as usize;
                 if expected_arguments_count != (values.len() - 2) {
                     anyhow::bail!(
-                        "{} Function `{}` expected {} arguments, found {}",
-                        location,
-                        name,
-                        expected_arguments_count,
+                        "{location} Function `{name}` expected {expected_arguments_count} arguments, found {}",
                         values.len()
                     );
                 }
@@ -220,10 +217,7 @@ impl FunctionCall {
                     function.borrow().declaration().value.count_params() as usize;
                 if expected_arguments_count != values.len() {
                     anyhow::bail!(
-                        "{} Function `{}` expected {} arguments, found {}",
-                        location,
-                        name,
-                        expected_arguments_count,
+                        "{location} Function `{name}` expected {expected_arguments_count} arguments, found {}",
                         values.len()
                     );
                 }
@@ -702,8 +696,7 @@ impl FunctionCall {
                     .ok_or_else(|| anyhow::anyhow!("Contract code part type is undefined"))?
                 {
                     anyhow::bail!(
-                        "{} The `CODECOPY` instruction is not supported in the runtime code",
-                        location,
+                        "{location} The `CODECOPY` instruction is not supported in the runtime code"
                     );
                 }
 
@@ -1062,7 +1055,7 @@ impl FunctionCall {
             }
             Name::BlobHash => {
                 let _arguments = self.pop_arguments_llvm::<D, 1>(context)?;
-                anyhow::bail!("{} The `BLOBHASH` instruction is not supported", location);
+                anyhow::bail!("{location} The `BLOBHASH` instruction is not supported");
             }
             Name::Difficulty | Name::Prevrandao => {
                 era_compiler_llvm_context::eravm_evm_contract_context::difficulty(context).map(Some)
@@ -1074,10 +1067,7 @@ impl FunctionCall {
                 era_compiler_llvm_context::eravm_evm_contract_context::basefee(context).map(Some)
             }
             Name::BlobBaseFee => {
-                anyhow::bail!(
-                    "{} The `BLOBBASEFEE` instruction is not supported",
-                    location
-                );
+                anyhow::bail!("{location} The `BLOBBASEFEE` instruction is not supported");
             }
             Name::MSize => {
                 era_compiler_llvm_context::eravm_evm_contract_context::msize(context).map(Some)
@@ -1090,22 +1080,16 @@ impl FunctionCall {
 
             Name::CallCode => {
                 let _arguments = self.pop_arguments_llvm::<D, 7>(context)?;
-                anyhow::bail!("{} The `CALLCODE` instruction is not supported", location)
+                anyhow::bail!("{location} The `CALLCODE` instruction is not supported")
             }
-            Name::Pc => anyhow::bail!("{} The `PC` instruction is not supported", location),
+            Name::Pc => anyhow::bail!("{location} The `PC` instruction is not supported"),
             Name::ExtCodeCopy => {
                 let _arguments = self.pop_arguments_llvm::<D, 4>(context)?;
-                anyhow::bail!(
-                    "{} The `EXTCODECOPY` instruction is not supported",
-                    location
-                )
+                anyhow::bail!("{location} The `EXTCODECOPY` instruction is not supported")
             }
             Name::SelfDestruct => {
                 let _arguments = self.pop_arguments_llvm::<D, 1>(context)?;
-                anyhow::bail!(
-                    "{} The `SELFDESTRUCT` instruction is not supported",
-                    location
-                )
+                anyhow::bail!("{location} The `SELFDESTRUCT` instruction is not supported")
             }
 
             Name::ZkToL1 => {
@@ -1603,10 +1587,7 @@ impl FunctionCall {
                     function.borrow().declaration().value.count_params() as usize;
                 if expected_arguments_count != values.len() {
                     anyhow::bail!(
-                        "{} Function `{}` expected {} arguments, found {}",
-                        location,
-                        name,
-                        expected_arguments_count,
+                        "{location} Function `{name}` expected {expected_arguments_count} arguments, found {}",
                         values.len()
                     );
                 }
@@ -2237,15 +2218,12 @@ impl FunctionCall {
 
             Name::CallCode => {
                 let _arguments = self.pop_arguments_llvm_evm::<D, 7>(context)?;
-                anyhow::bail!("{} The `CALLCODE` instruction is not supported", location)
+                anyhow::bail!("{location} The `CALLCODE` instruction is not supported")
             }
-            Name::Pc => anyhow::bail!("{} The `PC` instruction is not supported", location),
+            Name::Pc => anyhow::bail!("{location} The `PC` instruction is not supported"),
             Name::SelfDestruct => {
                 let _arguments = self.pop_arguments_llvm_evm::<D, 1>(context)?;
-                anyhow::bail!(
-                    "{} The `SELFDESTRUCT` instruction is not supported",
-                    location
-                )
+                anyhow::bail!("{location} The `SELFDESTRUCT` instruction is not supported")
             }
 
             _ => Ok(None),

--- a/src/yul/parser/statement/expression/function_call/mod.rs
+++ b/src/yul/parser/statement/expression/function_call/mod.rs
@@ -620,7 +620,7 @@ impl FunctionCall {
 
                 match context
                     .code_type()
-                    .ok_or_else(|| anyhow::anyhow!("The contract code part type is undefined"))?
+                    .ok_or_else(|| anyhow::anyhow!("Contract code part type is undefined"))?
                 {
                     era_compiler_llvm_context::CodeType::Deploy => {
                         Ok(Some(context.field_const(0).as_basic_value_enum()))
@@ -637,7 +637,7 @@ impl FunctionCall {
             Name::CallDataSize => {
                 match context
                     .code_type()
-                    .ok_or_else(|| anyhow::anyhow!("The contract code part type is undefined"))?
+                    .ok_or_else(|| anyhow::anyhow!("Contract code part type is undefined"))?
                 {
                     era_compiler_llvm_context::CodeType::Deploy => {
                         Ok(Some(context.field_const(0).as_basic_value_enum()))
@@ -652,7 +652,7 @@ impl FunctionCall {
 
                 match context
                     .code_type()
-                    .ok_or_else(|| anyhow::anyhow!("The contract code part type is undefined"))?
+                    .ok_or_else(|| anyhow::anyhow!("Contract code part type is undefined"))?
                 {
                     era_compiler_llvm_context::CodeType::Deploy => {
                         let calldata_size =
@@ -680,7 +680,7 @@ impl FunctionCall {
             Name::CodeSize => {
                 match context
                     .code_type()
-                    .ok_or_else(|| anyhow::anyhow!("The contract code part type is undefined"))?
+                    .ok_or_else(|| anyhow::anyhow!("Contract code part type is undefined"))?
                 {
                     era_compiler_llvm_context::CodeType::Deploy => {
                         era_compiler_llvm_context::eravm_evm_calldata::size(context).map(Some)
@@ -699,7 +699,7 @@ impl FunctionCall {
             Name::CodeCopy => {
                 if let era_compiler_llvm_context::CodeType::Runtime = context
                     .code_type()
-                    .ok_or_else(|| anyhow::anyhow!("The contract code part type is undefined"))?
+                    .ok_or_else(|| anyhow::anyhow!("Contract code part type is undefined"))?
                 {
                     anyhow::bail!(
                         "{} The `CODECOPY` instruction is not supported in the runtime code",

--- a/src/yul/parser/statement/variable_declaration.rs
+++ b/src/yul/parser/statement/variable_declaration.rs
@@ -183,8 +183,7 @@ where
         );
         if expression.value.get_type() != llvm_type.as_basic_type_enum() {
             anyhow::bail!(
-                "{} Assignment to {:?} received an invalid number of arguments",
-                location,
+                "{location} Assignment to {:?} received an invalid number of arguments",
                 self.bindings
             );
         }
@@ -295,8 +294,7 @@ where
         );
         if expression.value.get_type() != llvm_type.as_basic_type_enum() {
             anyhow::bail!(
-                "{} Assignment to {:?} received an invalid number of arguments",
-                location,
+                "{location} Assignment to {:?} received an invalid number of arguments",
                 self.bindings
             );
         }

--- a/src/zksolc/arguments.rs
+++ b/src/zksolc/arguments.rs
@@ -116,6 +116,10 @@ pub struct Arguments {
     #[structopt(long = "target")]
     pub target: Option<String>,
 
+    /// Sets the number of threads, which execute the tests concurrently.
+    #[structopt(short = "t", long = "threads")]
+    pub threads: Option<usize>,
+
     /// Switch to missing deployable libraries detection mode.
     /// Only available for standard JSON input/output mode.
     /// Contracts are not compiled in this mode, and all compilation artifacts are not included.

--- a/src/zksolc/arguments.rs
+++ b/src/zksolc/arguments.rs
@@ -74,6 +74,10 @@ pub struct Arguments {
     #[structopt(long = "jump-table-density-threshold")]
     pub jump_table_density_threshold: Option<u32>,
 
+    /// Pass arbitary options to LLVM.
+    #[structopt(long = "llvm-options")]
+    pub llvm_options: Option<Vec<String>>,
+
     /// Disable the `solc` optimizer.
     /// Use it if your project uses the `MSIZE` instruction, or in other cases.
     /// Beware that it will prevent libraries from being inlined.

--- a/src/zksolc/arguments.rs
+++ b/src/zksolc/arguments.rs
@@ -74,9 +74,9 @@ pub struct Arguments {
     #[structopt(long = "jump-table-density-threshold")]
     pub jump_table_density_threshold: Option<u32>,
 
-    /// Pass arbitary options to LLVM.
+    /// Pass arbitary space-separated options to LLVM.
     #[structopt(long = "llvm-options")]
-    pub llvm_options: Option<Vec<String>>,
+    pub llvm_options: Option<String>,
 
     /// Disable the `solc` optimizer.
     /// Use it if your project uses the `MSIZE` instruction, or in other cases.
@@ -243,7 +243,7 @@ impl Arguments {
         .filter(|&&x| x)
         .count();
         if modes_count > 1 {
-            anyhow::bail!("Only one modes is allowed at the same time: Yul, LLVM IR, EraVM assembly, combined JSON, standard JSON.");
+            anyhow::bail!("Only one mode is allowed at the same time: Yul, LLVM IR, EraVM assembly, combined JSON, standard JSON.");
         }
 
         if self.yul || self.llvm_ir || self.zkasm {
@@ -258,11 +258,6 @@ impl Arguments {
             if self.allow_paths.is_some() {
                 anyhow::bail!(
                     "`allow-paths` is not used in Yul, LLVM IR and EraVM assembly modes."
-                );
-            }
-            if !self.libraries.is_empty() {
-                anyhow::bail!(
-                    "Libraries are not supported in Yul, LLVM IR and EraVM assembly modes."
                 );
             }
 
@@ -282,6 +277,10 @@ impl Arguments {
         }
 
         if self.llvm_ir || self.zkasm {
+            if !self.libraries.is_empty() {
+                anyhow::bail!("Libraries are not supported in LLVM IR and EraVM assembly modes.");
+            }
+
             if self.solc.is_some() {
                 anyhow::bail!("`solc` is not used in LLVM IR and EraVM assembly modes.");
             }

--- a/src/zksolc/main.rs
+++ b/src/zksolc/main.rs
@@ -61,7 +61,7 @@ fn main_inner() -> anyhow::Result<()> {
         .stack_size(RAYON_WORKER_STACK_SIZE)
         .build_global()
         .expect("Thread pool configuration failure");
-    
+
     inkwell::support::enable_llvm_pretty_stack_trace();
     era_compiler_llvm_context::initialize_target(target);
 

--- a/src/zksolc/main.rs
+++ b/src/zksolc/main.rs
@@ -108,6 +108,7 @@ fn main_inner() -> anyhow::Result<()> {
     }
     optimizer_settings.is_verify_each_enabled = arguments.llvm_verify_each;
     optimizer_settings.is_debug_logging_enabled = arguments.llvm_debug_logging;
+    let llvm_options = arguments.llvm_options.unwrap_or_default();
 
     let include_metadata_hash = match arguments.metadata_hash {
         Some(metadata_hash) => {
@@ -126,6 +127,7 @@ fn main_inner() -> anyhow::Result<()> {
                     arguments.libraries,
                     arguments.solc,
                     optimizer_settings,
+                    llvm_options.as_slice(),
                     arguments.is_system_mode,
                     include_metadata_hash,
                     debug_config,
@@ -134,6 +136,7 @@ fn main_inner() -> anyhow::Result<()> {
                 era_compiler_solidity::llvm_ir_to_eravm(
                     input_files.as_slice(),
                     optimizer_settings,
+                    llvm_options.as_slice(),
                     arguments.is_system_mode,
                     include_metadata_hash,
                     debug_config,
@@ -141,6 +144,7 @@ fn main_inner() -> anyhow::Result<()> {
             } else if arguments.zkasm {
                 era_compiler_solidity::eravm_assembly(
                     input_files.as_slice(),
+                    llvm_options.as_slice(),
                     include_metadata_hash,
                     debug_config,
                 )
@@ -151,6 +155,7 @@ fn main_inner() -> anyhow::Result<()> {
                 };
                 era_compiler_solidity::standard_json_eravm(
                     solc_compiler.as_ref(),
+                    llvm_options.as_slice(),
                     standard_json.map(PathBuf::from),
                     arguments.detect_missing_libraries,
                     arguments.force_evmla,
@@ -176,6 +181,7 @@ fn main_inner() -> anyhow::Result<()> {
                     evm_version,
                     !arguments.disable_solc_optimizer,
                     optimizer_settings,
+                    llvm_options.as_slice(),
                     arguments.force_evmla,
                     arguments.is_system_mode,
                     include_metadata_hash,
@@ -204,6 +210,7 @@ fn main_inner() -> anyhow::Result<()> {
                     evm_version,
                     !arguments.disable_solc_optimizer,
                     optimizer_settings,
+                    llvm_options.as_slice(),
                     arguments.force_evmla,
                     arguments.is_system_mode,
                     include_metadata_hash,
@@ -264,6 +271,7 @@ fn main_inner() -> anyhow::Result<()> {
                     arguments.libraries,
                     arguments.solc,
                     optimizer_settings,
+                    llvm_options.as_slice(),
                     include_metadata_hash,
                     debug_config,
                 )
@@ -271,6 +279,7 @@ fn main_inner() -> anyhow::Result<()> {
                 era_compiler_solidity::llvm_ir_to_evm(
                     input_files.as_slice(),
                     optimizer_settings,
+                    llvm_options.as_slice(),
                     include_metadata_hash,
                     debug_config,
                 )
@@ -281,6 +290,7 @@ fn main_inner() -> anyhow::Result<()> {
                 };
                 era_compiler_solidity::standard_json_evm(
                     solc_compiler.as_ref(),
+                    llvm_options.as_slice(),
                     standard_json.map(PathBuf::from),
                     arguments.force_evmla,
                     arguments.base_path,
@@ -304,6 +314,7 @@ fn main_inner() -> anyhow::Result<()> {
                     evm_version,
                     !arguments.disable_solc_optimizer,
                     optimizer_settings,
+                    llvm_options.as_slice(),
                     arguments.force_evmla,
                     include_metadata_hash,
                     arguments.metadata_literal,
@@ -330,6 +341,7 @@ fn main_inner() -> anyhow::Result<()> {
                     evm_version,
                     !arguments.disable_solc_optimizer,
                     optimizer_settings,
+                    llvm_options.as_slice(),
                     arguments.force_evmla,
                     include_metadata_hash,
                     arguments.metadata_literal,

--- a/src/zksolc/main.rs
+++ b/src/zksolc/main.rs
@@ -61,6 +61,7 @@ fn main_inner() -> anyhow::Result<()> {
         .stack_size(RAYON_WORKER_STACK_SIZE)
         .build_global()
         .expect("Thread pool configuration failure");
+    
     inkwell::support::enable_llvm_pretty_stack_trace();
     era_compiler_llvm_context::initialize_target(target);
 
@@ -68,7 +69,7 @@ fn main_inner() -> anyhow::Result<()> {
         return era_compiler_solidity::run_process(target);
     }
     if let era_compiler_llvm_context::Target::EVM = target {
-        anyhow::bail!("The EVM target is under development and not supported yet.")
+        anyhow::bail!("The EVM target is under development and not available yet.")
     }
 
     let debug_config = match arguments.debug_output_directory {
@@ -113,12 +114,11 @@ fn main_inner() -> anyhow::Result<()> {
     optimizer_settings.is_verify_each_enabled = arguments.llvm_verify_each;
     optimizer_settings.is_debug_logging_enabled = arguments.llvm_debug_logging;
 
-    let llvm_options: Vec<String> = arguments
+    let llvm_options: Vec<&str> = arguments
         .llvm_options
-        .unwrap_or_default()
-        .into_iter()
-        .map(|option| option.replace('\\', ""))
-        .collect();
+        .as_ref()
+        .map(|options| options.split(' ').collect())
+        .unwrap_or_default();
 
     let include_metadata_hash = match arguments.metadata_hash {
         Some(metadata_hash) => {


### PR DESCRIPTION
# What ❔

Allows passing arbitrary LLVM arguments in FE.

## Why ❔

It is needed for experiments with the optimizer, and for debugging.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
