### PR TITLE
ci: fix release issue with empty ref parameter

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,9 +121,9 @@ jobs:
         id: release
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            git config --global --add safe.directory $GITHUB_WORKSPACE
             VERSION_OR_SHA=$(git rev-parse --short HEAD)
             echo "version_or_sha=${VERSION_OR_SHA}" >> $GITHUB_OUTPUT
+            echo "full_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
             echo "release_title=prerelease-${VERSION_OR_SHA}-${{ github.event.inputs.prerelease_suffix }}" >> $GITHUB_OUTPUT
           else
             VERSION_OR_SHA="${GITHUB_REF#refs/tags/}"
@@ -137,7 +137,7 @@ jobs:
         run: |
           tree ./releases
           BINARIES=($(find ./releases -type f))
-          [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && TARGET_PARAM="--target ${{ github.event.inputs.ref }}"
+          [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && TARGET_PARAM="--target ${{ steps.release.outputs.full_sha }}"
           gh release create ${{ steps.release.outputs.version_or_sha }} \
             --title ${{ steps.release.outputs.release_title }} \
             --prerelease ${TARGET_PARAM} \


### PR DESCRIPTION
# What ❔

Fixes an issue with release generation if `ref` is not specified.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

GH API cannot take short sha for commit.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
