### PR TITLE
fix: write standard JSON errors to JSON

### DIFF
--- a/src/build_eravm/mod.rs
+++ b/src/build_eravm/mod.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 
 use crate::solc::combined_json::CombinedJson;
 use crate::solc::standard_json::output::contract::Contract as StandardJsonOutputContract;
+use crate::solc::standard_json::output::error::Error as StandardJsonOutputError;
 use crate::solc::standard_json::output::Output as StandardJsonOutput;
 use crate::solc::version::Version as SolcVersion;
 
@@ -20,7 +21,7 @@ use self::contract::Contract;
 #[derive(Debug, Default)]
 pub struct Build {
     /// The contract data,
-    pub contracts: BTreeMap<String, Contract>,
+    pub contracts: BTreeMap<String, anyhow::Result<Contract>>,
 }
 
 impl Build {
@@ -34,13 +35,30 @@ impl Build {
         output_binary: bool,
         overwrite: bool,
     ) -> anyhow::Result<()> {
-        for (_path, contract) in self.contracts.into_iter() {
-            contract.write_to_directory(
-                output_directory,
-                output_assembly,
-                output_binary,
-                overwrite,
-            )?;
+        let mut errors = Vec::new();
+        for (path, build) in self.contracts.into_iter() {
+            match build {
+                Ok(build) => build.write_to_directory(
+                    output_directory,
+                    output_assembly,
+                    output_binary,
+                    overwrite,
+                )?,
+                Err(error) => {
+                    errors.push((path, error));
+                }
+            }
+        }
+
+        if !errors.is_empty() {
+            anyhow::bail!(
+                "{}",
+                errors
+                    .into_iter()
+                    .map(|(path, error)| format!("Contract `{path}` error: {error}"))
+                    .collect::<Vec<String>>()
+                    .join("\n")
+            );
         }
 
         Ok(())
@@ -54,7 +72,8 @@ impl Build {
         combined_json: &mut CombinedJson,
         zksolc_version: &semver::Version,
     ) -> anyhow::Result<()> {
-        for (path, contract) in self.contracts.into_iter() {
+        let mut errors = Vec::new();
+        for (path, build) in self.contracts.into_iter() {
             let combined_json_contract = combined_json
                 .contracts
                 .iter_mut()
@@ -67,10 +86,26 @@ impl Build {
                 })
                 .ok_or_else(|| anyhow::anyhow!("Contract `{}` not found in the project", path))?;
 
-            contract.write_to_combined_json(combined_json_contract)?;
+            match build {
+                Ok(build) => build.write_to_combined_json(combined_json_contract)?,
+                Err(error) => {
+                    errors.push((path, error));
+                }
+            }
         }
 
         combined_json.zk_version = Some(zksolc_version.to_string());
+
+        if !errors.is_empty() {
+            anyhow::bail!(
+                "{}",
+                errors
+                    .into_iter()
+                    .map(|(path, error)| format!("Contract `{path}` error: {error}"))
+                    .collect::<Vec<String>>()
+                    .join("\n")
+            );
+        }
 
         Ok(())
     }
@@ -91,26 +126,47 @@ impl Build {
                 standard_json.contracts.as_mut().expect("Always exists")
             }
         };
+        let standard_json_errors = match standard_json.errors.as_mut() {
+            Some(errors) => errors,
+            None => {
+                standard_json.errors = Some(Vec::new());
+                standard_json.errors.as_mut().expect("Always exists")
+            }
+        };
 
         for (full_path, build) in self.contracts.into_iter() {
             let mut full_path_split = full_path.split(':');
             let path = full_path_split.next().expect("Always exists");
             let name = full_path_split.next().unwrap_or(path);
 
-            match standard_json_contracts
-                .get_mut(path)
-                .and_then(|contracts| contracts.get_mut(name))
-            {
-                Some(contract) => {
-                    build.write_to_standard_json(contract)?;
-                }
-                None => {
-                    let contracts = standard_json_contracts
-                        .entry(path.to_owned())
-                        .or_insert_with(BTreeMap::new);
-                    let mut contract = StandardJsonOutputContract::default();
-                    build.write_to_standard_json(&mut contract)?;
-                    contracts.insert(name.to_owned(), contract);
+            match build {
+                Ok(build) => match standard_json_contracts
+                    .get_mut(path)
+                    .and_then(|contracts| contracts.get_mut(name))
+                {
+                    Some(contract) => {
+                        build.write_to_standard_json(contract)?;
+                    }
+                    None => {
+                        let contracts = standard_json_contracts
+                            .entry(path.to_owned())
+                            .or_insert_with(BTreeMap::new);
+                        let mut contract = StandardJsonOutputContract::default();
+                        build.write_to_standard_json(&mut contract)?;
+                        contracts.insert(name.to_owned(), contract);
+                    }
+                },
+                Err(error) => {
+                    let message = error.to_string();
+                    standard_json_errors.push(StandardJsonOutputError {
+                        component: "general".to_owned(),
+                        error_code: None,
+                        formatted_message: message.clone(),
+                        message,
+                        severity: "error".to_owned(),
+                        source_location: None,
+                        r#type: "Error".to_owned(),
+                    });
                 }
             }
         }

--- a/src/solc/standard_json/output/mod.rs
+++ b/src/solc/standard_json/output/mod.rs
@@ -80,6 +80,34 @@ impl Output {
     }
 
     ///
+    /// Checks for errors, returning `Err` if there is at least one error.
+    ///
+    pub fn check_errors(&self) -> anyhow::Result<()> {
+        if self
+            .errors
+            .as_ref()
+            .map(|errors| errors.iter().any(|error| error.severity == "error"))
+            .unwrap_or_default()
+        {
+            anyhow::bail!(
+                "{}",
+                self.errors
+                    .as_ref()
+                    .map(|errors| {
+                        errors
+                            .iter()
+                            .map(|error| error.message.clone())
+                            .collect::<Vec<String>>()
+                            .join("\n")
+                    })
+                    .unwrap_or_default()
+            );
+        }
+
+        Ok(())
+    }
+
+    ///
     /// Removes EVM artifacts to prevent their accidental usage.
     ///
     pub fn remove_evm(&mut self) {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -93,6 +93,7 @@ pub fn build_solidity(
         &semver::Version::from_str(env!("CARGO_PKG_VERSION"))?,
     )?;
 
+    solc_output.check_errors()?;
     Ok(solc_output)
 }
 
@@ -152,6 +153,7 @@ pub fn build_solidity_and_detect_missing_libraries(
         &semver::Version::from_str(env!("CARGO_PKG_VERSION"))?,
     )?;
 
+    solc_output.check_errors()?;
     Ok(solc_output)
 }
 
@@ -181,6 +183,7 @@ pub fn build_yul(sources: BTreeMap<String, String>) -> anyhow::Result<SolcStanda
     )?;
     build.write_to_standard_json(&mut solc_output, None, &zksolc_version)?;
 
+    solc_output.check_errors()?;
     Ok(solc_output)
 }
 
@@ -224,6 +227,7 @@ pub fn build_yul_standard_json(
     )?;
     build.write_to_standard_json(&mut solc_output, solc_version, &zksolc_version)?;
 
+    solc_output.check_errors()?;
     Ok(solc_output)
 }
 
@@ -258,6 +262,7 @@ pub fn build_llvm_ir_standard_json(
     )?;
     build.write_to_standard_json(&mut solc_output, None, &zksolc_version)?;
 
+    solc_output.check_errors()?;
     Ok(solc_output)
 }
 
@@ -292,6 +297,7 @@ pub fn build_eravm_assembly_standard_json(
     )?;
     build.write_to_standard_json(&mut solc_output, None, &zksolc_version)?;
 
+    solc_output.check_errors()?;
     Ok(solc_output)
 }
 

--- a/src/zksolc/main.rs
+++ b/src/zksolc/main.rs
@@ -241,22 +241,29 @@ fn main_inner() -> anyhow::Result<()> {
                     "Compiler run successful. Artifact(s) can be found in directory {output_directory:?}."
                 )?;
             } else if arguments.output_assembly || arguments.output_binary {
-                for (path, contract) in build.contracts.into_iter() {
-                    if arguments.output_assembly {
-                        writeln!(
-                            std::io::stdout(),
-                            "Contract `{}` assembly:\n\n{}",
-                            path,
-                            contract.build.assembly_text
-                        )?;
-                    }
-                    if arguments.output_binary {
-                        writeln!(
-                            std::io::stdout(),
-                            "Contract `{}` bytecode: 0x{}",
-                            path,
-                            hex::encode(contract.build.bytecode)
-                        )?;
+                for (path, build) in build.contracts.into_iter() {
+                    match build {
+                        Ok(build) => {
+                            if arguments.output_assembly {
+                                writeln!(
+                                    std::io::stdout(),
+                                    "Contract `{}` assembly:\n\n{}",
+                                    path,
+                                    build.build.assembly_text
+                                )?;
+                            }
+                            if arguments.output_binary {
+                                writeln!(
+                                    std::io::stdout(),
+                                    "Contract `{}` bytecode: 0x{}",
+                                    path,
+                                    hex::encode(build.build.bytecode)
+                                )?;
+                            }
+                        }
+                        Err(error) => {
+                            writeln!(std::io::stderr(), "Contract `{path}` error: {error}",)?;
+                        }
                     }
                 }
             } else {
@@ -369,20 +376,27 @@ fn main_inner() -> anyhow::Result<()> {
                     "Compiler run successful. Artifact(s) can be found in directory {output_directory:?}."
                 )?;
             } else if arguments.output_assembly || arguments.output_binary {
-                for (path, contract) in build.contracts.into_iter() {
-                    if arguments.output_binary {
-                        writeln!(
-                            std::io::stdout(),
-                            "Contract `{}` deploy bytecode: 0x{}",
-                            path,
-                            hex::encode(contract.deploy_build.bytecode)
-                        )?;
-                        writeln!(
-                            std::io::stdout(),
-                            "Contract `{}` runtime bytecode: 0x{}",
-                            path,
-                            hex::encode(contract.runtime_build.bytecode)
-                        )?;
+                for (path, build) in build.contracts.into_iter() {
+                    match build {
+                        Ok(build) => {
+                            if arguments.output_binary {
+                                writeln!(
+                                    std::io::stdout(),
+                                    "Contract `{}` deploy bytecode: 0x{}",
+                                    path,
+                                    hex::encode(build.deploy_build.bytecode)
+                                )?;
+                                writeln!(
+                                    std::io::stdout(),
+                                    "Contract `{}` runtime bytecode: 0x{}",
+                                    path,
+                                    hex::encode(build.runtime_build.bytecode)
+                                )?;
+                            }
+                        }
+                        Err(error) => {
+                            writeln!(std::io::stderr(), "Contract `{path}` error: {error}",)?;
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
# What ❔

Write standard JSON errors to JSON.

## Why ❔

Errors have been printed to stderr even in standard JSON mode. It is different from `solc` behavior and we've easily fixed it.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
