### PR TITLE
feat: resolve error locations

### DIFF
--- a/src/solc/standard_json/output/error/mod.rs
+++ b/src/solc/standard_json/output/error/mod.rs
@@ -35,138 +35,148 @@ pub struct Error {
 
 impl Error {
     ///
-    /// Returns the `ecrecover` function usage warning.
+    /// A shortcut constructor.
     ///
-    pub fn message_ecrecover(src: Option<&str>) -> Self {
-        let message = r#"
-┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ Warning: It looks like you are using 'ecrecover' to validate a signature of a user account.      │
-│ ZKsync Era comes with native account abstraction support, therefore it is highly recommended NOT │
-│ to rely on the fact that the account has an ECDSA private key attached to it since accounts might│
-│ implement other signature schemes.                                                               │
-│ Read more about Account Abstraction at https://v2-docs.zksync.io/dev/developer-guides/aa.html    │
-└──────────────────────────────────────────────────────────────────────────────────────────────────┘"#
-            .to_owned();
+    pub fn new_error<S>(message: S, source_location: Option<SourceLocation>) -> Self
+    where
+        S: std::fmt::Display,
+    {
+        let location = source_location.as_ref().map(SourceLocation::resolve);
+        let formatted_message = match location {
+            Some(location) => format!("{message}\n--> {location}\n"),
+            None => message.to_string(),
+        };
 
         Self {
             component: "general".to_owned(),
             error_code: None,
-            formatted_message: message,
+            formatted_message,
+            message: "".to_owned(),
+            severity: "error".to_owned(),
+            source_location,
+            r#type: "Error".to_owned(),
+        }
+    }
+
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new_warning<S>(message: S, source_location: Option<SourceLocation>) -> Self
+    where
+        S: std::fmt::Display,
+    {
+        let location = source_location.as_ref().map(SourceLocation::resolve);
+        let formatted_message = match location {
+            Some(location) => format!("{message}\n--> {location}\n"),
+            None => message.to_string(),
+        };
+
+        Self {
+            component: "general".to_owned(),
+            error_code: None,
+            formatted_message,
             message: "".to_owned(),
             severity: "warning".to_owned(),
-            source_location: src.map(SourceLocation::from_str).and_then(Result::ok),
+            source_location,
             r#type: "Warning".to_owned(),
         }
     }
 
     ///
-    /// Returns the `<address payable>`'s `send` and `transfer` methods usage error.
+    /// Returns the `ecrecover` function usage warning.
     ///
-    pub fn message_send_and_transfer(src: Option<&str>) -> Self {
+    pub fn warning_ecrecover(src: Option<&str>) -> Self {
         let message = r#"
 ┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ Warning: It looks like you are using '<address payable>.send/transfer(<X>)' without providing    │
-│ the gas amount. Such calls will fail depending on the pubdata costs.                             │
+│ It looks like you are using 'ecrecover' to validate a signature of a user account.               │
+│ ZKsync Era comes with native account abstraction support, therefore it is highly recommended NOT │
+│ to rely on the fact that the account has an ECDSA private key attached to it since accounts      │
+│ might implement other signature schemes.                                                         │
+│ Read more about Account Abstraction at https://v2-docs.zksync.io/dev/developer-guides/aa.html    │
+└──────────────────────────────────────────────────────────────────────────────────────────────────┘"#;
+
+        Self::new_warning(
+            message,
+            src.map(SourceLocation::from_str).and_then(Result::ok),
+        )
+    }
+
+    ///
+    /// Returns the `<address payable>`'s `send` and `transfer` methods usage error.
+    ///
+    pub fn warning_send_and_transfer(src: Option<&str>) -> Self {
+        let message = r#"
+┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ It looks like you are using '<address payable>.send/transfer(<X>)' without providing the gas     │
+│ amount. Such calls will fail depending on the pubdata costs.                                     │
 │ This might be a false positive if you are using an interface (like IERC20) instead of the        │
 │ native Solidity `send/transfer`.                                                                 │
 │ Please use 'payable(<address>).call{value: <X>}("")' instead, but be careful with the reentrancy │
 │ attack. `send` and `transfer` send limited amount of gas that prevents reentrancy, whereas       │
 │ `<address>.call{value: <X>}` sends all gas to the callee. Learn more on                          │
 │ https://docs.soliditylang.org/en/latest/security-considerations.html#reentrancy                  │
-└──────────────────────────────────────────────────────────────────────────────────────────────────┘"#
-            .to_owned();
+└──────────────────────────────────────────────────────────────────────────────────────────────────┘"#;
 
-        Self {
-            component: "general".to_owned(),
-            error_code: None,
-            formatted_message: message,
-            message: "".to_owned(),
-            severity: "warning".to_owned(),
-            source_location: src.map(SourceLocation::from_str).and_then(Result::ok),
-            r#type: "Warning".to_owned(),
-        }
+        Self::new_warning(
+            message,
+            src.map(SourceLocation::from_str).and_then(Result::ok),
+        )
     }
 
     ///
     /// Returns the `extcodesize` instruction usage warning.
     ///
-    pub fn message_extcodesize(src: Option<&str>) -> Self {
+    pub fn warning_extcodesize(src: Option<&str>) -> Self {
         let message = r#"
 ┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ Warning: Your code or one of its dependencies uses the 'extcodesize' instruction, which is       │
-│ usually needed in the following cases:                                                           │
+│ Your code or one of its dependencies uses the 'extcodesize' instruction, which is usually needed │
+│ in the following cases:                                                                          │
 │   1. To detect whether an address belongs to a smart contract.                                   │
 │   2. To detect whether the deploy code execution has finished.                                   │
 │ ZKsync Era comes with native account abstraction support (so accounts are smart contracts,       │
 │ including private-key controlled EOAs), and you should avoid differentiating between contracts   │
 │ and non-contract addresses.                                                                      │
-└──────────────────────────────────────────────────────────────────────────────────────────────────┘"#
-            .to_owned();
+└──────────────────────────────────────────────────────────────────────────────────────────────────┘"#;
 
-        Self {
-            component: "general".to_owned(),
-            error_code: None,
-            formatted_message: message,
-            message: "".to_owned(),
-            severity: "warning".to_owned(),
-            source_location: src.map(SourceLocation::from_str).and_then(Result::ok),
-            r#type: "Warning".to_owned(),
-        }
+        Self::new_warning(
+            message,
+            src.map(SourceLocation::from_str).and_then(Result::ok),
+        )
     }
 
     ///
     /// Returns the `origin` instruction usage warning.
     ///
-    pub fn message_tx_origin(src: Option<&str>) -> Self {
+    pub fn warning_tx_origin(src: Option<&str>) -> Self {
         let message = r#"
 ┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ Warning: You are checking for 'tx.origin' in your code, which might lead to unexpected behavior. │
+│ You are checking for 'tx.origin' in your code, which might lead to unexpected behavior.          │
 │ ZKsync Era comes with native account abstraction support, and therefore the initiator of a       │
 │ transaction might be different from the contract calling your code. It is highly recommended NOT │
 │ to rely on tx.origin, but use msg.sender instead.                                                │
 │ Read more about Account Abstraction at https://v2-docs.zksync.io/dev/developer-guides/aa.html    │
-└──────────────────────────────────────────────────────────────────────────────────────────────────┘"#
-            .to_owned();
+└──────────────────────────────────────────────────────────────────────────────────────────────────┘"#;
 
-        Self {
-            component: "general".to_owned(),
-            error_code: None,
-            formatted_message: message,
-            message: "".to_owned(),
-            severity: "warning".to_owned(),
-            source_location: src.map(SourceLocation::from_str).and_then(Result::ok),
-            r#type: "Warning".to_owned(),
-        }
+        Self::new_warning(
+            message,
+            src.map(SourceLocation::from_str).and_then(Result::ok),
+        )
     }
 
     ///
     /// Returns the internal function pointer usage error.
     ///
-    pub fn message_internal_function_pointer(src: Option<&str>) -> Self {
+    pub fn error_internal_function_pointer(src: Option<&str>) -> Self {
         let message = r#"
 ┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ Error: Internal function pointers are not supported in EVM legacy assembly pipeline.             │
-│ Please use the Yul IR codegen instead.                                                           │
-└──────────────────────────────────────────────────────────────────────────────────────────────────┘"#
-            .to_owned();
+│ Internal function pointers are not supported in EVM legacy assembly pipeline.                    │
+│ Please use the latest solc with Yul codegen instead.                                             │
+└──────────────────────────────────────────────────────────────────────────────────────────────────┘"#;
 
-        Self {
-            component: "general".to_owned(),
-            error_code: None,
-            formatted_message: message,
-            message: "".to_owned(),
-            severity: "error".to_owned(),
-            source_location: src.map(SourceLocation::from_str).and_then(Result::ok),
-            r#type: "Error".to_owned(),
-        }
-    }
-
-    ///
-    /// Appends the contract path to the message..
-    ///
-    pub fn push_contract_path(&mut self, path: &str) {
-        self.formatted_message
-            .push_str(format!("\n--> {path}\n").as_str());
+        Self::new_error(
+            message,
+            src.map(SourceLocation::from_str).and_then(Result::ok),
+        )
     }
 }
 

--- a/src/solc/standard_json/output/error/source_location.rs
+++ b/src/solc/standard_json/output/error/source_location.rs
@@ -25,8 +25,26 @@ impl SourceLocation {
     ///
     /// A shortcut constructor.
     ///
-    pub fn new(file: String, start: isize, end: isize) -> Self {
+    pub fn new(file: String) -> Self {
+        Self {
+            file,
+            start: -1,
+            end: -1,
+        }
+    }
+
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new_with_location(file: String, start: isize, end: isize) -> Self {
         Self { file, start, end }
+    }
+
+    ///
+    /// Resolves the location, converting absolute offsets to line and column.
+    ///
+    pub fn resolve(&self) -> String {
+        self.file.to_owned()
     }
 }
 
@@ -47,10 +65,6 @@ impl FromStr for SourceLocation {
             .unwrap_or_default();
         let file = parts.next().unwrap_or_default().to_owned();
 
-        Ok(Self {
-            file,
-            start,
-            end: start + length,
-        })
+        Ok(Self::new_with_location(file, start, start + length))
     }
 }

--- a/src/solc/standard_json/output/source.rs
+++ b/src/solc/standard_json/output/source.rs
@@ -50,7 +50,7 @@ impl Source {
             return None;
         }
 
-        Some(SolcStandardJsonOutputError::message_ecrecover(
+        Some(SolcStandardJsonOutputError::warning_ecrecover(
             ast.get("src")?.as_str(),
         ))
     }
@@ -74,7 +74,7 @@ impl Source {
             return None;
         }
 
-        Some(SolcStandardJsonOutputError::message_send_and_transfer(
+        Some(SolcStandardJsonOutputError::warning_send_and_transfer(
             ast.get("src")?.as_str(),
         ))
     }
@@ -100,7 +100,7 @@ impl Source {
             return None;
         }
 
-        Some(SolcStandardJsonOutputError::message_extcodesize(
+        Some(SolcStandardJsonOutputError::warning_extcodesize(
             ast.get("src")?.as_str(),
         ))
     }
@@ -124,7 +124,7 @@ impl Source {
             return None;
         }
 
-        Some(SolcStandardJsonOutputError::message_tx_origin(
+        Some(SolcStandardJsonOutputError::warning_tx_origin(
             ast.get("src")?.as_str(),
         ))
     }
@@ -150,7 +150,7 @@ impl Source {
             return None;
         }
 
-        Some(SolcStandardJsonOutputError::message_tx_origin(
+        Some(SolcStandardJsonOutputError::warning_tx_origin(
             ast.get("src")?.as_str(),
         ))
     }
@@ -176,11 +176,7 @@ impl Source {
             return None;
         }
 
-        Some(
-            SolcStandardJsonOutputError::message_internal_function_pointer(
-                ast.get("src")?.as_str(),
-            ),
-        )
+        Some(SolcStandardJsonOutputError::error_internal_function_pointer(ast.get("src")?.as_str()))
     }
 
     ///

--- a/src/tests/messages.rs
+++ b/src/tests/messages.rs
@@ -27,30 +27,28 @@ contract ECRecoverExample {
 
 #[test]
 fn ecrecover() {
-    assert!(
-        super::check_solidity_warning(
-            ECRECOVER_TEST_SOURCE,
-            "Warning: It looks like you are using 'ecrecover' to validate a signature of a user account.",
-            BTreeMap::new(),
-            SolcPipeline::Yul,
-            false,
-            None,
-        ).expect("Test failure")
-    );
+    assert!(super::check_solidity_warning(
+        ECRECOVER_TEST_SOURCE,
+        "It looks like you are using 'ecrecover' to validate a signature of a user account.",
+        BTreeMap::new(),
+        SolcPipeline::Yul,
+        false,
+        None,
+    )
+    .expect("Test failure"));
 }
 
 #[test]
 fn ecrecover_suppressed() {
-    assert!(
-        !super::check_solidity_warning(
-            ECRECOVER_TEST_SOURCE,
-            "Warning: It looks like you are using 'ecrecover' to validate a signature of a user account.",
-            BTreeMap::new(),
-            SolcPipeline::Yul,
-            false,
-            Some(vec![Warning::EcRecover]),
-        ).expect("Test failure")
-    );
+    assert!(!super::check_solidity_warning(
+        ECRECOVER_TEST_SOURCE,
+        "It looks like you are using 'ecrecover' to validate a signature of a user account.",
+        BTreeMap::new(),
+        SolcPipeline::Yul,
+        false,
+        Some(vec![Warning::EcRecover]),
+    )
+    .expect("Test failure"));
 }
 
 pub const SEND_TEST_SOURCE: &str = r#"
@@ -73,30 +71,28 @@ contract SendExample {
 
 #[test]
 fn send() {
-    assert!(
-        super::check_solidity_warning(
-            SEND_TEST_SOURCE,
-            "Warning: It looks like you are using '<address payable>.send/transfer(<X>)' without providing",
-            BTreeMap::new(),
-            SolcPipeline::Yul,
-            false,
-            None,
-        ).expect("Test failure")
-    );
+    assert!(super::check_solidity_warning(
+        SEND_TEST_SOURCE,
+        "It looks like you are using '<address payable>.send/transfer(<X>)' without providing",
+        BTreeMap::new(),
+        SolcPipeline::Yul,
+        false,
+        None,
+    )
+    .expect("Test failure"));
 }
 
 #[test]
 fn send_suppressed() {
-    assert!(
-        !super::check_solidity_warning(
-            SEND_TEST_SOURCE,
-            "Warning: It looks like you are using '<address payable>.send/transfer(<X>)' without providing",
-            BTreeMap::new(),
-            SolcPipeline::Yul,
-            false,
-            Some(vec![Warning::SendTransfer]),
-        ).expect("Test failure")
-    );
+    assert!(!super::check_solidity_warning(
+        SEND_TEST_SOURCE,
+        "It looks like you are using '<address payable>.send/transfer(<X>)' without providing",
+        BTreeMap::new(),
+        SolcPipeline::Yul,
+        false,
+        Some(vec![Warning::SendTransfer]),
+    )
+    .expect("Test failure"));
 }
 
 pub const TRANSFER_TEST_SOURCE: &str = r#"
@@ -118,30 +114,28 @@ contract TransferExample {
 
 #[test]
 fn transfer() {
-    assert!(
-        super::check_solidity_warning(
-            TRANSFER_TEST_SOURCE,
-            "Warning: It looks like you are using '<address payable>.send/transfer(<X>)' without providing",
-            BTreeMap::new(),
-            SolcPipeline::Yul,
-            false,
-            None,
-        ).expect("Test failure")
-    );
+    assert!(super::check_solidity_warning(
+        TRANSFER_TEST_SOURCE,
+        "It looks like you are using '<address payable>.send/transfer(<X>)' without providing",
+        BTreeMap::new(),
+        SolcPipeline::Yul,
+        false,
+        None,
+    )
+    .expect("Test failure"));
 }
 
 #[test]
 fn transfer_suppressed() {
-    assert!(
-        !super::check_solidity_warning(
-            TRANSFER_TEST_SOURCE,
-            "Warning: It looks like you are using '<address payable>.send/transfer(<X>)' without providing",
-            BTreeMap::new(),
-            SolcPipeline::Yul,
-            false,
-            Some(vec![Warning::SendTransfer]),
-        ).expect("Test failure")
-    );
+    assert!(!super::check_solidity_warning(
+        TRANSFER_TEST_SOURCE,
+        "It looks like you are using '<address payable>.send/transfer(<X>)' without providing",
+        BTreeMap::new(),
+        SolcPipeline::Yul,
+        false,
+        Some(vec![Warning::SendTransfer]),
+    )
+    .expect("Test failure"));
 }
 
 pub const EXTCODESIZE_TEST_SOURCE: &str = r#"
@@ -163,7 +157,7 @@ contract ExternalCodeSize {
 fn extcodesize() {
     assert!(super::check_solidity_warning(
         EXTCODESIZE_TEST_SOURCE,
-        "Warning: Your code or one of its dependencies uses the 'extcodesize' instruction,",
+        "Your code or one of its dependencies uses the 'extcodesize' instruction,",
         BTreeMap::new(),
         SolcPipeline::Yul,
         false,
@@ -176,7 +170,7 @@ fn extcodesize() {
 fn extcodesize_suppressed() {
     assert!(!super::check_solidity_warning(
         EXTCODESIZE_TEST_SOURCE,
-        "Warning: Your code or one of its dependencies uses the 'extcodesize' instruction,",
+        "Your code or one of its dependencies uses the 'extcodesize' instruction,",
         BTreeMap::new(),
         SolcPipeline::Yul,
         false,
@@ -200,7 +194,7 @@ contract TxOriginExample {
 fn tx_origin() {
     assert!(super::check_solidity_warning(
         TX_ORIGIN_TEST_SOURCE,
-        "Warning: You are checking for 'tx.origin' in your code, which might lead to",
+        "You are checking for 'tx.origin' in your code, which might lead to",
         BTreeMap::new(),
         SolcPipeline::Yul,
         false,
@@ -213,7 +207,7 @@ fn tx_origin() {
 fn tx_origin_suppressed() {
     assert!(!super::check_solidity_warning(
         TX_ORIGIN_TEST_SOURCE,
-        "Warning: You are checking for 'tx.origin' in your code, which might lead to",
+        "You are checking for 'tx.origin' in your code, which might lead to",
         BTreeMap::new(),
         SolcPipeline::Yul,
         false,
@@ -244,7 +238,7 @@ contract TxOriginExample {
 fn tx_origin_assembly() {
     assert!(super::check_solidity_warning(
         TX_ORIGIN_ASSEMBLY_TEST_SOURCE,
-        "Warning: You are checking for 'tx.origin' in your code, which might lead to",
+        "You are checking for 'tx.origin' in your code, which might lead to",
         BTreeMap::new(),
         SolcPipeline::Yul,
         false,
@@ -257,7 +251,7 @@ fn tx_origin_assembly() {
 fn tx_origin_assembly_suppressed() {
     assert!(!super::check_solidity_warning(
         TX_ORIGIN_ASSEMBLY_TEST_SOURCE,
-        "Warning: You are checking for 'tx.origin' in your code, which might lead to",
+        "You are checking for 'tx.origin' in your code, which might lead to",
         BTreeMap::new(),
         SolcPipeline::Yul,
         false,
@@ -301,7 +295,7 @@ contract InternalFunctionPointerExample {
 
     assert!(super::check_solidity_warning(
         source_code,
-        "Error: Internal function pointers are not supported in EVM legacy assembly pipeline.",
+        "Internal function pointers are not supported in EVM legacy assembly pipeline.",
         BTreeMap::new(),
         SolcPipeline::EVMLA,
         true,
@@ -339,7 +333,7 @@ contract StackFunctionPointerExample {
 
     assert!(super::check_solidity_warning(
         source_code,
-        "Error: Internal function pointers are not supported in EVM legacy assembly pipeline.",
+        "Internal function pointers are not supported in EVM legacy assembly pipeline.",
         BTreeMap::new(),
         SolcPipeline::EVMLA,
         true,
@@ -384,7 +378,7 @@ contract StorageFunctionPointerExample {
 
     assert!(super::check_solidity_warning(
         source_code,
-        "Error: Internal function pointers are not supported in EVM legacy assembly pipeline.",
+        "Internal function pointers are not supported in EVM legacy assembly pipeline.",
         BTreeMap::new(),
         SolcPipeline::EVMLA,
         true,


### PR DESCRIPTION
# What ❔

1. Resolves the errors locations of extra `zksolc` errors.
2. Minimizes the output JSON by pruning `null` fields.

## Why ❔

1. Errors and warnings were missing their locations.
2. These extra fields increase RAM usage with large projects.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
