### PR TITLE
chore: move common error handling code to a trait

### DIFF
--- a/src/build_eravm/mod.rs
+++ b/src/build_eravm/mod.rs
@@ -5,7 +5,6 @@
 pub mod contract;
 
 use std::collections::BTreeMap;
-use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -13,6 +12,7 @@ use normpath::PathExt;
 
 use crate::solc::combined_json::CombinedJson;
 use crate::solc::standard_json::output::contract::Contract as StandardJsonOutputContract;
+use crate::solc::standard_json::output::error::collectable::Collectable as CollectableError;
 use crate::solc::standard_json::output::error::Error as StandardJsonOutputError;
 use crate::solc::standard_json::output::Output as StandardJsonOutput;
 use crate::solc::version::Version as SolcVersion;
@@ -172,87 +172,21 @@ impl Build {
 
         Ok(())
     }
+}
 
-    ///
-    /// Checks if there is at least one error.
-    ///
-    pub fn has_errors(&self) -> bool {
-        self.contracts.values().any(|result| result.is_err())
-            || self
-                .messages
-                .iter()
-                .any(|message| message.severity == "error")
+impl CollectableError for Build {
+    fn errors(&self) -> Vec<&StandardJsonOutputError> {
+        self.contracts
+            .values()
+            .filter_map(|build| build.as_ref().err())
+            .collect()
     }
 
-    ///
-    /// Checks if there is at least one warning.
-    ///
-    pub fn has_warnings(&self) -> bool {
-        self.messages
-            .iter()
-            .any(|message| message.severity == "warning")
+    fn warnings(&self) -> Vec<&StandardJsonOutputError> {
+        self.messages.iter().collect()
     }
 
-    ///
-    /// Collects errors into one message and bails, if there is at least one error.
-    ///
-    pub fn collect_errors(&self) -> anyhow::Result<()> {
-        if !self.has_errors() {
-            return Ok(());
-        }
-
-        anyhow::bail!(
-            "{}",
-            self.contracts
-                .values()
-                .filter_map(|result| result.as_ref().err())
-                .map(|error| error.to_string())
-                .collect::<Vec<String>>()
-                .join("\n")
-        );
-    }
-
-    ///
-    /// Checks for errors, exiting the application if there is at least one error.
-    ///
-    pub fn exit_on_error(&self) {
-        if !self.has_errors() {
-            return;
-        }
-
-        std::io::stderr()
-            .write_all(
-                self.contracts
-                    .values()
-                    .filter_map(|result| result.as_ref().err())
-                    .map(|error| error.to_string())
-                    .collect::<Vec<String>>()
-                    .join("\n")
-                    .as_bytes(),
-            )
-            .expect("Stderr writing error");
-        std::process::exit(era_compiler_common::EXIT_CODE_FAILURE);
-    }
-
-    ///
-    /// Removes warnings from the list of messages and prints them to stderr.
-    ///
-    pub fn take_and_write_warnings(&mut self) {
-        if !self.has_warnings() {
-            return;
-        }
-        writeln!(
-            std::io::stderr(),
-            "{}",
-            self.messages
-                .iter()
-                .filter(|error| error.severity == "warning")
-                .map(|error| error.to_string())
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-        .expect("Stderr writing error");
-        self.messages
-            .retain(|message| message.severity != "warning");
+    fn remove_warnings(&mut self) {
+        self.messages.clear();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ pub use self::solc::standard_json::input::Input as SolcStandardJsonInput;
 pub use self::solc::standard_json::output::contract::evm::bytecode::Bytecode as SolcStandardJsonOutputContractEVMBytecode;
 pub use self::solc::standard_json::output::contract::evm::EVM as SolcStandardJsonOutputContractEVM;
 pub use self::solc::standard_json::output::contract::Contract as SolcStandardJsonOutputContract;
+pub use self::solc::standard_json::output::error::collectable::Collectable as CollectableError;
 pub use self::solc::standard_json::output::error::source_location::SourceLocation as SolcStandardJsonOutputErrorSourceLocation;
 pub use self::solc::standard_json::output::error::Error as SolcStandardJsonOutputError;
 pub use self::solc::standard_json::output::Output as SolcStandardJsonOutput;

--- a/src/solc/standard_json/output/error/collectable.rs
+++ b/src/solc/standard_json/output/error/collectable.rs
@@ -1,0 +1,105 @@
+//!
+//! The collectable errors trait.
+//!
+
+use std::io::Write;
+
+use crate::solc::standard_json::output::error::Error;
+
+///
+/// The collectable errors trait.
+///
+/// Should be implemented by entities that can collect errors, and perform actions
+/// on them as a list upon request.
+///
+pub trait Collectable {
+    ///
+    /// Returns errors as a list.
+    ///
+    fn errors(&self) -> Vec<&Error>;
+
+    ///
+    /// Returns warnings as a list.
+    ///
+    fn warnings(&self) -> Vec<&Error>;
+
+    ///
+    /// Removes warnings from the list of messages.
+    ///
+    fn remove_warnings(&mut self);
+
+    ///
+    /// Checks if there is at least one error.
+    ///
+    fn has_errors(&self) -> bool {
+        !self.errors().is_empty()
+    }
+
+    ///
+    /// Checks if there is at least one warning.
+    ///
+    fn has_warnings(&self) -> bool {
+        !self.warnings().is_empty()
+    }
+
+    ///
+    /// Collects errors into one message and bails, if there is at least one error.
+    ///
+    fn collect_errors(&self) -> anyhow::Result<()> {
+        if !self.has_errors() {
+            return Ok(());
+        }
+
+        anyhow::bail!(
+            "{}",
+            self.errors()
+                .iter()
+                .map(|error| error.to_string())
+                .collect::<Vec<String>>()
+                .join("\n")
+        );
+    }
+
+    ///
+    /// Checks for errors, exiting the application if there is at least one error.
+    ///
+    fn exit_on_error(&self) {
+        if !self.has_errors() {
+            return;
+        }
+
+        std::io::stderr()
+            .write_all(
+                self.errors()
+                    .iter()
+                    .map(|error| error.to_string())
+                    .collect::<Vec<String>>()
+                    .join("\n")
+                    .as_bytes(),
+            )
+            .expect("Stderr writing error");
+        std::process::exit(era_compiler_common::EXIT_CODE_FAILURE);
+    }
+
+    ///
+    /// Removes warnings from the list of messages and prints them to stderr.
+    ///
+    fn take_and_write_warnings(&mut self) {
+        if !self.has_warnings() {
+            return;
+        }
+
+        writeln!(
+            std::io::stderr(),
+            "{}",
+            self.warnings()
+                .iter()
+                .map(|error| error.to_string())
+                .collect::<Vec<String>>()
+                .join("\n")
+        )
+        .expect("Stderr writing error");
+
+        self.remove_warnings();
+    }
+}

--- a/src/solc/standard_json/output/error/mod.rs
+++ b/src/solc/standard_json/output/error/mod.rs
@@ -2,6 +2,7 @@
 //! The `solc --standard-json` output error.
 //!
 
+pub mod collectable;
 pub mod mapped_location;
 pub mod source_location;
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -24,6 +24,7 @@ use crate::solc::pipeline::Pipeline as SolcPipeline;
 use crate::solc::standard_json::input::settings::optimizer::Optimizer as SolcStandardJsonInputSettingsOptimizer;
 use crate::solc::standard_json::input::settings::selection::Selection as SolcStandardJsonInputSettingsSelection;
 use crate::solc::standard_json::input::Input as SolcStandardJsonInput;
+use crate::solc::standard_json::output::error::collectable::Collectable as CollectableError;
 use crate::solc::standard_json::output::Output as SolcStandardJsonOutput;
 use crate::solc::Compiler as SolcCompiler;
 use crate::warning::Warning;


### PR DESCRIPTION
# What ❔

Moves common solc error handling code to a trait.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
