### PR TITLE
feat: remove obsolete warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Parallelization in AST and IR parsing
 - Location resolution for EraVM-specific messages in standard JSON output
+- The `suppress-errors` parameter to disable some compilation errors
 
 ### Changed
 
@@ -13,7 +14,12 @@
 - AST and IRs are not emitted anymore if not explicitly requested
 - Empty files and contracts are pruned from standard JSON output
 - ASCII boxes are made more compatible with original messages of solc
+- `<address payable>.send/transfer(<X>)` now triggers a compilation error
 - Updated to Rust v1.79.0
+
+### Removed
+
+- Obsolete warnings for `extcodesize` and `ecrecover`
 
 ### Fixed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,17 +13,18 @@ pub(crate) mod build_eravm;
 pub(crate) mod build_evm;
 pub(crate) mod r#const;
 pub(crate) mod evmla;
+pub(crate) mod message_type;
 pub(crate) mod missing_libraries;
 pub(crate) mod process;
 pub(crate) mod project;
 pub(crate) mod solc;
-pub(crate) mod warning;
 pub(crate) mod yul;
 
 pub use self::build_eravm::contract::Contract as EraVMContractBuild;
 pub use self::build_eravm::Build as EraVMBuild;
 pub use self::build_evm::contract::Contract as EVMContractBuild;
 pub use self::build_evm::Build as EVMBuild;
+pub use self::message_type::MessageType;
 pub use self::process::input_eravm::Input as EraVMProcessInput;
 pub use self::process::input_evm::Input as EVMProcessInput;
 pub use self::process::output_eravm::Output as EraVMProcessOutput;
@@ -54,7 +55,6 @@ pub use self::solc::standard_json::output::error::Error as SolcStandardJsonOutpu
 pub use self::solc::standard_json::output::Output as SolcStandardJsonOutput;
 pub use self::solc::version::Version as SolcVersion;
 pub use self::solc::Compiler as SolcCompiler;
-pub use self::warning::Warning;
 
 mod tests;
 
@@ -264,7 +264,8 @@ pub fn standard_output_eravm(
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
     llvm_options: Vec<String>,
     output_assembly: bool,
-    suppressed_warnings: Option<Vec<Warning>>,
+    suppressed_errors: Vec<MessageType>,
+    suppressed_warnings: Vec<MessageType>,
     threads: Option<usize>,
     debug_config: Option<era_compiler_llvm_context::DebugConfig>,
 ) -> anyhow::Result<EraVMBuild> {
@@ -293,6 +294,7 @@ pub fn standard_output_eravm(
         enable_eravm_extensions,
         false,
         llvm_options.clone(),
+        suppressed_errors,
         suppressed_warnings,
     )?;
     let sources = solc_input.sources()?;
@@ -381,7 +383,8 @@ pub fn standard_output_evm(
         false,
         false,
         llvm_options.clone(),
-        None,
+        vec![],
+        vec![],
     )?;
     let sources = solc_input.sources()?;
     let libraries = solc_input.settings.libraries.clone().unwrap_or_default();
@@ -751,7 +754,8 @@ pub fn combined_json_eravm(
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
     llvm_options: Vec<String>,
     output_assembly: bool,
-    suppressed_warnings: Option<Vec<Warning>>,
+    suppressed_errors: Vec<MessageType>,
+    suppressed_warnings: Vec<MessageType>,
     threads: Option<usize>,
     debug_config: Option<era_compiler_llvm_context::DebugConfig>,
 ) -> anyhow::Result<()> {
@@ -775,6 +779,7 @@ pub fn combined_json_eravm(
         optimizer_settings,
         llvm_options,
         output_assembly,
+        suppressed_errors,
         suppressed_warnings,
         threads,
         debug_config,

--- a/src/message_type.rs
+++ b/src/message_type.rs
@@ -1,5 +1,5 @@
 //!
-//! The compiler warning.
+//! The compiler message type.
 //!
 
 use std::str::FromStr;
@@ -8,23 +8,20 @@ use serde::Deserialize;
 use serde::Serialize;
 
 ///
-/// The compiler warning.
+/// The compiler message type.
 ///
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Warning {
-    /// The warning for eponymous feature.
-    EcRecover,
-    /// The warning for eponymous feature.
+pub enum MessageType {
+    /// The error for eponymous feature.
     SendTransfer,
-    /// The warning for eponymous feature.
-    ExtCodeSize,
+
     /// The warning for eponymous feature.
     TxOrigin,
 }
 
-impl Warning {
+impl MessageType {
     ///
-    /// Converts string arguments into an array of warnings.
+    /// Converts string arguments into an array of messages.
     ///
     pub fn try_from_strings(strings: &[String]) -> Result<Vec<Self>, anyhow::Error> {
         strings
@@ -34,16 +31,14 @@ impl Warning {
     }
 }
 
-impl FromStr for Warning {
+impl FromStr for MessageType {
     type Err = anyhow::Error;
 
     fn from_str(string: &str) -> Result<Self, Self::Err> {
         match string {
-            "ecrecover" => Ok(Self::EcRecover),
             "sendtransfer" => Ok(Self::SendTransfer),
-            "extcodesize" => Ok(Self::ExtCodeSize),
             "txorigin" => Ok(Self::TxOrigin),
-            _ => Err(anyhow::anyhow!("Invalid warning: {}", string)),
+            r#type => Err(anyhow::anyhow!("Invalid message type: {type}")),
         }
     }
 }

--- a/src/solc/mod.rs
+++ b/src/solc/mod.rs
@@ -95,7 +95,8 @@ impl Compiler {
         include_paths: Vec<String>,
         allow_paths: Option<String>,
     ) -> anyhow::Result<StandardJsonOutput> {
-        let suppressed_warnings = input.suppressed_warnings.take().unwrap_or_default();
+        let mut suppressed_messages = input.suppressed_errors.take().unwrap_or_default();
+        suppressed_messages.extend(input.suppressed_warnings.take().unwrap_or_default());
 
         let mut command = std::process::Command::new(self.executable.as_str());
         command.stdin(std::process::Stdio::piped());
@@ -170,7 +171,7 @@ impl Compiler {
                 sources,
                 &self.version,
                 pipeline,
-                suppressed_warnings.as_slice(),
+                suppressed_messages.as_slice(),
             )?;
         }
         solc_output.remove_evm();

--- a/src/solc/standard_json/input/mod.rs
+++ b/src/solc/standard_json/input/mod.rs
@@ -14,11 +14,11 @@ use std::path::PathBuf;
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::ParallelIterator;
 
+use crate::message_type::MessageType;
 use crate::solc::pipeline::Pipeline as SolcPipeline;
 use crate::solc::standard_json::input::settings::metadata::Metadata as SolcStandardJsonInputSettingsMetadata;
 use crate::solc::standard_json::input::settings::optimizer::Optimizer as SolcStandardJsonInputSettingsOptimizer;
 use crate::solc::standard_json::input::settings::selection::Selection as SolcStandardJsonInputSettingsSelection;
-use crate::warning::Warning;
 
 use self::language::Language;
 use self::settings::Settings;
@@ -37,9 +37,12 @@ pub struct Input {
     /// The compiler settings.
     pub settings: Settings,
 
+    /// The suppressed errors.
+    #[serde(skip_serializing)]
+    pub suppressed_errors: Option<Vec<MessageType>>,
     /// The suppressed warnings.
     #[serde(skip_serializing)]
-    pub suppressed_warnings: Option<Vec<Warning>>,
+    pub suppressed_warnings: Option<Vec<MessageType>>,
 }
 
 impl Input {
@@ -93,7 +96,8 @@ impl Input {
         enable_eravm_extensions: bool,
         detect_missing_libraries: bool,
         llvm_options: Vec<String>,
-        suppressed_warnings: Option<Vec<Warning>>,
+        suppressed_errors: Vec<MessageType>,
+        suppressed_warnings: Vec<MessageType>,
     ) -> anyhow::Result<Self> {
         let mut paths: BTreeSet<PathBuf> = paths.iter().cloned().collect();
         let libraries = Settings::parse_libraries(library_map)?;
@@ -126,7 +130,8 @@ impl Input {
                 llvm_options,
                 metadata,
             ),
-            suppressed_warnings,
+            suppressed_errors: Some(suppressed_errors),
+            suppressed_warnings: Some(suppressed_warnings),
         })
     }
 
@@ -146,7 +151,8 @@ impl Input {
         enable_eravm_extensions: bool,
         detect_missing_libraries: bool,
         llvm_options: Vec<String>,
-        suppressed_warnings: Option<Vec<Warning>>,
+        suppressed_errors: Vec<MessageType>,
+        suppressed_warnings: Vec<MessageType>,
     ) -> anyhow::Result<Self> {
         let sources = sources
             .into_iter()
@@ -169,7 +175,8 @@ impl Input {
                 llvm_options,
                 metadata,
             ),
-            suppressed_warnings,
+            suppressed_errors: Some(suppressed_errors),
+            suppressed_warnings: Some(suppressed_warnings),
         })
     }
 
@@ -204,6 +211,7 @@ impl Input {
                 llvm_options,
                 None,
             ),
+            suppressed_errors: None,
             suppressed_warnings: None,
         }
     }
@@ -244,6 +252,7 @@ impl Input {
                 llvm_options,
                 None,
             ),
+            suppressed_errors: None,
             suppressed_warnings: None,
         }
     }

--- a/src/solc/standard_json/output/mod.rs
+++ b/src/solc/standard_json/output/mod.rs
@@ -15,11 +15,11 @@ use rayon::iter::ParallelIterator;
 
 use crate::evmla::assembly::instruction::Instruction;
 use crate::evmla::assembly::Assembly;
+use crate::message_type::MessageType;
 use crate::solc::pipeline::Pipeline as SolcPipeline;
 use crate::solc::standard_json::input::settings::selection::file::flag::Flag as SelectionFlag;
 use crate::solc::standard_json::output::contract::evm::EVM as StandardJSONOutputContractEVM;
 use crate::solc::version::Version as SolcVersion;
-use crate::warning::Warning;
 
 use self::contract::Contract;
 use self::error::collectable::Collectable as CollectableError;
@@ -226,7 +226,7 @@ impl Output {
         sources: &BTreeMap<String, String>,
         version: &SolcVersion,
         pipeline: SolcPipeline,
-        suppressed_warnings: &[Warning],
+        suppressed_messages: &[MessageType],
     ) -> anyhow::Result<()> {
         let source_asts = match self.sources.as_ref() {
             Some(sources) => sources,
@@ -250,7 +250,7 @@ impl Output {
                             sources,
                             version,
                             pipeline,
-                            suppressed_warnings,
+                            suppressed_messages,
                         )
                     })
                     .unwrap_or_default()

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -19,6 +19,7 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use crate::message_type::MessageType;
 use crate::project::Project;
 use crate::solc::pipeline::Pipeline as SolcPipeline;
 use crate::solc::standard_json::input::settings::optimizer::Optimizer as SolcStandardJsonInputSettingsOptimizer;
@@ -27,7 +28,6 @@ use crate::solc::standard_json::input::Input as SolcStandardJsonInput;
 use crate::solc::standard_json::output::error::collectable::Collectable as CollectableError;
 use crate::solc::standard_json::output::Output as SolcStandardJsonOutput;
 use crate::solc::Compiler as SolcCompiler;
-use crate::warning::Warning;
 
 ///
 /// Builds the Solidity project and returns the standard JSON output.
@@ -65,7 +65,8 @@ pub fn build_solidity(
         true,
         false,
         vec![],
-        None,
+        vec![],
+        vec![],
     )?;
 
     let mut solc_output = solc_compiler.standard_json(
@@ -147,7 +148,8 @@ pub fn build_solidity_and_detect_missing_libraries(
         false,
         false,
         vec![],
-        None,
+        vec![],
+        vec![],
     )?;
 
     let mut solc_output = solc_compiler.standard_json(
@@ -362,7 +364,7 @@ pub fn check_solidity_warning(
     libraries: BTreeMap<String, BTreeMap<String, String>>,
     pipeline: SolcPipeline,
     skip_for_zkvm_edition: bool,
-    suppressed_warnings: Option<Vec<Warning>>,
+    suppressed_warnings: Vec<MessageType>,
 ) -> anyhow::Result<bool> {
     check_dependencies();
 
@@ -386,6 +388,7 @@ pub fn check_solidity_warning(
         false,
         false,
         false,
+        vec![],
         vec![],
         suppressed_warnings,
     )?;

--- a/src/zksolc/arguments.rs
+++ b/src/zksolc/arguments.rs
@@ -176,10 +176,15 @@ pub struct Arguments {
     #[structopt(long = "bin")]
     pub output_binary: bool,
 
+    /// Suppress specified errors.
+    /// Available arguments: `sendtransfer`.
+    #[structopt(long = "suppress-errors")]
+    pub suppressed_errors: Option<Vec<String>>,
+
     /// Suppress specified warnings.
-    /// Available arguments: `ecrecover`, `sendtransfer`, `extcodesize`, `txorigin`, `blocktimestamp`, `blocknumber`, `blockhash`.
+    /// Available arguments: `txorigin`.
     #[structopt(long = "suppress-warnings")]
-    pub suppress_warnings: Option<Vec<String>>,
+    pub suppressed_warnings: Option<Vec<String>>,
 
     /// Dump all IRs to files in the specified directory.
     /// Only for testing and debugging.

--- a/src/zksolc/main.rs
+++ b/src/zksolc/main.rs
@@ -133,12 +133,12 @@ fn main_inner(
         .map(|options| options.split(' ').map(|option| option.to_owned()).collect())
         .unwrap_or_default();
 
-    let suppressed_warnings = match arguments.suppress_warnings {
-        Some(warnings) => Some(era_compiler_solidity::Warning::try_from_strings(
-            warnings.as_slice(),
-        )?),
-        None => None,
-    };
+    let suppressed_errors = era_compiler_solidity::MessageType::try_from_strings(
+        arguments.suppressed_errors.unwrap_or_default().as_slice(),
+    )?;
+    let suppressed_warnings = era_compiler_solidity::MessageType::try_from_strings(
+        arguments.suppressed_warnings.unwrap_or_default().as_slice(),
+    )?;
 
     let debug_config = match arguments.debug_output_directory {
         Some(ref debug_output_directory) => {
@@ -236,6 +236,7 @@ fn main_inner(
                     optimizer_settings,
                     llvm_options,
                     arguments.output_assembly,
+                    suppressed_errors,
                     suppressed_warnings,
                     arguments.threads,
                     debug_config,
@@ -266,6 +267,7 @@ fn main_inner(
                     optimizer_settings,
                     llvm_options,
                     arguments.output_assembly,
+                    suppressed_errors,
                     suppressed_warnings,
                     arguments.threads,
                     debug_config,


### PR DESCRIPTION
# What ❔

1. Removed obsolete warnings for `ecrecover` and `extcodesize`.
2. `send`/`transfer` now trigger an error with ZKsync edition of solc.
3. Added the `suppress-errors` parameter to suppress the error above.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
