### PR TITLE
chore: remove ASCII boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - All messages are now written to JSON output in standard JSON mode
 - AST and IRs are not emitted anymore if not explicitly requested
 - Empty files and contracts are pruned from standard JSON output
-- ASCII boxes are made more compatible with original messages of solc
+- Message formats are made more compatible with original messages of solc
 - `<address payable>.send/transfer(<X>)` now triggers a compilation error
 - Updated to Rust v1.79.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,15 @@
 ### Removed
 
 - Obsolete warnings for `extcodesize` and `ecrecover`
+- EVM-specific warnings which solc has been emitting unconditionally
 
 ### Fixed
 
 - Dependency graph inefficiency that caused excessive compilation time
 - Removed JSON stream readers which are much slower than strings and vectors
-- Filtered out several EVM-specific warnings from standard JSON output
 - Missing output with non-canonical input paths in combined JSON output
+- Missing warnings with solc v0.4.x and v0.5.x due to differences in AST
+- The unknown `bytecodeHash` error in standard JSON mode with solc v0.5.x
 
 ## [1.5.0] - 2024-06-10
 

--- a/src/build_eravm/contract.rs
+++ b/src/build_eravm/contract.rs
@@ -97,13 +97,9 @@ impl Contract {
                 );
             } else {
                 File::create(&file_path)
-                    .map_err(|error| {
-                        anyhow::anyhow!("File {:?} creating error: {}", file_path, error)
-                    })?
+                    .map_err(|error| anyhow::anyhow!("File {:?} creating: {}", file_path, error))?
                     .write_all(assembly.as_bytes())
-                    .map_err(|error| {
-                        anyhow::anyhow!("File {:?} writing error: {}", file_path, error)
-                    })?;
+                    .map_err(|error| anyhow::anyhow!("File {:?} writing: {}", file_path, error))?;
             }
         }
 
@@ -124,15 +120,11 @@ impl Contract {
                 );
             } else {
                 File::create(&file_path)
-                    .map_err(|error| {
-                        anyhow::anyhow!("File {:?} creating error: {}", file_path, error)
-                    })?
+                    .map_err(|error| anyhow::anyhow!("File {:?} creating: {}", file_path, error))?
                     .write_all(
                         format!("0x{}", hex::encode(self.build.bytecode.as_slice())).as_bytes(),
                     )
-                    .map_err(|error| {
-                        anyhow::anyhow!("File {:?} writing error: {}", file_path, error)
-                    })?;
+                    .map_err(|error| anyhow::anyhow!("File {:?} writing: {}", file_path, error))?;
             }
         }
 

--- a/src/build_evm/contract.rs
+++ b/src/build_evm/contract.rs
@@ -114,11 +114,11 @@ impl Contract {
                 } else {
                     File::create(&file_path)
                         .map_err(|error| {
-                            anyhow::anyhow!("File {:?} creating error: {}", file_path, error)
+                            anyhow::anyhow!("File {:?} creating: {}", file_path, error)
                         })?
                         .write_all(format!("0x{}", hex::encode(bytecode.as_slice())).as_bytes())
                         .map_err(|error| {
-                            anyhow::anyhow!("File {:?} writing error: {}", file_path, error)
+                            anyhow::anyhow!("File {:?} writing: {}", file_path, error)
                         })?;
                 }
             }

--- a/src/message_type.rs
+++ b/src/message_type.rs
@@ -38,7 +38,7 @@ impl FromStr for MessageType {
         match string {
             "sendtransfer" => Ok(Self::SendTransfer),
             "txorigin" => Ok(Self::TxOrigin),
-            r#type => Err(anyhow::anyhow!("Invalid message type: {type}")),
+            r#type => Err(anyhow::anyhow!("Invalid suppressed message type: {type}")),
         }
     }
 }

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -102,7 +102,7 @@ where
 
     let mut process = command
         .spawn()
-        .unwrap_or_else(|error| panic!("{executable:?} subprocess spawning error: {error:?}"));
+        .unwrap_or_else(|error| panic!("{executable:?} subprocess spawning: {error:?}"));
 
     let stdin = process
         .stdin
@@ -111,13 +111,11 @@ where
     let stdin_input = serde_json::to_vec(&input).expect("Always valid");
     stdin
         .write_all(stdin_input.as_slice())
-        .unwrap_or_else(
-            |error| panic!("{executable:?} subprocess stdin writing error: {error:?}",),
-        );
+        .unwrap_or_else(|error| panic!("{executable:?} subprocess stdin writing: {error:?}",));
 
-    let result = process.wait_with_output().unwrap_or_else(|error| {
-        panic!("{executable:?} subprocess output reading error: {error:?}")
-    });
+    let result = process
+        .wait_with_output()
+        .unwrap_or_else(|error| panic!("{executable:?} subprocess output reading: {error:?}"));
     era_compiler_common::deserialize_from_slice(result.stdout.as_slice())
-        .unwrap_or_else(|error| panic!("{executable:?} subprocess stdout parsing error: {error:?}"))
+        .unwrap_or_else(|error| panic!("{executable:?} subprocess stdout parsing: {error:?}"))
 }

--- a/src/solc/standard_json/input/mod.rs
+++ b/src/solc/standard_json/input/mod.rs
@@ -108,11 +108,10 @@ impl Input {
         let sources = paths
             .into_par_iter()
             .map(|path| {
-                let source = Source::try_read(path.as_path())
-                    .unwrap_or_else(|error| panic!("Source code file {path:?} reading: {error}"));
-                (path.to_string_lossy().to_string(), source)
+                let source = Source::try_read(path.as_path())?;
+                Ok((path.to_string_lossy().to_string(), source))
             })
-            .collect();
+            .collect::<anyhow::Result<BTreeMap<String, Source>>>()?;
 
         Ok(Self {
             language,

--- a/src/solc/standard_json/input/settings/metadata.rs
+++ b/src/solc/standard_json/input/settings/metadata.rs
@@ -8,12 +8,13 @@
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Metadata {
-    /// The bytecode hash mode.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub bytecode_hash: Option<era_compiler_llvm_context::EraVMMetadataHash>,
     /// Whether to use literal content.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_literal_content: Option<bool>,
+
+    /// The bytecode hash mode.
+    #[serde(skip_serializing)]
+    pub bytecode_hash: Option<era_compiler_llvm_context::EraVMMetadataHash>,
 }
 
 impl Metadata {

--- a/src/solc/standard_json/input/source.rs
+++ b/src/solc/standard_json/input/source.rs
@@ -29,11 +29,11 @@ impl Source {
             let mut solidity_code = String::with_capacity(16384);
             std::io::stdin()
                 .read_to_string(&mut solidity_code)
-                .map_err(|error| anyhow::anyhow!("<stdin> reading error: {error}"))?;
+                .map_err(|error| anyhow::anyhow!("<stdin> reading: {error}"))?;
             solidity_code
         } else {
             std::fs::read_to_string(path)
-                .map_err(|error| anyhow::anyhow!("File {path:?} reading error: {error}"))?
+                .map_err(|error| anyhow::anyhow!("File {path:?} reading: {error}"))?
         };
 
         Ok(Self {

--- a/src/solc/standard_json/output/error/mapped_location.rs
+++ b/src/solc/standard_json/output/error/mapped_location.rs
@@ -109,12 +109,12 @@ impl<'a> std::fmt::Display for MappedLocation<'a> {
                 if let (Some(source_code_line), Some(length)) = (self.source_code_line, self.length)
                 {
                     let line_number_length = line.to_string().len();
-                    writeln!(f, "{} ═╦> {path}", " ".repeat(line_number_length))?;
-                    writeln!(f, " {} ║", " ".repeat(line_number_length))?;
-                    writeln!(f, " {line} ║ {source_code_line}")?;
+                    writeln!(f, "{} --> {path}", " ".repeat(line_number_length))?;
+                    writeln!(f, " {} |", " ".repeat(line_number_length))?;
+                    writeln!(f, " {line} | {source_code_line}")?;
                     writeln!(
                         f,
-                        " {} ║ {} {}",
+                        " {} | {} {}",
                         " ".repeat(line_number_length),
                         " ".repeat(column),
                         "^".repeat(std::cmp::min(length, source_code_line.len() - column))

--- a/src/solc/standard_json/output/error/mod.rs
+++ b/src/solc/standard_json/output/error/mod.rs
@@ -55,33 +55,9 @@ impl Error {
         S: std::fmt::Display,
     {
         let message = message.to_string();
-        let mut message_line_length = message
-            .lines()
-            .max_by_key(|line| line.len())
-            .map(|line| line.len())
-            .unwrap_or_else(|| message.len());
-        message_line_length = std::cmp::max(message_line_length, Self::DEFAULT_ERROR_LINE_LENGTH);
 
-        let mut formatted_message = format!(
-            "{type}: ╠{}╗",
-            "═".repeat(message_line_length - r#type.len())
-        );
-        formatted_message.push('\n');
-        formatted_message.push_str(format!("║ {} ║", " ".repeat(message_line_length)).as_str());
-        formatted_message.push('\n');
-        formatted_message.push_str(
-            message
-                .trim()
-                .lines()
-                .map(|line| format!("║ {line}{} ║", " ".repeat(message_line_length - line.len())))
-                .collect::<Vec<String>>()
-                .join("\n")
-                .as_str(),
-        );
-        formatted_message.push('\n');
-        formatted_message.push_str(format!("║ {} ║", " ".repeat(message_line_length)).as_str());
-        formatted_message.push('\n');
-        formatted_message.push_str(format!("╚═{}═╝", "═".repeat(message_line_length)).as_str());
+        let mut formatted_message = format!("{type}: ");
+        formatted_message.push_str(message.trim());
         formatted_message.push('\n');
         if let Some(ref source_location) = source_location {
             let source_code = sources.and_then(|sources| {
@@ -147,8 +123,7 @@ You are checking for 'tx.origin', which might lead to unexpected behavior.
 ZKsync Era comes with native account abstraction support, and therefore the initiator of a
 transaction might be different from the contract calling your code. It is highly recommended NOT
 to rely on tx.origin, but use msg.sender instead.
-Learn more about Account Abstraction at
-    https://docs.zksync.io/build/developer-reference/account-abstraction/
+Learn more about Account Abstraction at https://docs.zksync.io/build/developer-reference/account-abstraction/
 "#;
 
         Self::new_warning(
@@ -172,8 +147,7 @@ Such calls will fail depending on the pubdata costs.
 Please use 'payable(<address>).call{value: <X>}("")' instead, but be careful with the
 reentrancy attack. `send` and `transfer` send limited amount of gas that prevents reentrancy,
 whereas `<address>.call{value: <X>}` sends all gas to the callee.
-Learn more about reentrancy at
-    https://docs.soliditylang.org/en/latest/security-considerations.html#reentrancy
+Learn more about reentrancy at https://docs.soliditylang.org/en/latest/security-considerations.html#reentrancy
 "#;
 
         Self::new_error(
@@ -192,8 +166,10 @@ Learn more about reentrancy at
         sources: &BTreeMap<String, String>,
     ) -> Self {
         let message = r#"
-Internal function pointers are not supported in EVM legacy assembly pipeline.
-Please use the latest solc with Yul codegen instead.
+Internal function pointers are not supported in the EVM assembly pipeline.
+Please do one of the following:
+    1. Use the ZKsync fork of the Solidity compiler: https://github.com/matter-labs/era-solidity/releases
+    2. Switch to the latest solc with Yul assembly pipeline: https://docs.soliditylang.org/en/latest/yul.html
 "#;
 
         Self::new_error(

--- a/src/solc/standard_json/output/mod.rs
+++ b/src/solc/standard_json/output/mod.rs
@@ -375,7 +375,7 @@ impl CollectableError for Output {
 
     fn remove_warnings(&mut self) {
         if let Some(ref mut errors) = self.errors {
-            errors.retain(|error| error.severity == "warning");
+            errors.retain(|error| error.severity != "warning");
         }
     }
 }

--- a/src/solc/standard_json/output/source.rs
+++ b/src/solc/standard_json/output/source.rs
@@ -79,17 +79,24 @@ impl Source {
     ) -> Option<SolcStandardJsonOutputError> {
         let ast = ast.as_object()?;
 
-        if ast.get("nodeType")?.as_str()? != "YulFunctionCall" {
-            return None;
-        }
-        if ast
-            .get("functionName")?
-            .as_object()?
-            .get("name")?
-            .as_str()?
-            != "origin"
-        {
-            return None;
+        match ast.get("nodeType")?.as_str()? {
+            "InlineAssembly" => {
+                if !ast.get("operations")?.as_str()?.contains("origin()") {
+                    return None;
+                }
+            }
+            "YulFunctionCall" => {
+                if ast
+                    .get("functionName")?
+                    .as_object()?
+                    .get("name")?
+                    .as_str()?
+                    != "origin"
+                {
+                    return None;
+                }
+            }
+            _ => return None,
         }
 
         Some(SolcStandardJsonOutputError::warning_tx_origin(

--- a/src/solc/standard_json/output/source.rs
+++ b/src/solc/standard_json/output/source.rs
@@ -51,14 +51,14 @@ impl Source {
             return None;
         }
         let member_name = expression.get("memberName")?.as_str()?;
-        if member_name != "send" && member_name != "transfer" {
+        if !["send", "transfer"].contains(&member_name) {
             return None;
         }
 
         let expression = expression.get("expression")?.as_object()?;
         let type_descriptions = expression.get("typeDescriptions")?.as_object()?;
         let type_identifier = type_descriptions.get("typeIdentifier")?.as_str()?;
-        if type_identifier != "t_address" && type_identifier != "t_address_payable" {
+        if type_identifier != "t_address_payable" {
             return None;
         }
 

--- a/src/tests/messages.rs
+++ b/src/tests/messages.rs
@@ -9,6 +9,14 @@ use std::collections::BTreeMap;
 use crate::message_type::MessageType;
 use crate::solc::pipeline::Pipeline as SolcPipeline;
 
+pub const TX_ORIGIN_TEST_SOURCE: &str = r#"
+contract TxOriginExample {
+    function main() private {
+        address txOrigin = tx.origin;
+    }
+}
+"#;
+
 #[test]
 fn tx_origin() {
     assert!(super::check_solidity_warning(
@@ -36,22 +44,14 @@ fn tx_origin_suppressed() {
 }
 
 pub const TX_ORIGIN_ASSEMBLY_TEST_SOURCE: &str = r#"
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
-
 contract TxOriginExample {
-    function isOriginSender() public view returns (bool) {
-        address txOrigin;
-        address sender = msg.sender;
-
+    function main() private {
         assembly {
-            txOrigin := origin() // Get the transaction origin using the 'origin' instruction
+            let txOrigin := origin()
         }
-
-        return txOrigin == sender;
     }
 }
-    "#;
+"#;
 
 #[test]
 fn tx_origin_assembly() {
@@ -80,22 +80,13 @@ fn tx_origin_assembly_suppressed() {
 }
 
 pub const SEND_TEST_SOURCE: &str = r#"
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
-
 contract SendExample {
-    address payable public recipient;
-
-    constructor(address payable _recipient) {
-        recipient = _recipient;
-    }
-
-    function forwardEther() external payable {
-        bool success = recipient.send(msg.value);
-        require(success, "Failed to send Ether");
+    function s() public payable returns (bool) {
+        address r = address(0);
+        return payable(r).send(msg.value);
     }
 }
-    "#;
+"#;
 
 #[test]
 fn send() {
@@ -124,21 +115,13 @@ fn send_suppressed() {
 }
 
 pub const TRANSFER_TEST_SOURCE: &str = r#"
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
-
 contract TransferExample {
-    address payable public recipient;
-
-    constructor(address payable _recipient) {
-        recipient = _recipient;
-    }
-
-    function forwardEther() external payable {
-        recipient.transfer(msg.value);
+    function s() public payable {
+        address r = address(0);
+        payable(r).transfer(msg.value);
     }
 }
-    "#;
+"#;
 
 #[test]
 fn transfer() {
@@ -165,17 +148,6 @@ fn transfer_suppressed() {
     )
     .expect("Test failure"));
 }
-
-pub const TX_ORIGIN_TEST_SOURCE: &str = r#"
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
-
-contract TxOriginExample {
-    function isOriginSender() public view returns (bool) {
-        return tx.origin == msg.sender;
-    }
-}
-    "#;
 
 #[test]
 fn internal_function_pointer_argument() {

--- a/src/yul/error.rs
+++ b/src/yul/error.rs
@@ -11,9 +11,9 @@ use crate::yul::parser::error::Error as ParserError;
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum Error {
     /// The lexer error.
-    #[error("Lexical error: {0}")]
+    #[error("Lexical: {0}")]
     Lexer(#[from] LexerError),
     /// The parser error.
-    #[error("Syntax error: {0}")]
+    #[error("Syntax: {0}")]
     Parser(#[from] ParserError),
 }


### PR DESCRIPTION
# What ❔

1. Removes ASCII boxes from compiler messages.
2. Fixes broken standard JSON I/O with solc 0.5.x due to unsupported `bytecodeHash` field.
3. Fixes the issue when warnings were sometimes printed twice.
4. Fixes warnings for `origin()` in assembly that were not emitted for solc 0.5 and older.

## Why ❔

1. They sometimes break formatting and require a lot of work to fix it. Our warnings are not that critical anymore, whereas critical ones have been converted to errors.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
