### PR TITLE
ci: support unit tests with sanitizers

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -5,10 +5,18 @@ inputs:
     description: 'Specific build target triplet.'
     required: false
     default: ''
+  sanitizer:
+    description: 'Sanitizer to use for build.'
+    required: false
+    default: ''
   release-suffix:
     description: 'Suffix to use for release name.'
     required: false
     default: ''
+  build-type:
+    description: 'Type of build: release or debug.'
+    required: false
+    default: 'release'
 runs:
   using: "composite"
   steps:
@@ -20,11 +28,23 @@ runs:
         rustup target add ${{ inputs.target }}
         echo "target=--target ${{ inputs.target }}" >> $GITHUB_OUTPUT
 
+    - name: Install nightly
+      if: inputs.sanitizer != '' && inputs.target != ''
+      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
+      run: |
+        rustup install nightly-${{ inputs.target }}
+        rustup component add rust-src --toolchain nightly-${{ inputs.target }}
+
     - name: Build zksolc
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       run: |
-        cargo build --release ${{ steps.build-target.outputs.target }}
-        echo "${PWD}/target/${{ inputs.target }}/release" >> "${GITHUB_PATH}"
+        if [ '${{ inputs.sanitizer }}' != '' ]; then
+          export RUSTFLAGS="-Z sanitizer=${{ inputs.sanitizer }}"
+          NIGHTLY='+nightly -Zbuild-std'
+        fi
+        [ ${{ inputs.build-type }} = 'release' ] && RELEASE="--release"
+        cargo ${NIGHTLY} build ${RELEASE} ${{ steps.build-target.outputs.target }}
+        echo "${PWD}/target/${{ inputs.target }}/${{ inputs.build-type }}" >> "${GITHUB_PATH}"
 
     - name: Prepare binary
       if: inputs.release-suffix != ''
@@ -33,8 +53,8 @@ runs:
         mkdir -p ./releases/${{ inputs.release-suffix }}
         [ ! -z "$GITHUB_REF_NAME" ] && TAG_SUFFIX="-v${GITHUB_REF_NAME}"
         [ "$RUNNER_OS" = "Windows" ] && WIN_SUFFIX=".exe"
-        strip "./target/${{ matrix.target }}/release/zksolc${WIN_SUFFIX}"
-        mv "./target/${{ matrix.target }}/release/zksolc${WIN_SUFFIX}" \
+        strip "./target/${{ matrix.target }}/${{ inputs.build-type }}/zksolc${WIN_SUFFIX}"
+        mv "./target/${{ matrix.target }}/${{ inputs.build-type }}/zksolc${WIN_SUFFIX}" \
           "./releases/${{ inputs.release-suffix }}/zksolc-${{ inputs.release-suffix }}${TAG_SUFFIX}${WIN_SUFFIX}"
 
     - name: Upload binary

--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -5,32 +5,50 @@ inputs:
     description: 'Specific target triplet.'
     required: false
     default: ''
+  sanitizer:
+    description: 'Sanitizer to use for test.'
+    required: false
+    default: ''
   results-xml:
     description: 'Output unit tests results XML filename.'
     required: false
     default: 'unit-tests-results.xml'
+  build-type:
+    description: 'Type of build: release or debug.'
+    required: false
+    default: 'release'
 runs:
   using: "composite"
   steps:
     - name: Define build target
       id: build-target
       if: inputs.target != ''
-      env:
-        RUSTC_BOOTSTRAP: "1"
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       run: |
         rustup target add ${{ inputs.target }}
         echo "target=--target ${{ inputs.target }}" >> "${GITHUB_OUTPUT}"
 
+    - name: Install nightly
+      if: inputs.sanitizer != '' && inputs.target != ''
+      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
+      run: |
+        rustup install nightly-${{ inputs.target }}
+        rustup component add rust-src --toolchain nightly-${{ inputs.target }}
+
     - name: Run unit tests
       continue-on-error: true
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       env:
-        RUSTC_BOOTSTRAP: "1"
+        RUSTC_BOOTSTRAP: 1
       run: |
         cargo install cargo2junit
-        cargo test ${{ steps.build-target.outputs.target }} -- -Z unstable-options \
-          --format json > results.json
+        if [ '${{ inputs.sanitizer }}' != '' ]; then
+          export RUSTFLAGS="-Z sanitizer=${{ inputs.sanitizer }}"
+          NIGHTLY="+nightly"
+        fi
+        [ ${{ inputs.build-type }} = 'release' ] && RELEASE="--release"
+        cargo ${NIGHTLY} test ${RELEASE} ${{ steps.build-target.outputs.target }} -- -Z unstable-options \
+          --format json | tee -a results.json
         if [ $? -eq 0 ]; then
           cargo2junit < results.json > "${{ inputs.results-xml }}"
         else

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -1,0 +1,67 @@
+name: Sanitizers tests
+
+on:
+  workflow_call:
+    inputs:
+      # For more information about the supported sanitizers in Rust, see:
+      # https://rustc-dev-guide.rust-lang.org/sanitizers.html
+      rust-sanitizer:
+        required: false
+        default: 'address'
+        type: string
+        description: 'A sanitizer to build Rust code with. Possible values are: address, cfi, hwaddress, kcfi, leak, memory or thread'
+      # For more information about the supported sanitizers in LLVM, see `LLVM_USE_SANITIZER` option in:
+      # https://www.llvm.org/docs/CMake.html
+      llvm-sanitizer:
+        required: false
+        default: 'Address'
+        type: string
+        description: 'A sanitizer to build LLVM with. Possible values are Address, Memory, MemoryWithOrigins, Undefined, Thread, DataFlow, and Address;Undefined'
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  run-with-sanitizers:
+    runs-on: ci-runner-compiler
+    container:
+      image: matterlabs/llvm_runner:ubuntu22-llvm17-latest
+      options: -m 110g
+    env:
+      TARGET: x86_64-unknown-linux-gnu
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build LLVM
+        uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@v1
+        with:
+          target-env: 'gnu'
+          enable-assertions: 'false'
+          builder-extra-args: "--sanitizer ${{ inputs.llvm-sanitizer || 'Address' }}"
+
+      - name: Build zksolc
+        uses: ./.github/actions/build
+        with:
+          target: ${{ env.TARGET }}
+          sanitizer: ${{ inputs.rust-sanitizer || 'address' }}
+          build-type: 'debug'
+
+      - name: Install solc compiler
+        uses: ./.github/actions/install-solc
+
+      - name: Run tests
+        uses: ./.github/actions/unit-tests
+        with:
+          target: ${{ env.TARGET }}
+          sanitizer: ${{ inputs.rust-sanitizer || 'address' }}
+          build-type: 'debug'
+
+      - name: Send Slack notification
+        uses: 8398a7/action-slack@v3
+        if: failure() && github.event_name == 'schedule'
+        with:
+          status: ${{ job.status }}
+          fields: repo,commit,author,action,eventName,ref,workflow,job,took
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
# What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

Support builds and unit tests run with sanitizers:
* As per request triggered manually from [actions page](https://github.com/matter-labs/era-compiler-solidity/actions/workflows/sanitizers.yaml)
* Weekly with address sanitizer

## Tests

[Testing workflow](https://github.com/matter-labs/era-compiler-solidity/actions/runs/9680376340/job/26708389798?pr=110)

## Why ❔

To add a capability to find more bugs using sanitizers.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
