### PR TITLE
release: support universal macosx binary

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,25 +102,23 @@ jobs:
 
   prepare-release:
     name: Prepare release
-    runs-on: ubuntu-latest
+    runs-on: matterlabs-ci-runner
+    container:
+      image: matterlabs/llvm_runner:ubuntu22-llvm17-latest
     needs: build
     steps:
+
       - name: Checkout source
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || '' }}
 
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: release*
-          path: releases
-
       - name: Identify release name
         id: release
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+          if [ '${{ github.event_name }}' = 'workflow_dispatch' ]; then
             VERSION_OR_SHA=$(git rev-parse --short HEAD)
             echo "version_or_sha=${VERSION_OR_SHA}" >> $GITHUB_OUTPUT
             echo "full_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
@@ -130,6 +128,25 @@ jobs:
             echo "version_or_sha=${VERSION_OR_SHA}" >> $GITHUB_OUTPUT
             echo "release_title=${VERSION_OR_SHA}" >> $GITHUB_OUTPUT
           fi
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release*
+          path: releases
+
+      - name: Prepare universal macos binary
+        if: github.ref_type == 'tag' || (inputs.release_macos_amd64 && inputs.release_macos_arm64)
+        env:
+          MACOSX_UNIVERSAL_SUFFIX: "macosx"
+        run: |
+          OUTDIR="./releases/release-${MACOSX_UNIVERSAL_SUFFIX}/${MACOSX_UNIVERSAL_SUFFIX}"
+          mkdir -p "${OUTDIR}"
+          [ ! -z "$GITHUB_REF_NAME" ] && TAG_SUFFIX="-v${GITHUB_REF_NAME}"
+          OUTPUT="${OUTDIR}/zksolc-${MACOSX_UNIVERSAL_SUFFIX}${TAG_SUFFIX}"
+          llvm-lipo -create -output "${OUTPUT}" \
+            ./releases/release-macosx-amd64/macosx-amd64/zksolc-macosx-amd64${TAG_SUFFIX} \
+            ./releases/release-macosx-arm64/macosx-arm64/zksolc-macosx-arm64${TAG_SUFFIX}
 
       - name: Get changelog
         if: github.ref_type == 'tag'


### PR DESCRIPTION
# What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

Add support for universal MacOS binary (x64 + arm64). For now, it is added additionally to existing arm64 and amd64 binaries.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Tests

[Testing workflow](https://github.com/matter-labs/era-compiler-solidity/actions/runs/9741681761)

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
