### PR TITLE
fix: replace md5 with keccak256

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,14 +308,13 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#d7be90b6918f05b9d77d4ac4cc2949a3525baf19"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#31946ecd883be041c5b232a85a778501f4cc3d85"
 dependencies = [
  "anyhow",
  "era-compiler-common",
  "hex",
  "inkwell",
  "itertools",
- "md5",
  "num",
  "semver",
  "serde",
@@ -333,7 +332,6 @@ dependencies = [
  "era-compiler-llvm-context",
  "hex",
  "inkwell",
- "md5",
  "mimalloc",
  "normpath",
  "num",
@@ -723,12 +721,6 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
-
-[[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ regex = "1.10"
 hex = "0.4"
 num = "0.4"
 sha3 = "0.10"
-md5 = "0.7"
 
 zkevm-assembly = { git = "https://github.com/matter-labs/era-zkEVM-assembly", branch = "v1.5.0" }
 

--- a/src/evmla/assembly/instruction/jump.rs
+++ b/src/evmla/assembly/instruction/jump.rs
@@ -11,7 +11,7 @@ use era_compiler_llvm_context::IEVMLAFunction;
 pub fn unconditional<'ctx, C>(
     context: &mut C,
     destination: num::BigUint,
-    stack_hash: md5::Digest,
+    stack_hash: [u8; era_compiler_common::BYTE_LENGTH_FIELD],
 ) -> anyhow::Result<()>
 where
     C: era_compiler_llvm_context::IContext<'ctx>,
@@ -46,7 +46,7 @@ where
 pub fn conditional<'ctx, C>(
     context: &mut C,
     destination: num::BigUint,
-    stack_hash: md5::Digest,
+    stack_hash: [u8; era_compiler_common::BYTE_LENGTH_FIELD],
     stack_height: usize,
 ) -> anyhow::Result<()>
 where

--- a/src/evmla/assembly/instruction/mod.rs
+++ b/src/evmla/assembly/instruction/mod.rs
@@ -340,7 +340,7 @@ impl Instruction {
     pub fn recursive_call(
         name: String,
         entry_key: era_compiler_llvm_context::BlockKey,
-        stack_hash: md5::Digest,
+        stack_hash: [u8; era_compiler_common::BYTE_LENGTH_FIELD],
         input_size: usize,
         output_size: usize,
         return_address: era_compiler_llvm_context::BlockKey,

--- a/src/evmla/assembly/instruction/name.rs
+++ b/src/evmla/assembly/instruction/name.rs
@@ -371,7 +371,7 @@ pub enum Name {
         /// The called function key.
         entry_key: era_compiler_llvm_context::BlockKey,
         /// The stack state hash after return.
-        stack_hash: md5::Digest,
+        stack_hash: [u8; era_compiler_common::BYTE_LENGTH_FIELD],
         /// The input size.
         input_size: usize,
         /// The output size.

--- a/src/evmla/ethereal_ir/function/block/element/stack/mod.rs
+++ b/src/evmla/ethereal_ir/function/block/element/stack/mod.rs
@@ -4,6 +4,8 @@
 
 pub mod element;
 
+use sha3::Digest;
+
 use self::element::Element;
 
 ///
@@ -49,15 +51,15 @@ impl Stack {
     ///
     /// Each block clone has its own initial stack state, which uniquely identifies the block.
     ///
-    pub fn hash(&self) -> md5::Digest {
-        let mut hash_context = md5::Context::new();
+    pub fn hash(&self) -> [u8; era_compiler_common::BYTE_LENGTH_FIELD] {
+        let mut hasher = sha3::Sha3_256::new();
         for element in self.elements.iter() {
             match element {
-                Element::Tag(tag) => hash_context.consume(tag.to_bytes_be()),
-                _ => hash_context.consume([0]),
+                Element::Tag(tag) => hasher.update(tag.to_bytes_be()),
+                _ => hasher.update([0]),
             }
         }
-        hash_context.compute()
+        hasher.finalize().into()
     }
 
     ///

--- a/src/evmla/ethereal_ir/function/block/mod.rs
+++ b/src/evmla/ethereal_ir/function/block/mod.rs
@@ -34,7 +34,7 @@ pub struct Block {
     /// The stack.
     pub stack: ElementStack,
     /// The extra block hashes for alternative routes.
-    pub extra_hashes: Vec<md5::Digest>,
+    pub extra_hashes: Vec<[u8; era_compiler_common::BYTE_LENGTH_FIELD]>,
 }
 
 impl Block {

--- a/src/evmla/ethereal_ir/function/visited_element.rs
+++ b/src/evmla/ethereal_ir/function/visited_element.rs
@@ -12,14 +12,17 @@ pub struct VisitedElement {
     /// The block key.
     pub block_key: era_compiler_llvm_context::BlockKey,
     /// The initial stack state hash.
-    pub stack_hash: md5::Digest,
+    pub stack_hash: [u8; era_compiler_common::BYTE_LENGTH_FIELD],
 }
 
 impl VisitedElement {
     ///
     /// A shortcut constructor.
     ///
-    pub fn new(block_key: era_compiler_llvm_context::BlockKey, stack_hash: md5::Digest) -> Self {
+    pub fn new(
+        block_key: era_compiler_llvm_context::BlockKey,
+        stack_hash: [u8; era_compiler_common::BYTE_LENGTH_FIELD],
+    ) -> Self {
         Self {
             block_key,
             stack_hash,


### PR DESCRIPTION
# What ❔

Replaces md5 with keccak256 in the EVM assembly translator.

## Why ❔

md5 is shorter and worse.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
