### PR TITLE
release: add version guard between cargo, tag and changelog

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,6 +114,20 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || '' }}
 
+      - name: Get changelog
+        if: github.ref_type == 'tag'
+        id: changelog_reader
+        uses: mindsers/changelog-reader-action@v2
+        with:
+          validation_level: warn
+          path: ./CHANGELOG.md
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release*
+          path: releases
+
       - name: Identify release name
         id: release
         run: |
@@ -129,11 +143,18 @@ jobs:
             echo "release_title=${VERSION_OR_SHA}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: release*
-          path: releases
+      - name: Check release version
+        if: github.ref_type == 'tag'
+        run: |
+          TAG="${{ steps.release.outputs.version_or_sha }}"
+          CARGO_PACKAGE_VERSION="$(cargo pkgid | cut -d "#" -f2)"
+          CHANGELOG_VERSION="${{ steps.changelog_reader.outputs.version }}"
+          # All versions must be equal
+          if [ "${CARGO_PACKAGE_VERSION}" != "${TAG}" ] || [ "${CARGO_PACKAGE_VERSION}" != "${CHANGELOG_VERSION}" ]; then
+            echo "Version mismatch: TAG=${TAG}, CARGO_PACKAGE_VERSION=${CARGO_PACKAGE_VERSION}, CHANGELOG_VERSION=${CHANGELOG_VERSION}"
+            echo "Please update the version in Cargo.toml, CHANGELOG.md and tag the commit with the same version."
+            exit 1
+          fi
 
       - name: Prepare universal macos binary
         if: github.ref_type == 'tag' || (inputs.release_macos_amd64 && inputs.release_macos_arm64)
@@ -147,14 +168,6 @@ jobs:
           llvm-lipo -create -output "${OUTPUT}" \
             ./releases/release-macosx-amd64/macosx-amd64/zksolc-macosx-amd64${TAG_SUFFIX} \
             ./releases/release-macosx-arm64/macosx-arm64/zksolc-macosx-arm64${TAG_SUFFIX}
-
-      - name: Get changelog
-        if: github.ref_type == 'tag'
-        id: changelog_reader
-        uses: mindsers/changelog-reader-action@v2
-        with:
-          validation_level: warn
-          path: ./CHANGELOG.md
 
       - name: Prepare release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
# What ❔

Add version guard that cargo package, created tag, and version in changelog must be equal when releasing.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Tests

[Testing workflow](https://github.com/matter-labs/era-compiler-solidity/actions/runs/9839561820/job/27162678159)

## Why ❔

To prevent discrepancies between `--version` output and releases.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
