### PR TITLE
ci: support static gnu binaries

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -17,6 +17,7 @@ inputs:
     description: 'Type of build: release or debug.'
     required: false
     default: 'release'
+
 runs:
   using: "composite"
   steps:
@@ -28,22 +29,19 @@ runs:
         rustup target add ${{ inputs.target }}
         echo "target=--target ${{ inputs.target }}" >> $GITHUB_OUTPUT
 
-    - name: Install nightly
-      if: inputs.sanitizer != '' && inputs.target != ''
-      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
-      run: |
-        rustup install nightly-${{ inputs.target }}
-        rustup component add rust-src --toolchain nightly-${{ inputs.target }}
-
     - name: Build zksolc
-      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
+      env:
+        RUSTC_BOOTSTRAP: 1
+        RUSTFLAGS: '-C target-feature=+crt-static'
+      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash -ex {0}' }}
       run: |
         if [ '${{ inputs.sanitizer }}' != '' ]; then
-          export RUSTFLAGS="-Z sanitizer=${{ inputs.sanitizer }}"
-          NIGHTLY='+nightly -Zbuild-std'
+          rustup component add rust-src --toolchain "$(rustc --version | cut -d ' ' -f2)-${TARGET}"
+          export RUSTFLAGS="${RUSTFLAGS} -Z sanitizer=${{ inputs.sanitizer }}"
+          BUILD_STD_LIB='-Zbuild-std'
         fi
         [ ${{ inputs.build-type }} = 'release' ] && RELEASE="--release"
-        cargo ${NIGHTLY} build ${RELEASE} ${{ steps.build-target.outputs.target }}
+        cargo ${BUILD_STD_LIB} build ${RELEASE} ${{ steps.build-target.outputs.target }}
         echo "${PWD}/target/${{ inputs.target }}/${{ inputs.build-type }}" >> "${GITHUB_PATH}"
 
     - name: Prepare binary

--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -17,6 +17,7 @@ inputs:
     description: 'Type of build: release or debug.'
     required: false
     default: 'release'
+
 runs:
   using: "composite"
   steps:
@@ -28,26 +29,19 @@ runs:
         rustup target add ${{ inputs.target }}
         echo "target=--target ${{ inputs.target }}" >> "${GITHUB_OUTPUT}"
 
-    - name: Install nightly
-      if: inputs.sanitizer != '' && inputs.target != ''
-      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
-      run: |
-        rustup install nightly-${{ inputs.target }}
-        rustup component add rust-src --toolchain nightly-${{ inputs.target }}
-
     - name: Run unit tests
       continue-on-error: true
-      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
+      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash -ex {0}' }}
       env:
         RUSTC_BOOTSTRAP: 1
       run: |
         cargo install cargo2junit
         if [ '${{ inputs.sanitizer }}' != '' ]; then
           export RUSTFLAGS="-Z sanitizer=${{ inputs.sanitizer }}"
-          NIGHTLY="+nightly"
         fi
         [ ${{ inputs.build-type }} = 'release' ] && RELEASE="--release"
-        cargo ${NIGHTLY} test ${RELEASE} ${{ steps.build-target.outputs.target }} -- -Z unstable-options \
+
+        cargo test ${RELEASE} ${{ steps.build-target.outputs.target }} -- -Z unstable-options \
           --format json | tee -a results.json
         if [ $? -eq 0 ]; then
           cargo2junit < results.json > "${{ inputs.results-xml }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,13 +22,23 @@ on:
         required: false
         type: boolean
         default: true
-      release_linux_amd64:
-        description: "Release for Linux amd64?"
+      release_linux_amd64_musl:
+        description: "Release for Linux amd64 musl?"
         required: false
         type: boolean
         default: true
-      release_linux_arm64:
-        description: "Release for Linux arm64?"
+      release_linux_arm64_musl:
+        description: "Release for Linux arm64 musl?"
+        required: false
+        type: boolean
+        default: true
+      release_linux_amd64_gnu:
+        description: "Release for Linux amd64 gnu?"
+        required: false
+        type: boolean
+        default: true
+      release_linux_arm64_gnu:
+        description: "Release for Linux arm64 gnu?"
         required: false
         type: boolean
         default: true
@@ -56,17 +66,21 @@ jobs:
           WINDOWS='{"name":"Windows","runner":"windows-2022-github-hosted-64core","release-suffix":"windows-amd64-gnu"}'
           MACOS_AMD64='{"name":"MacOS-x86","runner":"macos-12-large","release-suffix":"macosx-amd64"}'
           MACOS_ARM64='{"name":"MacOS-arm64","runner":["self-hosted","macOS","ARM64"],"release-suffix":"macosx-arm64"}'
-          LINUX_AMD64='{"name":"Linux-AMD64","runner":"matterlabs-ci-runner","image":"matterlabs/llvm_runner:ubuntu22-llvm17-latest","target":"x86_64-unknown-linux-musl","release-suffix":"linux-amd64-musl"}'
-          LINUX_ARM64='{"name":"Linux-ARM64","runner":"matterlabs-ci-runner-arm","image":"matterlabs/llvm_runner:ubuntu22-llvm17-latest","target":"aarch64-unknown-linux-musl","release-suffix":"linux-arm64-musl"}'
+          LINUX_AMD64_GNU='{"name":"Linux-AMD64-gnu","runner":"matterlabs-ci-runner","image":"ghcr.io/matter-labs/zksync-llvm-runner:latest","target":"x86_64-unknown-linux-gnu","release-suffix":"linux-amd64-gnu"}'
+          LINUX_ARM64_GNU='{"name":"Linux-ARM64-gnu","runner":"matterlabs-ci-runner-arm","image":"ghcr.io/matter-labs/zksync-llvm-runner:latest","target":"aarch64-unknown-linux-gnu","release-suffix":"linux-arm64-gnu"}'
+          LINUX_AMD64_MUSL='{"name":"Linux-AMD64-musl","runner":"matterlabs-ci-runner","image":"ghcr.io/matter-labs/zksync-llvm-runner:latest","target":"x86_64-unknown-linux-musl","release-suffix":"linux-amd64-musl"}'
+          LINUX_ARM64_MUSL='{"name":"Linux-ARM64-musl","runner":"matterlabs-ci-runner-arm","image":"ghcr.io/matter-labs/zksync-llvm-runner:latest","target":"aarch64-unknown-linux-musl","release-suffix":"linux-arm64-musl"}'
           # Disable platforms for non-tag builds if user requested
           if [ ${GITHUB_REF_TYPE} != tag ]; then
             [ ${{ github.event.inputs.release_windows_amd64 }} != true ] && WINDOWS=
             [ ${{ github.event.inputs.release_macos_amd64 }} != true ] && MACOS_AMD64=
             [ ${{ github.event.inputs.release_macos_arm64 }} != true ] && MACOS_ARM64=
-            [ ${{ github.event.inputs.release_linux_amd64 }} != true ] && LINUX_AMD64=
-            [ ${{ github.event.inputs.release_linux_arm64 }} != true ] && LINUX_ARM64=
+            [ ${{ github.event.inputs.release_linux_amd64_gnu }} != true ] && LINUX_AMD64_GNU=
+            [ ${{ github.event.inputs.release_linux_arm64_gnu }} != true ] && LINUX_ARM64_GNU=
+            [ ${{ github.event.inputs.release_linux_amd64_musl }} != true ] && LINUX_AMD64_MUSL=
+            [ ${{ github.event.inputs.release_linux_arm64_musl }} != true ] && LINUX_ARM64_MUSL=
           fi
-          PLATFORMS=(${WINDOWS} ${MACOS_AMD64} ${MACOS_ARM64} ${LINUX_AMD64} ${LINUX_ARM64})
+          PLATFORMS=(${WINDOWS} ${MACOS_AMD64} ${MACOS_ARM64} ${LINUX_AMD64_GNU} ${LINUX_ARM64_GNU} ${LINUX_AMD64_MUSL} ${LINUX_ARM64_MUSL})
           echo "matrix={ \"include\": [ $(IFS=, ; echo "${PLATFORMS[*]}") ] }" | tee -a "${GITHUB_OUTPUT}"
 
   build:
@@ -91,7 +105,7 @@ jobs:
       - name: Build LLVM
         uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@v1
         with:
-          target-env: 'musl'
+          target-env: ${{ contains(matrix.target, 'musl') && 'musl' || 'gnu' }}
           enable-assertions: 'false'
 
       - name: Build zksolc
@@ -104,7 +118,7 @@ jobs:
     name: Prepare release
     runs-on: matterlabs-ci-runner
     container:
-      image: matterlabs/llvm_runner:ubuntu22-llvm17-latest
+      image: ghcr.io/matter-labs/zksync-llvm-runner:latest
     needs: build
     steps:
 

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -1,7 +1,7 @@
 name: Sanitizers tests
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       # For more information about the supported sanitizers in Rust, see:
       # https://rustc-dev-guide.rust-lang.org/sanitizers.html
@@ -24,7 +24,7 @@ jobs:
   run-with-sanitizers:
     runs-on: ci-runner-compiler
     container:
-      image: matterlabs/llvm_runner:ubuntu22-llvm17-latest
+      image: ghcr.io/matter-labs/zksync-llvm-runner:latest
       options: -m 110g
     env:
       TARGET: x86_64-unknown-linux-gnu
@@ -38,7 +38,7 @@ jobs:
         with:
           target-env: 'gnu'
           enable-assertions: 'false'
-          builder-extra-args: "--sanitizer ${{ inputs.llvm-sanitizer || 'Address' }}"
+          sanitizer: ${{ inputs.llvm-sanitizer || 'Address' }}
 
       - name: Build zksolc
         uses: ./.github/actions/build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,13 +39,21 @@ jobs:
             runner: macos-12-large
           - name: "MacOS arm64"
             runner: [self-hosted, macOS, ARM64]
-          - name: "Linux x86"
+          - name: "Linux x86 gnu"
             runner: matterlabs-ci-runner
-            image: matterlabs/llvm_runner:ubuntu22-llvm17-latest
-            target: "x86_64-unknown-linux-musl"
-          - name: "Linux ARM64"
+            image: ghcr.io/matter-labs/zksync-llvm-runner:latest
+            target: "x86_64-unknown-linux-gnu"
+          - name: "Linux ARM64 gnu"
             runner: matterlabs-ci-runner-arm
-            image: matterlabs/llvm_runner:ubuntu22-llvm17-latest
+            image: ghcr.io/matter-labs/zksync-llvm-runner:latest
+            target: "aarch64-unknown-linux-gnu"
+          - name: "Linux x86 musl"
+            runner: matterlabs-ci-runner
+            image: ghcr.io/matter-labs/zksync-llvm-runner:latest
+            target: "x86_64-unknown-linux-musl"
+          - name: "Linux ARM64 musl"
+            runner: matterlabs-ci-runner-arm
+            image: ghcr.io/matter-labs/zksync-llvm-runner:latest
             target: "aarch64-unknown-linux-musl"
           - name: "Windows"
             runner: windows-2022-github-hosted-16core
@@ -75,14 +83,8 @@ jobs:
         if: steps.changed-files-yaml.outputs.cli_tests_only_changed != 'true'
         uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@v1
         with:
-          target-env: 'musl'
+          target-env: ${{ contains(matrix.target, 'musl') && 'musl' || 'gnu' }}
           enable-assertions: 'false'
-
-      - name: Cargo checks
-        if: steps.changed-files-yaml.outputs.cli_tests_only_changed != 'true' && matrix.name == 'Linux x86'
-        uses: matter-labs/era-compiler-ci/.github/actions/cargo-check@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build zksolc
         if: steps.changed-files-yaml.outputs.cli_tests_only_changed != 'true'
@@ -104,3 +106,9 @@ jobs:
         with:
           use-prebuilt-zksolc: ${{ steps.changed-files-yaml.outputs.cli_tests_only_changed }}
           zksolc-version: ${{ github.event.inputs.zksolc-version }}
+
+      - name: Cargo checks
+        if: steps.changed-files-yaml.outputs.cli_tests_only_changed != 'true' && matrix.name == 'Linux x86 gnu'
+        uses: matter-labs/era-compiler-ci/.github/actions/cargo-check@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,7 +696,7 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 [[package]]
 name = "llvm-sys"
 version = "170.0.1"
-source = "git+https://github.com/matter-labs-forks/llvm-sys.rs?branch=llvm-17.0#d165991787fe71259076aeabe25019f2e94c2a4b"
+source = "git+https://github.com/matter-labs-forks/llvm-sys.rs?branch=llvm-17.0#53ff49c016baaa75caded057f1d533995fce5ae0"
 dependencies = [
  "anyhow",
  "cc",


### PR DESCRIPTION
# What ❔

Support Linux GNU targets in addition to Musl ones:
* Two new targets `*-unknown-linux-gnu` to be tested
* Two new static binaries will be generated in the release with `*-linux-gnu` suffix.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To simplify and deprecate heavy and slow Musl targets in the future.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
