### PR TITLE
ci: add code coverage support with codecov

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: 'Type of build: release or debug.'
     required: false
     default: 'release'
+  enable-coverage:
+    description: 'Enable code coverage.'
+    required: false
+    default: 'false'
 
 runs:
   using: "composite"
@@ -41,6 +45,9 @@ runs:
           BUILD_STD_LIB='-Zbuild-std'
         fi
         [ ${{ inputs.build-type }} = 'release' ] && RELEASE="--release"
+        if [ '${{ inputs.enable-coverage }}' = 'true' ]; then
+          export RUSTFLAGS="${RUSTFLAGS} -C instrument-coverage"
+        fi
         cargo ${BUILD_STD_LIB} build ${RELEASE} ${{ steps.build-target.outputs.target }}
         echo "${PWD}/target/${{ inputs.target }}/${{ inputs.build-type }}" >> "${GITHUB_PATH}"
 

--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -17,6 +17,14 @@ inputs:
     description: 'Type of build: release or debug.'
     required: false
     default: 'release'
+  enable-coverage:
+    description: 'Enable code coverage.'
+    required: false
+    default: 'false'
+  coverage-token:
+    description: 'Codecov token.'
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -37,11 +45,19 @@ runs:
       run: |
         cargo install cargo2junit
         if [ '${{ inputs.sanitizer }}' != '' ]; then
-          export RUSTFLAGS="-Z sanitizer=${{ inputs.sanitizer }}"
+          rustup component add rust-src --toolchain "$(rustc --version | cut -d ' ' -f2)-${TARGET}"
+          export RUSTFLAGS="${RUSTFLAGS} -Z sanitizer=${{ inputs.sanitizer }}"
         fi
         [ ${{ inputs.build-type }} = 'release' ] && RELEASE="--release"
 
-        cargo test ${RELEASE} ${{ steps.build-target.outputs.target }} -- -Z unstable-options \
+        TEST_COMMAND="test"
+        if [ '${{ inputs.enable-coverage }}' = 'true' ]; then
+          cargo install cargo-llvm-cov
+          export LLVM_COV=$(which llvm-cov)
+          export LLVM_PROFDATA=$(which llvm-profdata)
+          TEST_COMMAND="llvm-cov --all-features --workspace --lcov --output-path lcov.info"
+        fi
+        cargo ${TEST_COMMAND} ${RELEASE} ${{ steps.build-target.outputs.target }} -- -Z unstable-options \
           --format json | tee -a results.json
         if [ $? -eq 0 ]; then
           cargo2junit < results.json > "${{ inputs.results-xml }}"
@@ -76,3 +92,11 @@ runs:
         files: ${{ inputs.results-xml }}
         action_fail_on_inconclusive: true
         comment_mode: off
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      if: inputs.enable-coverage == 'true'
+      with:
+        token: ${{ inputs.coverage-token }}
+        files: lcov.info
+        slug: ${{ github.repository }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,26 @@ jobs:
     uses: matter-labs/era-compiler-ci/.github/workflows/secrets-scanner.yaml@v1
     secrets: inherit
 
+  # Check for cargo issues
+  cargo-checks:
+    runs-on: matterlabs-ci-runner
+    container:
+      image: ghcr.io/matter-labs/zksync-llvm-runner:latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Build LLVM
+        uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@v1
+        with:
+          target-env: 'gnu'
+          enable-assertions: 'false'
+
+      - name: Cargo checks
+        uses: matter-labs/era-compiler-ci/.github/actions/cargo-check@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
   # Build and run unit and CLI tests
   build-and-test:
     strategy:
@@ -43,6 +63,7 @@ jobs:
             runner: matterlabs-ci-runner
             image: ghcr.io/matter-labs/zksync-llvm-runner:latest
             target: "x86_64-unknown-linux-gnu"
+            enable-coverage: 'true' # enable coverage on Linux GNU
           - name: "Linux ARM64 gnu"
             runner: matterlabs-ci-runner-arm
             image: ghcr.io/matter-labs/zksync-llvm-runner:latest
@@ -85,12 +106,14 @@ jobs:
         with:
           target-env: ${{ contains(matrix.target, 'musl') && 'musl' || 'gnu' }}
           enable-assertions: 'false'
+          enable-coverage: ${{ matrix.enable-coverage || 'false' }}
 
       - name: Build zksolc
         if: steps.changed-files-yaml.outputs.cli_tests_only_changed != 'true'
         uses: ./.github/actions/build
         with:
           target: ${{ matrix.target || '' }}
+          enable-coverage: ${{ matrix.enable-coverage || 'false' }}
 
       - name: Install solc compiler
         uses: ./.github/actions/install-solc
@@ -100,15 +123,11 @@ jobs:
         uses: ./.github/actions/unit-tests
         with:
           target: ${{ matrix.target || '' }}
+          enable-coverage: ${{ matrix.enable-coverage || 'false' }}
+          coverage-token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Run CLI tests
         uses: ./.github/actions/cli-tests
         with:
           use-prebuilt-zksolc: ${{ steps.changed-files-yaml.outputs.cli_tests_only_changed }}
           zksolc-version: ${{ github.event.inputs.zksolc-version }}
-
-      - name: Cargo checks
-        if: steps.changed-files-yaml.outputs.cli_tests_only_changed != 'true' && matrix.name == 'Linux x86 gnu'
-        uses: matter-labs/era-compiler-ci/.github/actions/cargo-check@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# What ❔

* [x] Add code coverage support and codecov.io integration.
* [x] Separate cargo checks into their own job to make workflows faster

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To monitor and improve code coverage for unit tests over time.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
