### PR TITLE
ci: fix sanitizers incompatibility with static libc

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -41,7 +41,7 @@ runs:
       run: |
         if [ '${{ inputs.sanitizer }}' != '' ]; then
           rustup component add rust-src --toolchain "$(rustc --version | cut -d ' ' -f2)-${TARGET}"
-          export RUSTFLAGS="${RUSTFLAGS} -Z sanitizer=${{ inputs.sanitizer }}"
+          export RUSTFLAGS="-Z sanitizer=${{ inputs.sanitizer }}"
           BUILD_STD_LIB='-Zbuild-std'
         fi
         [ ${{ inputs.build-type }} = 'release' ] && RELEASE="--release"


### PR DESCRIPTION
# What ❔

Disable static libc when running with sanitizers.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Static libc is incompatible with sanitizers run.

## Testing

[Testing workflow with sanitizers](https://github.com/matter-labs/era-compiler-solidity/actions/runs/10307324378)

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
