### PR TITLE
feat: move LLVM-independent data to common

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,28 +273,28 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 [[package]]
 name = "era-compiler-common"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#9b0143d1687b4b259e620aa292fa9dbb389dfb4d"
+source = "git+https://github.com/matter-labs/era-compiler-common?branch=az-cpr-1794-split-target-parameter-of-compiler-tester#96935671d9f82b61c47a725c9c5fb00fb984ea74"
 dependencies = [
  "anyhow",
+ "hex",
  "serde",
  "serde_json",
  "serde_stacker",
+ "sha3",
 ]
 
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#93c56db7d429a66b6535d6ce276e8bc0e4d7bfdf"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-cpr-1794-split-target-parameter-of-compiler-tester#7066216eebc93002a85d0cac86fd80405d9b1571"
 dependencies = [
  "anyhow",
  "era-compiler-common",
- "hex",
  "inkwell",
  "itertools",
  "num",
  "semver",
  "serde",
- "sha3",
  "zkevm_opcode_defs",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ hex = "0.4"
 num = "0.4"
 sha3 = "0.10"
 
-era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
+era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "az-cpr-1794-split-target-parameter-of-compiler-tester" }
+era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-cpr-1794-split-target-parameter-of-compiler-tester" }
 
 [dependencies.inkwell]
 git = "https://github.com/matter-labs-forks/inkwell"

--- a/src/evmla/assembly/mod.rs
+++ b/src/evmla/assembly/mod.rs
@@ -50,7 +50,7 @@ impl Assembly {
     ///
     pub fn keccak256(&self) -> String {
         let json = serde_json::to_vec(self).expect("Always valid");
-        era_compiler_llvm_context::eravm_utils::keccak256(json.as_slice())
+        era_compiler_common::Hash::keccak256(json.as_slice()).to_string()
     }
 
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,7 +283,7 @@ pub fn standard_output_eravm(
             optimizer_settings.is_fallback_to_size_enabled(),
         ),
         Some(SolcStandardJsonInputSettingsMetadata::new(
-            era_compiler_llvm_context::EraVMMetadataHash::None,
+            era_compiler_common::HashType::None,
             use_literal_content,
         )),
         force_evmla,
@@ -368,7 +368,7 @@ pub fn standard_output_evm(
             optimizer_settings.is_fallback_to_size_enabled(),
         ),
         Some(SolcStandardJsonInputSettingsMetadata::new(
-            era_compiler_llvm_context::EraVMMetadataHash::None,
+            era_compiler_common::HashType::None,
             use_literal_content,
         )),
         force_evmla,
@@ -451,9 +451,7 @@ pub fn standard_json_eravm(
         .unwrap_or_default()
         || detect_missing_libraries;
     let include_metadata_hash = match solc_input.settings.metadata {
-        Some(ref metadata) => {
-            metadata.bytecode_hash != Some(era_compiler_llvm_context::EraVMMetadataHash::None)
-        }
+        Some(ref metadata) => metadata.bytecode_hash != Some(era_compiler_common::HashType::None),
         None => true,
     };
     let output_assembly = solc_input
@@ -613,9 +611,7 @@ pub fn standard_json_evm(
     let llvm_options = solc_input.settings.llvm_options.take().unwrap_or_default();
 
     let include_metadata_hash = match solc_input.settings.metadata {
-        Some(ref metadata) => {
-            metadata.bytecode_hash != Some(era_compiler_llvm_context::EraVMMetadataHash::None)
-        }
+        Some(ref metadata) => metadata.bytecode_hash != Some(era_compiler_common::HashType::None),
         None => true,
     };
 

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -26,9 +26,9 @@ pub static EXECUTABLE: OnceLock<PathBuf> = OnceLock::new();
 ///
 /// Read input from `stdin`, compile a contract, and write the output to `stdout`.
 ///
-pub fn run(target: era_compiler_llvm_context::Target) {
+pub fn run(target: era_compiler_common::Target) {
     match target {
-        era_compiler_llvm_context::Target::EraVM => {
+        era_compiler_common::Target::EraVM => {
             let input_json =
                 std::io::read_to_string(std::io::stdin()).expect("Stdin reading error");
             let input: EraVMInput = era_compiler_common::deserialize_from_str(input_json.as_str())
@@ -52,7 +52,7 @@ pub fn run(target: era_compiler_llvm_context::Target) {
                 });
             serde_json::to_writer(std::io::stdout(), &result).expect("Stdout writing error");
         }
-        era_compiler_llvm_context::Target::EVM => {
+        era_compiler_common::Target::EVM => {
             let input_json =
                 std::io::read_to_string(std::io::stdin()).expect("Stdin reading error");
             let input: EVMInput = era_compiler_common::deserialize_from_str(input_json.as_str())
@@ -81,11 +81,7 @@ pub fn run(target: era_compiler_llvm_context::Target) {
 ///
 /// Runs this process recursively to compile a single contract.
 ///
-pub fn call<I, O>(
-    path: &str,
-    input: I,
-    target: era_compiler_llvm_context::Target,
-) -> crate::Result<O>
+pub fn call<I, O>(path: &str, input: I, target: era_compiler_common::Target) -> crate::Result<O>
 where
     I: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/src/project/contract/mod.rs
+++ b/src/project/contract/mod.rs
@@ -115,7 +115,7 @@ impl Contract {
             }
             IR::EraVMAssembly(eravm_assembly) => {
                 let target_machine = era_compiler_llvm_context::TargetMachine::new(
-                    era_compiler_llvm_context::Target::EraVM,
+                    era_compiler_common::Target::EraVM,
                     optimizer.settings(),
                     llvm_options.as_slice(),
                 )?;

--- a/src/project/thread_pool_eravm.rs
+++ b/src/project/thread_pool_eravm.rs
@@ -140,11 +140,8 @@ impl ThreadPool {
         let results = self.results.clone();
         let pool = self.to_owned();
         self.inner.evaluate(move || {
-            let result: crate::Result<EraVMOutput> = crate::process::call(
-                path.as_str(),
-                input,
-                era_compiler_llvm_context::Target::EraVM,
-            );
+            let result: crate::Result<EraVMOutput> =
+                crate::process::call(path.as_str(), input, era_compiler_common::Target::EraVM);
             results
                 .write()
                 .expect("Sync")

--- a/src/project/thread_pool_evm.rs
+++ b/src/project/thread_pool_evm.rs
@@ -134,7 +134,7 @@ impl ThreadPool {
         let pool = self.to_owned();
         self.inner.evaluate(move || {
             let result: crate::Result<EVMOutput> =
-                crate::process::call(path.as_str(), input, era_compiler_llvm_context::Target::EVM);
+                crate::process::call(path.as_str(), input, era_compiler_common::Target::EVM);
             results
                 .write()
                 .expect("Sync")

--- a/src/solc/standard_json/input/settings/metadata.rs
+++ b/src/solc/standard_json/input/settings/metadata.rs
@@ -14,17 +14,14 @@ pub struct Metadata {
 
     /// The bytecode hash mode.
     #[serde(skip_serializing)]
-    pub bytecode_hash: Option<era_compiler_llvm_context::EraVMMetadataHash>,
+    pub bytecode_hash: Option<era_compiler_common::HashType>,
 }
 
 impl Metadata {
     ///
     /// A shortcut constructor.
     ///
-    pub fn new(
-        bytecode_hash: era_compiler_llvm_context::EraVMMetadataHash,
-        use_literal_content: bool,
-    ) -> Self {
+    pub fn new(bytecode_hash: era_compiler_common::HashType, use_literal_content: bool) -> Self {
         Self {
             bytecode_hash: Some(bytecode_hash),
             use_literal_content: Some(use_literal_content),

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -43,7 +43,7 @@ pub fn build_solidity(
     check_dependencies(Some(solc_version));
 
     inkwell::support::enable_llvm_pretty_stack_trace();
-    era_compiler_llvm_context::initialize_target(era_compiler_llvm_context::Target::EraVM);
+    era_compiler_llvm_context::initialize_target(era_compiler_common::Target::EraVM);
     let _ = crate::process::EXECUTABLE.set(PathBuf::from(crate::r#const::DEFAULT_EXECUTABLE_NAME));
 
     let solc_compiler = SolcCompiler::new(
@@ -132,7 +132,7 @@ pub fn build_solidity_and_detect_missing_libraries(
     check_dependencies(Some(solc_version));
 
     inkwell::support::enable_llvm_pretty_stack_trace();
-    era_compiler_llvm_context::initialize_target(era_compiler_llvm_context::Target::EraVM);
+    era_compiler_llvm_context::initialize_target(era_compiler_common::Target::EraVM);
     let _ = crate::process::EXECUTABLE.set(PathBuf::from(crate::r#const::DEFAULT_EXECUTABLE_NAME));
 
     let solc_compiler = SolcCompiler::new(
@@ -203,7 +203,7 @@ pub fn build_yul(sources: BTreeMap<String, String>) -> anyhow::Result<SolcStanda
     check_dependencies(None);
 
     inkwell::support::enable_llvm_pretty_stack_trace();
-    era_compiler_llvm_context::initialize_target(era_compiler_llvm_context::Target::EraVM);
+    era_compiler_llvm_context::initialize_target(era_compiler_common::Target::EraVM);
     let _ = crate::process::EXECUTABLE.set(PathBuf::from(crate::r#const::DEFAULT_EXECUTABLE_NAME));
 
     let zksolc_version = semver::Version::parse(env!("CARGO_PKG_VERSION")).expect("Always valid");
@@ -252,7 +252,7 @@ pub fn build_yul_standard_json(
     check_dependencies(solc_compiler.map(|compiler| &compiler.version.default));
 
     inkwell::support::enable_llvm_pretty_stack_trace();
-    era_compiler_llvm_context::initialize_target(era_compiler_llvm_context::Target::EraVM);
+    era_compiler_llvm_context::initialize_target(era_compiler_common::Target::EraVM);
     let _ = crate::process::EXECUTABLE.set(PathBuf::from(crate::r#const::DEFAULT_EXECUTABLE_NAME));
 
     let zksolc_version = semver::Version::parse(env!("CARGO_PKG_VERSION")).expect("Always valid");
@@ -305,7 +305,7 @@ pub fn build_llvm_ir_standard_json(
     check_dependencies(None);
 
     inkwell::support::enable_llvm_pretty_stack_trace();
-    era_compiler_llvm_context::initialize_target(era_compiler_llvm_context::Target::EraVM);
+    era_compiler_llvm_context::initialize_target(era_compiler_common::Target::EraVM);
     let _ = crate::process::EXECUTABLE.set(PathBuf::from(crate::r#const::DEFAULT_EXECUTABLE_NAME));
 
     let zksolc_version = semver::Version::parse(env!("CARGO_PKG_VERSION")).expect("Always valid");
@@ -342,7 +342,7 @@ pub fn build_eravm_assembly_standard_json(
     check_dependencies(None);
 
     inkwell::support::enable_llvm_pretty_stack_trace();
-    era_compiler_llvm_context::initialize_target(era_compiler_llvm_context::Target::EraVM);
+    era_compiler_llvm_context::initialize_target(era_compiler_common::Target::EraVM);
     let _ = crate::process::EXECUTABLE.set(PathBuf::from(crate::r#const::DEFAULT_EXECUTABLE_NAME));
 
     let zksolc_version = semver::Version::parse(env!("CARGO_PKG_VERSION")).expect("Always valid");

--- a/src/zksolc/arguments.rs
+++ b/src/zksolc/arguments.rs
@@ -341,7 +341,7 @@ impl Arguments {
         }
 
         if self.eravm_assembly {
-            if Some(era_compiler_llvm_context::Target::EVM.to_string()) == self.target {
+            if Some(era_compiler_common::Target::EVM.to_string()) == self.target {
                 messages.push(SolcStandardJsonOutputError::new_error(
                     "EraVM assembly cannot be compiled to EVM bytecode.",
                     None,

--- a/src/zksolc/main.rs
+++ b/src/zksolc/main.rs
@@ -75,8 +75,8 @@ fn main_inner(
     }
 
     let target = match arguments.target {
-        Some(ref target) => era_compiler_llvm_context::Target::from_str(target.as_str())?,
-        None => era_compiler_llvm_context::Target::EraVM,
+        Some(ref target) => era_compiler_common::Target::from_str(target.as_str())?,
+        None => era_compiler_common::Target::EraVM,
     };
 
     let mut thread_pool_builder = rayon::ThreadPoolBuilder::new();
@@ -95,7 +95,7 @@ fn main_inner(
         era_compiler_solidity::run_recursive(target);
         return Ok(());
     }
-    if let era_compiler_llvm_context::Target::EVM = target {
+    if let era_compiler_common::Target::EVM = target {
         anyhow::bail!("The EVM target is under development and not available yet.")
     }
 
@@ -110,9 +110,8 @@ fn main_inner(
 
     let include_metadata_hash = match arguments.metadata_hash {
         Some(metadata_hash) => {
-            let metadata =
-                era_compiler_llvm_context::EraVMMetadataHash::from_str(metadata_hash.as_str())?;
-            metadata != era_compiler_llvm_context::EraVMMetadataHash::None
+            let metadata = era_compiler_common::HashType::from_str(metadata_hash.as_str())?;
+            metadata != era_compiler_common::HashType::None
         }
         None => true,
     };
@@ -153,7 +152,7 @@ fn main_inner(
     let enable_eravm_extensions = arguments.enable_eravm_extensions || arguments.system_mode;
 
     match target {
-        era_compiler_llvm_context::Target::EraVM => {
+        era_compiler_common::Target::EraVM => {
             let build = if arguments.yul {
                 era_compiler_solidity::yul_to_eravm(
                     input_files.as_slice(),
@@ -296,7 +295,7 @@ fn main_inner(
                 )?;
             }
         }
-        era_compiler_llvm_context::Target::EVM => {
+        era_compiler_common::Target::EVM => {
             let build = if arguments.yul {
                 era_compiler_solidity::yul_to_evm(
                     input_files.as_slice(),


### PR DESCRIPTION
# What ❔

Moves some LLVM-unrelated definitions to [the common crate](https://github.com/matter-labs/era-compiler-common/pull/17).

## Why ❔

They can be useful for some crates that doesn't want to depend on LLVM.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
