### PR TITLE
feat: set noinline attribute for all calls in -O0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "autocfg"
@@ -390,7 +390,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 [[package]]
 name = "era-compiler-common"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#503b2edb28958f6b096427aaabf05cf7994b4cb4"
+source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#46d12b9ac54c6382fae26f4b3fc7f88131ffb41d"
 dependencies = [
  "anyhow",
  "base58",
@@ -405,7 +405,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#b00192e637041b8a27f166568eedd99f258ba01d"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#8809df8ecd952972a9cba078b5f368df5c153c58"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -714,7 +714,7 @@ source = "git+https://github.com/matter-labs-forks/inkwell?branch=llvm-17#45cd0b
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -786,9 +786,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.156"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5f43f184355eefb8d17fc948dbecf6c13be3c141f20d834ae842193a448c72a"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -1003,7 +1003,7 @@ version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
@@ -1386,7 +1386,7 @@ checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1573,9 +1573,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.74"
+version = "2.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
+checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1614,7 +1614,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1705,9 +1705,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "which"
-version = "6.0.2"
+version = "6.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d9c5ed668ee1f17edb3b627225343d210006a90bb1e3745ce1f30b1fb115075"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
 dependencies = [
  "either",
  "home",
@@ -1861,7 +1861,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]

--- a/src/zksolc/arguments.rs
+++ b/src/zksolc/arguments.rs
@@ -87,7 +87,7 @@ pub struct Arguments {
     /// The EVM target version to generate IR for.
     /// See https://github.com/matter-labs/era-compiler-common/blob/main/src/evm_version.rs for reference.
     #[structopt(long = "evm-version")]
-    pub evm_version: Option<String>,
+    pub evm_version: Option<era_compiler_common::EVMVersion>,
 
     /// Specify addresses of deployable libraries. Syntax: `<libraryName>=<address> [, or whitespace] ...`.
     /// Addresses are interpreted as hexadecimal strings prefixed with `0x`.

--- a/src/zksolc/main.rs
+++ b/src/zksolc/main.rs
@@ -101,13 +101,6 @@ fn main_inner(
 
     let (input_files, remappings) = arguments.split_input_files_and_remappings()?;
 
-    let evm_version = match arguments.evm_version {
-        Some(evm_version) => Some(era_compiler_common::EVMVersion::try_from(
-            evm_version.as_str(),
-        )?),
-        None => None,
-    };
-
     let include_metadata_hash = match arguments.metadata_hash {
         Some(metadata_hash) => {
             let metadata = era_compiler_common::HashType::from_str(metadata_hash.as_str())?;
@@ -220,7 +213,7 @@ fn main_inner(
                     arguments.libraries,
                     &solc_compiler,
                     messages,
-                    evm_version,
+                    arguments.evm_version,
                     !arguments.disable_solc_optimizer,
                     arguments.force_evmla,
                     enable_eravm_extensions,
@@ -253,7 +246,7 @@ fn main_inner(
                     arguments.libraries,
                     &solc_compiler,
                     messages,
-                    evm_version,
+                    arguments.evm_version,
                     !arguments.disable_solc_optimizer,
                     arguments.force_evmla,
                     enable_eravm_extensions,
@@ -348,7 +341,7 @@ fn main_inner(
                     arguments.libraries,
                     &solc_compiler,
                     messages,
-                    evm_version,
+                    arguments.evm_version,
                     !arguments.disable_solc_optimizer,
                     arguments.force_evmla,
                     include_metadata_hash,
@@ -377,7 +370,7 @@ fn main_inner(
                     arguments.libraries,
                     &solc,
                     messages,
-                    evm_version,
+                    arguments.evm_version,
                     !arguments.disable_solc_optimizer,
                     arguments.force_evmla,
                     include_metadata_hash,


### PR DESCRIPTION
# What ❔

Sets the `noinline` attribute for all calls in `-O0`.

## Why ❔

It will prevent inlining of some runtime functions with `alwaysinline` attribute.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
