### PR TITLE
test: optimize parallel regression tests execution

### DIFF
--- a/era-compiler-solidity/tests/cli/asm.rs
+++ b/era-compiler-solidity/tests/cli/asm.rs
@@ -1,16 +1,14 @@
-pub mod cli_tests;
-#[cfg(test)]
-pub mod common;
+use crate::{cli, common};
 use predicates::prelude::*;
 
 #[test]
 fn run_zksolc_with_asm_by_default() -> anyhow::Result<()> {
     let _ = common::setup();
-    let args = &[cli_tests::TEST_SOLIDITY_CONTRACT_PATH, "--asm"];
+    let args = &[cli::TEST_SOLIDITY_CONTRACT_PATH, "--asm"];
     let invalid_args = &["--asm"];
 
     // Valid command
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     let result_status_code = result
         .success()
         .stdout(predicate::str::contains("__entry:"))
@@ -20,11 +18,11 @@ fn run_zksolc_with_asm_by_default() -> anyhow::Result<()> {
         .expect("No exit code.");
 
     // solc exit code == zksolc exit code
-    let solc_result = cli_tests::execute_solc(args)?;
+    let solc_result = cli::execute_solc(args)?;
     solc_result.code(result_status_code);
 
     // Run invalid: zksolc --asm
-    let invalid_result = cli_tests::execute_zksolc(invalid_args)?;
+    let invalid_result = cli::execute_zksolc(invalid_args)?;
     let invalid_result_status_code = invalid_result
         .failure()
         .stderr(
@@ -37,7 +35,7 @@ fn run_zksolc_with_asm_by_default() -> anyhow::Result<()> {
         .expect("No exit code.");
 
     // Invalid solc exit code == Invalid zksolc exit code
-    let invalid_solc_result = cli_tests::execute_solc(invalid_args)?;
+    let invalid_solc_result = cli::execute_solc(invalid_args)?;
     invalid_solc_result.code(invalid_result_status_code);
 
     Ok(())
@@ -46,9 +44,9 @@ fn run_zksolc_with_asm_by_default() -> anyhow::Result<()> {
 #[test]
 fn run_zksolc_with_two_same_flags_asm_asm() -> anyhow::Result<()> {
     let _ = common::setup();
-    let args = &[cli_tests::TEST_SOLIDITY_CONTRACT_PATH, "--asm", "--asm"];
+    let args = &[cli::TEST_SOLIDITY_CONTRACT_PATH, "--asm", "--asm"];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     let status_code = result
         .failure()
         .stderr(predicate::str::contains(
@@ -59,7 +57,7 @@ fn run_zksolc_with_two_same_flags_asm_asm() -> anyhow::Result<()> {
         .code()
         .expect("No exit code.");
 
-    let solc_result = cli_tests::execute_solc(args)?;
+    let solc_result = cli::execute_solc(args)?;
     solc_result.code(status_code);
 
     Ok(())
@@ -68,10 +66,10 @@ fn run_zksolc_with_two_same_flags_asm_asm() -> anyhow::Result<()> {
 #[test]
 fn run_zksolc_with_asm_with_wrong_input_format() -> anyhow::Result<()> {
     let _ = common::setup();
-    let args = &[cli_tests::TEST_YUL_CONTRACT_PATH, "--asm"];
+    let args = &[cli::TEST_YUL_CONTRACT_PATH, "--asm"];
 
-    let result = cli_tests::execute_zksolc(args)?;
-    let solc_result = cli_tests::execute_solc(args)?;
+    let result = cli::execute_zksolc(args)?;
+    let solc_result = cli::execute_solc(args)?;
 
     let result_exit_code = result
         .failure()

--- a/era-compiler-solidity/tests/cli/basic.rs
+++ b/era-compiler-solidity/tests/cli/basic.rs
@@ -1,6 +1,4 @@
-pub mod cli_tests;
-#[cfg(test)]
-pub mod common;
+use crate::{cli, common};
 use predicates::prelude::*;
 use tempfile::TempDir;
 
@@ -9,7 +7,7 @@ fn run_zksolc_without_any_args() -> anyhow::Result<()> {
     let _ = common::setup();
     let args: &[&str] = &[];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     let status_code = result
         .failure()
         .stderr(predicate::str::contains(
@@ -20,7 +18,7 @@ fn run_zksolc_without_any_args() -> anyhow::Result<()> {
         .code()
         .expect("No exit code.");
 
-    let solc_result = cli_tests::execute_solc(args)?;
+    let solc_result = cli::execute_solc(args)?;
     solc_result.code(status_code);
 
     Ok(())
@@ -31,14 +29,14 @@ fn default_run_of_zksolc_from_the_help() -> anyhow::Result<()> {
     let _ = common::setup();
     let tmp_dir = TempDir::new()?;
     let args = &[
-        cli_tests::TEST_SOLIDITY_CONTRACT_PATH,
+        cli::TEST_SOLIDITY_CONTRACT_PATH,
         "-O3",
         "--bin",
         "--output-dir",
         tmp_dir.path().to_str().unwrap(),
     ];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     result
         .success()
         .stderr(predicate::str::contains("Compiler run successful."));
@@ -47,13 +45,11 @@ fn default_run_of_zksolc_from_the_help() -> anyhow::Result<()> {
 
     let bin_output_file = tmp_dir
         .path()
-        .join(cli_tests::TEST_SOLIDITY_CONTRACT_NAME)
-        .join(cli_tests::SOLIDITY_BIN_OUTPUT_NAME);
+        .join(cli::TEST_SOLIDITY_CONTRACT_NAME)
+        .join(cli::SOLIDITY_BIN_OUTPUT_NAME);
 
     assert!(bin_output_file.exists());
-    assert!(!cli_tests::is_file_empty(
-        &bin_output_file.to_str().unwrap()
-    )?);
+    assert!(!cli::is_file_empty(&bin_output_file.to_str().unwrap())?);
 
     Ok(())
 }
@@ -63,7 +59,7 @@ fn run_zksolc_with_multiple_output_options() -> anyhow::Result<()> {
     let _ = common::setup();
     let tmp_dir = TempDir::new()?;
     let args = &[
-        cli_tests::TEST_SOLIDITY_CONTRACT_PATH,
+        cli::TEST_SOLIDITY_CONTRACT_PATH,
         "-O3",
         "--bin",
         "--asm",
@@ -71,7 +67,7 @@ fn run_zksolc_with_multiple_output_options() -> anyhow::Result<()> {
         tmp_dir.path().to_str().unwrap(),
     ];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     result
         .success()
         .stderr(predicate::str::contains("Compiler run successful."));
@@ -80,21 +76,17 @@ fn run_zksolc_with_multiple_output_options() -> anyhow::Result<()> {
 
     let bin_output_file = tmp_dir
         .path()
-        .join(cli_tests::TEST_SOLIDITY_CONTRACT_NAME)
-        .join(cli_tests::SOLIDITY_BIN_OUTPUT_NAME);
+        .join(cli::TEST_SOLIDITY_CONTRACT_NAME)
+        .join(cli::SOLIDITY_BIN_OUTPUT_NAME);
     let asm_output_file = tmp_dir
         .path()
-        .join(cli_tests::TEST_SOLIDITY_CONTRACT_NAME)
-        .join(cli_tests::SOLIDITY_ASM_OUTPUT_NAME);
+        .join(cli::TEST_SOLIDITY_CONTRACT_NAME)
+        .join(cli::SOLIDITY_ASM_OUTPUT_NAME);
 
     assert!(bin_output_file.exists());
     assert!(asm_output_file.exists());
-    assert!(!cli_tests::is_file_empty(
-        &bin_output_file.to_str().unwrap()
-    )?);
-    assert!(!cli_tests::is_file_empty(
-        &asm_output_file.to_str().unwrap()
-    )?);
+    assert!(!cli::is_file_empty(&bin_output_file.to_str().unwrap())?);
+    assert!(!cli::is_file_empty(&asm_output_file.to_str().unwrap())?);
 
     Ok(())
 }
@@ -104,31 +96,31 @@ fn bin_output_is_the_same_in_file_and_cli() -> anyhow::Result<()> {
     let _ = common::setup();
     let tmp_dir = TempDir::new()?;
     let args = &[
-        cli_tests::TEST_SOLIDITY_CONTRACT_PATH,
+        cli::TEST_SOLIDITY_CONTRACT_PATH,
         "-O3",
         "--bin",
         "--output-dir",
         tmp_dir.path().to_str().unwrap(),
     ];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     result
         .success()
         .stderr(predicate::str::contains("Compiler run successful."));
 
     let bin_output_file = tmp_dir
         .path()
-        .join(cli_tests::TEST_SOLIDITY_CONTRACT_NAME)
-        .join(cli_tests::SOLIDITY_BIN_OUTPUT_NAME);
+        .join(cli::TEST_SOLIDITY_CONTRACT_NAME)
+        .join(cli::SOLIDITY_BIN_OUTPUT_NAME);
     assert!(bin_output_file.exists());
 
-    let cli_args = &[cli_tests::TEST_SOLIDITY_CONTRACT_PATH, "-O3", "--bin"];
-    let cli_result = cli_tests::execute_zksolc(cli_args)?;
+    let cli_args = &[cli::TEST_SOLIDITY_CONTRACT_PATH, "-O3", "--bin"];
+    let cli_result = cli::execute_zksolc(cli_args)?;
 
     let stderr =
         String::from_utf8(cli_result.get_output().clone().stdout).expect("Invalid UTF-8 sequence");
 
-    assert!(cli_tests::is_output_same_as_file(
+    assert!(cli::is_output_same_as_file(
         &bin_output_file.to_str().unwrap(),
         &stderr.as_str()
     )?);

--- a/era-compiler-solidity/tests/cli/bin.rs
+++ b/era-compiler-solidity/tests/cli/bin.rs
@@ -1,16 +1,14 @@
-pub mod cli_tests;
-#[cfg(test)]
-pub mod common;
+use crate::{cli, common};
 use predicates::prelude::*;
 
 #[test]
 fn run_zksolc_with_bin_by_default() -> anyhow::Result<()> {
     let _ = common::setup();
-    let args = &[cli_tests::TEST_SOLIDITY_CONTRACT_PATH, "--bin"];
+    let args = &[cli::TEST_SOLIDITY_CONTRACT_PATH, "--bin"];
     let invalid_args = &["--bin"];
 
     // Valid command
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     let result_status_code = result
         .success()
         .stdout(predicate::str::contains("bytecode: 0x"))
@@ -20,11 +18,11 @@ fn run_zksolc_with_bin_by_default() -> anyhow::Result<()> {
         .expect("No exit code.");
 
     // solc exit code == zksolc exit code
-    let solc_result = cli_tests::execute_solc(args)?;
+    let solc_result = cli::execute_solc(args)?;
     solc_result.code(result_status_code);
 
     // Run invalid: zksolc --bin
-    let invalid_result = cli_tests::execute_zksolc(invalid_args)?;
+    let invalid_result = cli::execute_zksolc(invalid_args)?;
     let invalid_result_status_code = invalid_result
         .failure()
         .stderr(
@@ -37,7 +35,7 @@ fn run_zksolc_with_bin_by_default() -> anyhow::Result<()> {
         .expect("No exit code.");
 
     // Invalid solc exit code == Invalid zksolc exit code
-    let invalid_solc_result = cli_tests::execute_solc(invalid_args)?;
+    let invalid_solc_result = cli::execute_solc(invalid_args)?;
     invalid_solc_result.code(invalid_result_status_code);
 
     Ok(())
@@ -46,9 +44,9 @@ fn run_zksolc_with_bin_by_default() -> anyhow::Result<()> {
 #[test]
 fn run_zksolc_with_two_same_flags_bin_bin() -> anyhow::Result<()> {
     let _ = common::setup();
-    let args = &[cli_tests::TEST_SOLIDITY_CONTRACT_PATH, "--bin", "--bin"];
+    let args = &[cli::TEST_SOLIDITY_CONTRACT_PATH, "--bin", "--bin"];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     let status_code = result
         .failure()
         .stderr(predicate::str::contains(
@@ -59,7 +57,7 @@ fn run_zksolc_with_two_same_flags_bin_bin() -> anyhow::Result<()> {
         .code()
         .expect("No exit code.");
 
-    let solc_result = cli_tests::execute_solc(args)?;
+    let solc_result = cli::execute_solc(args)?;
     solc_result.code(status_code);
 
     Ok(())
@@ -68,10 +66,10 @@ fn run_zksolc_with_two_same_flags_bin_bin() -> anyhow::Result<()> {
 #[test]
 fn run_zksolc_with_bin_with_wrong_input_format() -> anyhow::Result<()> {
     let _ = common::setup();
-    let args = &[cli_tests::TEST_YUL_CONTRACT_PATH, "--bin"];
+    let args = &[cli::TEST_YUL_CONTRACT_PATH, "--bin"];
 
-    let result = cli_tests::execute_zksolc(args)?;
-    let solc_result = cli_tests::execute_solc(args)?;
+    let result = cli::execute_zksolc(args)?;
+    let solc_result = cli::execute_solc(args)?;
 
     let result_exit_code = result
         .failure()

--- a/era-compiler-solidity/tests/cli/combined_json.rs
+++ b/era-compiler-solidity/tests/cli/combined_json.rs
@@ -1,6 +1,4 @@
-pub mod cli_tests;
-#[cfg(test)]
-pub mod common;
+use crate::{cli, common};
 use predicates::prelude::*;
 
 const JSON_ARGS: &[&str] = &[
@@ -21,7 +19,7 @@ fn run_zksolc_with_just_combined_json() -> anyhow::Result<()> {
     let _ = common::setup();
     let args = &["--combined-json"];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     let status_code = result
         .failure()
         .stderr(predicate::str::contains(
@@ -32,7 +30,7 @@ fn run_zksolc_with_just_combined_json() -> anyhow::Result<()> {
         .code()
         .expect("No exit code.");
 
-    let solc_result = cli_tests::execute_solc(args)?;
+    let solc_result = cli::execute_solc(args)?;
     solc_result.code(status_code);
 
     Ok(())
@@ -41,9 +39,9 @@ fn run_zksolc_with_just_combined_json() -> anyhow::Result<()> {
 #[test]
 fn run_zksolc_with_sol_contract_and_combined_json() -> anyhow::Result<()> {
     let _ = common::setup();
-    let args = &[cli_tests::TEST_SOLIDITY_CONTRACT_PATH, "--combined-json"];
+    let args = &[cli::TEST_SOLIDITY_CONTRACT_PATH, "--combined-json"];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     let status_code = result
         .failure()
         .stderr(predicate::str::contains(
@@ -54,7 +52,7 @@ fn run_zksolc_with_sol_contract_and_combined_json() -> anyhow::Result<()> {
         .code()
         .expect("No exit code.");
 
-    let solc_result = cli_tests::execute_solc(args)?;
+    let solc_result = cli::execute_solc(args)?;
     solc_result.code(status_code);
 
     Ok(())
@@ -64,13 +62,9 @@ fn run_zksolc_with_sol_contract_and_combined_json() -> anyhow::Result<()> {
 fn run_zksolc_with_combined_json_and_valid_args() -> anyhow::Result<()> {
     let _ = common::setup();
     for &arg in JSON_ARGS {
-        let args = &[
-            cli_tests::TEST_SOLIDITY_CONTRACT_PATH,
-            "--combined-json",
-            arg,
-        ];
+        let args = &[cli::TEST_SOLIDITY_CONTRACT_PATH, "--combined-json", arg];
 
-        let result = cli_tests::execute_zksolc(args)?;
+        let result = cli::execute_zksolc(args)?;
         let status_code = result
             .success()
             .stdout(predicate::str::contains("contracts"))
@@ -79,7 +73,7 @@ fn run_zksolc_with_combined_json_and_valid_args() -> anyhow::Result<()> {
             .code()
             .expect("No exit code.");
 
-        let solc_result = cli_tests::execute_solc(args)?;
+        let solc_result = cli::execute_solc(args)?;
         solc_result.code(status_code);
     }
 
@@ -91,12 +85,12 @@ fn run_zksolc_with_combined_json_and_invalid_args() -> anyhow::Result<()> {
     let _ = common::setup();
     for &arg in JSON_ARGS {
         let args = &[
-            cli_tests::TEST_SOLIDITY_CONTRACT_PATH,
+            cli::TEST_SOLIDITY_CONTRACT_PATH,
             "--combined-json",
             &format!("--{}", arg),
         ];
 
-        let result = cli_tests::execute_zksolc(args)?;
+        let result = cli::execute_zksolc(args)?;
         let status_code = result
             .failure()
             .stderr(
@@ -107,7 +101,7 @@ fn run_zksolc_with_combined_json_and_invalid_args() -> anyhow::Result<()> {
             .code()
             .expect("No exit code.");
 
-        let solc_result = cli_tests::execute_solc(args)?;
+        let solc_result = cli::execute_solc(args)?;
         solc_result.code(status_code);
     }
 
@@ -119,13 +113,13 @@ fn run_zksolc_with_combined_json_and_duplicate_args() -> anyhow::Result<()> {
     let _ = common::setup();
     for &arg in JSON_ARGS {
         let args = &[
-            cli_tests::TEST_SOLIDITY_CONTRACT_PATH,
+            cli::TEST_SOLIDITY_CONTRACT_PATH,
             "--combined-json",
             arg,
             arg,
         ];
 
-        let result = cli_tests::execute_zksolc(args)?;
+        let result = cli::execute_zksolc(args)?;
         let status_code = result
             .failure()
             .stderr(
@@ -137,7 +131,7 @@ fn run_zksolc_with_combined_json_and_duplicate_args() -> anyhow::Result<()> {
             .code()
             .expect("No exit code.");
 
-        let solc_result = cli_tests::execute_solc(args)?;
+        let solc_result = cli::execute_solc(args)?;
         solc_result.code(status_code);
     }
 
@@ -149,14 +143,14 @@ fn run_zksolc_with_multiple_combined_json_flags() -> anyhow::Result<()> {
     let _ = common::setup();
     for &arg in JSON_ARGS {
         let args = &[
-            cli_tests::TEST_SOLIDITY_CONTRACT_PATH,
+            cli::TEST_SOLIDITY_CONTRACT_PATH,
             "--combined-json",
             arg,
             "--combined-json",
             arg,
         ];
 
-        let result = cli_tests::execute_zksolc(args)?;
+        let result = cli::execute_zksolc(args)?;
         let status_code = result
             .failure()
             .stderr(predicate::str::contains("cannot be used multiple times"))
@@ -165,7 +159,7 @@ fn run_zksolc_with_multiple_combined_json_flags() -> anyhow::Result<()> {
             .code()
             .expect("No exit code.");
 
-        let solc_result = cli_tests::execute_solc(args)?;
+        let solc_result = cli::execute_solc(args)?;
         solc_result.code(status_code);
     }
 
@@ -176,9 +170,9 @@ fn run_zksolc_with_multiple_combined_json_flags() -> anyhow::Result<()> {
 fn run_zksolc_with_yul_and_combined_json() -> anyhow::Result<()> {
     let _ = common::setup();
     for &arg in JSON_ARGS {
-        let args = &[cli_tests::TEST_YUL_CONTRACT_PATH, "--combined-json", arg];
+        let args = &[cli::TEST_YUL_CONTRACT_PATH, "--combined-json", arg];
 
-        let result = cli_tests::execute_zksolc(args)?;
+        let result = cli::execute_zksolc(args)?;
         let status_code = result
             .failure()
             .stderr(predicate::str::contains("Expected identifier"))
@@ -187,7 +181,7 @@ fn run_zksolc_with_yul_and_combined_json() -> anyhow::Result<()> {
             .code()
             .expect("No exit code.");
 
-        let solc_result = cli_tests::execute_solc(args)?;
+        let solc_result = cli::execute_solc(args)?;
         solc_result.code(status_code);
     }
 

--- a/era-compiler-solidity/tests/cli/eravm_assembly.rs
+++ b/era-compiler-solidity/tests/cli/eravm_assembly.rs
@@ -1,18 +1,16 @@
-pub mod cli_tests;
-#[cfg(test)]
-pub mod common;
+use crate::{cli, common};
 use predicates::prelude::*;
 
 #[test]
 fn run_zksolc_with_eravm_assembly_by_default() -> anyhow::Result<()> {
     let _ = common::setup();
     let args = &[
-        cli_tests::TEST_ERAVM_ASSEMBLY_CONTRACT_PATH,
+        cli::TEST_ERAVM_ASSEMBLY_CONTRACT_PATH,
         "--eravm-assembly",
         "--bin",
     ];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     result
         .success()
         .stdout(predicate::str::contains("bytecode"));
@@ -24,12 +22,12 @@ fn run_zksolc_with_eravm_assembly_by_default() -> anyhow::Result<()> {
 fn run_zksolc_with_double_eravm_options() -> anyhow::Result<()> {
     let _ = common::setup();
     let args = &[
-        cli_tests::TEST_ERAVM_ASSEMBLY_CONTRACT_PATH,
+        cli::TEST_ERAVM_ASSEMBLY_CONTRACT_PATH,
         "--eravm-assembly",
         "--eravm-assembly",
     ];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     result.failure().stderr(predicate::str::contains(
         "The argument '--eravm-assembly' was provided more than once",
     ));
@@ -41,12 +39,12 @@ fn run_zksolc_with_double_eravm_options() -> anyhow::Result<()> {
 fn run_zksolc_with_incompatible_input_format() -> anyhow::Result<()> {
     let _ = common::setup();
     let args = &[
-        cli_tests::TEST_SOLIDITY_CONTRACT_PATH,
+        cli::TEST_SOLIDITY_CONTRACT_PATH,
         "--eravm-assembly",
         "--bin",
     ];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     result
         .failure()
         .stderr(predicate::str::contains("error: cannot parse operand"));
@@ -58,13 +56,13 @@ fn run_zksolc_with_incompatible_input_format() -> anyhow::Result<()> {
 fn run_zksolc_with_incompatible_json_modes() -> anyhow::Result<()> {
     let _ = common::setup();
     let args = &[
-        cli_tests::TEST_ERAVM_ASSEMBLY_CONTRACT_PATH,
+        cli::TEST_ERAVM_ASSEMBLY_CONTRACT_PATH,
         "--eravm-assembly",
         "--combined-json",
         "wrong",
     ];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     result
         .failure()
         .stderr(predicate::str::contains("Only one mode is allowed"));

--- a/era-compiler-solidity/tests/cli/libraries.rs
+++ b/era-compiler-solidity/tests/cli/libraries.rs
@@ -1,19 +1,16 @@
-#![cfg(test)]
-
-pub mod cli_tests;
-pub mod common;
+use crate::{cli, common};
 use predicates::prelude::*;
 
 #[test]
 fn run_zksolc_with_sol_and_libraries() -> anyhow::Result<()> {
     let _ = common::setup();
     let args = &[
-        cli_tests::TEST_SOLIDITY_CONTRACT_PATH,
+        cli::TEST_SOLIDITY_CONTRACT_PATH,
         "--libraries",
-        cli_tests::LIBRARY_DEFAULT_PATH,
+        cli::LIBRARY_DEFAULT_PATH,
     ];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     result
         .success()
         .stderr(predicate::str::contains("Compiler run successful"));
@@ -26,7 +23,7 @@ fn run_zksolc_without_sol_and_with_libraries() -> anyhow::Result<()> {
     let _ = common::setup();
     let args = &["--libraries"];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     result.failure().stderr(predicate::str::contains(
         "requires a value but none was supplied",
     ));

--- a/era-compiler-solidity/tests/cli/llvm_ir.rs
+++ b/era-compiler-solidity/tests/cli/llvm_ir.rs
@@ -1,17 +1,14 @@
-#![cfg(test)]
-
-pub mod cli_tests;
-pub mod common;
+use crate::{cli, common};
 use predicates::prelude::*;
 
 #[test]
 fn run_zksolc_with_llvm_ir_by_default() -> anyhow::Result<()> {
     let _ = common::setup();
-    let args = &[cli_tests::TEST_LLVM_CONTRACT_PATH, "--llvm-ir"];
+    let args = &[cli::TEST_LLVM_CONTRACT_PATH, "--llvm-ir"];
     let invalid_args = &["--llvm-ir", "anyarg"];
 
-    let result = cli_tests::execute_zksolc(args)?;
-    let invalid_result = cli_tests::execute_zksolc(invalid_args)?;
+    let result = cli::execute_zksolc(args)?;
+    let invalid_result = cli::execute_zksolc(invalid_args)?;
 
     result.success().stderr(predicate::str::contains(
         "Compiler run successful. No output requested. Use --asm and --bin flags.",
@@ -24,9 +21,9 @@ fn run_zksolc_with_llvm_ir_by_default() -> anyhow::Result<()> {
 #[test]
 fn run_zksolc_with_same_llvm_ir_flags() -> anyhow::Result<()> {
     let _ = common::setup();
-    let args = &[cli_tests::TEST_LLVM_CONTRACT_PATH, "--llvm-ir", "--llvm-ir"];
+    let args = &[cli::TEST_LLVM_CONTRACT_PATH, "--llvm-ir", "--llvm-ir"];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     result.failure().stderr(predicate::str::contains(
         "The argument '--llvm-ir' was provided more than once",
     ));
@@ -37,9 +34,9 @@ fn run_zksolc_with_same_llvm_ir_flags() -> anyhow::Result<()> {
 #[test]
 fn run_zksolc_with_wrong_input_format() -> anyhow::Result<()> {
     let _ = common::setup();
-    let args = &[cli_tests::TEST_SOLIDITY_CONTRACT_PATH, "--llvm-ir", "--bin"];
+    let args = &[cli::TEST_SOLIDITY_CONTRACT_PATH, "--llvm-ir", "--bin"];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     result
         .failure()
         .stderr(predicate::str::contains("expected top-level entity"));
@@ -51,13 +48,13 @@ fn run_zksolc_with_wrong_input_format() -> anyhow::Result<()> {
 fn run_zksolc_with_incompatible_json_modes_combined_json() -> anyhow::Result<()> {
     let _ = common::setup();
     let args = &[
-        cli_tests::TEST_LLVM_CONTRACT_PATH,
+        cli::TEST_LLVM_CONTRACT_PATH,
         "--llvm-ir",
         "--combined-json",
         "anyarg",
     ];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     result.failure().stderr(predicate::str::contains(
         "Only one mode is allowed at the same time",
     ));
@@ -68,13 +65,9 @@ fn run_zksolc_with_incompatible_json_modes_combined_json() -> anyhow::Result<()>
 #[test]
 fn run_zksolc_with_incompatible_json_modes_standard_json() -> anyhow::Result<()> {
     let _ = common::setup();
-    let args = &[
-        cli_tests::TEST_YUL_CONTRACT_PATH,
-        "--llvm-ir",
-        "--standard-json",
-    ];
+    let args = &[cli::TEST_YUL_CONTRACT_PATH, "--llvm-ir", "--standard-json"];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     result.success().stdout(predicate::str::contains(
         "Only one mode is allowed at the same time",
     ));

--- a/era-compiler-solidity/tests/cli/metadata_hash.rs
+++ b/era-compiler-solidity/tests/cli/metadata_hash.rs
@@ -1,19 +1,12 @@
-#![cfg(test)]
-
-pub mod cli_tests;
-pub mod common;
-
+use crate::{cli, common};
 use predicates::prelude::*;
 
 #[test]
 fn run_zksolc_with_metadata_hash_default() -> anyhow::Result<()> {
     let _ = common::setup();
-    let args = &[
-        cli_tests::TEST_SOLIDITY_CONTRACT_PATH,
-        "--metadata-hash=none",
-    ];
+    let args = &[cli::TEST_SOLIDITY_CONTRACT_PATH, "--metadata-hash=none"];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     let zksolc_result = result
         .success()
         .stderr(predicate::str::contains("Compiler run successful"))
@@ -22,7 +15,7 @@ fn run_zksolc_with_metadata_hash_default() -> anyhow::Result<()> {
         .code()
         .expect("No exit code.");
 
-    let solc_result = cli_tests::execute_solc(args)?;
+    let solc_result = cli::execute_solc(args)?;
     solc_result.code(zksolc_result);
 
     Ok(())
@@ -31,9 +24,9 @@ fn run_zksolc_with_metadata_hash_default() -> anyhow::Result<()> {
 #[test]
 fn run_zksolc_with_metadata_hash_no_arg() -> anyhow::Result<()> {
     let _ = common::setup();
-    let args = &[cli_tests::TEST_SOLIDITY_CONTRACT_PATH, "--metadata-hash"];
+    let args = &[cli::TEST_SOLIDITY_CONTRACT_PATH, "--metadata-hash"];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     let zksolc_result = result
         .failure()
         .stderr(predicate::str::contains(
@@ -44,7 +37,7 @@ fn run_zksolc_with_metadata_hash_no_arg() -> anyhow::Result<()> {
         .code()
         .expect("No exit code.");
 
-    let solc_result = cli_tests::execute_solc(args)?;
+    let solc_result = cli::execute_solc(args)?;
     solc_result.code(zksolc_result);
 
     Ok(())
@@ -55,7 +48,7 @@ fn run_zksolc_with_metadata_hash_no_input_file() -> anyhow::Result<()> {
     let _ = common::setup();
     let args = &["--metadata-hash=none"];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     let zksolc_result = result
         .failure()
         .stderr(predicate::str::contains("No input sources specified"))
@@ -64,7 +57,7 @@ fn run_zksolc_with_metadata_hash_no_input_file() -> anyhow::Result<()> {
         .code()
         .expect("No exit code.");
 
-    let solc_result = cli_tests::execute_solc(args)?;
+    let solc_result = cli::execute_solc(args)?;
     solc_result.code(zksolc_result);
 
     Ok(())

--- a/era-compiler-solidity/tests/cli/missing_lib.rs
+++ b/era-compiler-solidity/tests/cli/missing_lib.rs
@@ -1,19 +1,15 @@
-#![cfg(test)]
-
-pub mod cli_tests;
-pub mod common;
-
+use crate::{cli, common};
 use predicates::prelude::*;
 
 #[test]
 fn run_zksolc_with_sol_detect_missing_libraries() -> anyhow::Result<()> {
     let _ = common::setup();
     let args = &[
-        cli_tests::TEST_SOLIDITY_CONTRACT_PATH,
+        cli::TEST_SOLIDITY_CONTRACT_PATH,
         "--detect-missing-libraries",
     ];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     result.failure().stderr(predicate::str::contains(
         "Missing deployable libraries detection mode is only supported in standard JSON mode.",
     ));
@@ -26,7 +22,7 @@ fn run_zksolc_without_sol_detect_missing_libraries() -> anyhow::Result<()> {
     let _ = common::setup();
     let args = &["--detect-missing-libraries"];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     result.failure().stderr(predicate::str::contains(
         "Missing deployable libraries detection mode is only supported in standard JSON mode.",
     ));

--- a/era-compiler-solidity/tests/cli/mod.rs
+++ b/era-compiler-solidity/tests/cli/mod.rs
@@ -1,11 +1,25 @@
-#![cfg(test)]
-
 use crate::common;
-use assert_cmd::prelude::*;
+use assert_cmd::assert::OutputAssertExt;
+use assert_cmd::cargo::CommandCargoExt;
 use era_compiler_solidity::SolcCompiler;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
+
+mod asm;
+mod basic;
+mod bin;
+mod combined_json;
+mod eravm_assembly;
+mod libraries;
+mod llvm_ir;
+mod metadata_hash;
+mod missing_lib;
+mod optimization;
+mod output_dir;
+mod solc;
+mod standard_json;
+mod yul;
 
 /// The solidity contract name
 pub const TEST_SOLIDITY_CONTRACT_NAME: &'static str = "contract.sol";
@@ -18,9 +32,6 @@ pub const SOLIDITY_BIN_OUTPUT_NAME: &'static str = "C.zbin";
 
 /// The solidity assembly artifact output name
 pub const SOLIDITY_ASM_OUTPUT_NAME: &'static str = "C.zasm";
-
-/// The yul contract name
-pub const TEST_YUL_CONTRACT_NAME: &'static str = "contract.yul";
 
 /// The yul contract for testing
 pub const TEST_YUL_CONTRACT_PATH: &'static str = "tests/examples/contracts/yul/contract.yul";

--- a/era-compiler-solidity/tests/cli/optimization.rs
+++ b/era-compiler-solidity/tests/cli/optimization.rs
@@ -1,8 +1,4 @@
-#![cfg(test)]
-
-pub mod cli_tests;
-pub mod common;
-
+use crate::{cli, common};
 use predicates::prelude::*;
 
 #[test]
@@ -11,12 +7,9 @@ fn run_zksolc_with_optimization_levels() -> anyhow::Result<()> {
     let optimization_args = ["0", "1", "2", "3", "s", "z"];
 
     for opt in &optimization_args {
-        let args = &[
-            cli_tests::TEST_SOLIDITY_CONTRACT_PATH,
-            &format!("-O{}", opt),
-        ];
+        let args = &[cli::TEST_SOLIDITY_CONTRACT_PATH, &format!("-O{}", opt)];
 
-        let result = cli_tests::execute_zksolc(args)?;
+        let result = cli::execute_zksolc(args)?;
         result
             .success()
             .stderr(predicate::str::contains("Compiler run successful"));
@@ -30,7 +23,7 @@ fn run_zksolc_with_optimization_no_input_file() -> anyhow::Result<()> {
     let _ = common::setup();
     let args = &["-O0"];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     result
         .failure()
         .stderr(predicate::str::contains("No input sources specified"));
@@ -41,9 +34,9 @@ fn run_zksolc_with_optimization_no_input_file() -> anyhow::Result<()> {
 #[test]
 fn run_zksolc_with_invalid_optimization_option() -> anyhow::Result<()> {
     let _ = common::setup();
-    let args = &[cli_tests::TEST_SOLIDITY_CONTRACT_PATH, "-O99"];
+    let args = &[cli::TEST_SOLIDITY_CONTRACT_PATH, "-O99"];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     result.failure().stderr(
         predicate::str::contains("Unexpected optimization option")
             .or(predicate::str::contains("Invalid value for")),

--- a/era-compiler-solidity/tests/cli/output_dir.rs
+++ b/era-compiler-solidity/tests/cli/output_dir.rs
@@ -1,8 +1,4 @@
-#![cfg(test)]
-
-pub mod cli_tests;
-pub mod common;
-
+use crate::{cli, common};
 use predicates::prelude::*;
 use tempfile::TempDir;
 
@@ -13,20 +9,20 @@ fn run_zksolc_with_output_dir_by_default() -> anyhow::Result<()> {
     let tmp_dir_solc = TempDir::with_prefix("solc_output")?;
 
     let zksolc_args = &[
-        cli_tests::TEST_SOLIDITY_CONTRACT_PATH,
+        cli::TEST_SOLIDITY_CONTRACT_PATH,
         "--bin",
         "--output-dir",
         tmp_dir_zksolc.path().to_str().unwrap(),
     ];
     let solc_args = &[
-        cli_tests::TEST_SOLIDITY_CONTRACT_PATH,
+        cli::TEST_SOLIDITY_CONTRACT_PATH,
         "--bin",
         "--output-dir",
         tmp_dir_solc.path().to_str().unwrap(),
     ];
 
     // Execute zksolc command
-    let result = cli_tests::execute_zksolc(zksolc_args)?;
+    let result = cli::execute_zksolc(zksolc_args)?;
     let zksolc_status = result
         .success()
         .stderr(predicate::str::contains("Compiler run successful"))
@@ -39,7 +35,7 @@ fn run_zksolc_with_output_dir_by_default() -> anyhow::Result<()> {
     assert!(tmp_dir_zksolc.path().exists());
 
     // Compare with solc
-    let solc_result = cli_tests::execute_solc(solc_args)?;
+    let solc_result = cli::execute_solc(solc_args)?;
     solc_result.code(zksolc_status);
 
     Ok(())
@@ -48,21 +44,17 @@ fn run_zksolc_with_output_dir_by_default() -> anyhow::Result<()> {
 #[test]
 fn run_zksolc_with_output_dir_invalid_arg_no_path() -> anyhow::Result<()> {
     let _ = common::setup();
-    let args = &[
-        cli_tests::TEST_SOLIDITY_CONTRACT_PATH,
-        "--bin",
-        "--output-dir",
-    ];
+    let args = &[cli::TEST_SOLIDITY_CONTRACT_PATH, "--bin", "--output-dir"];
 
     // Execute invalid zksolc command
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     let zksolc_status = result
         .failure()
         .stderr(predicate::str::contains("error: The argument '--output-dir <output-directory>' requires a value but none was supplied"))
         .get_output().status.code().expect("No exit code.");
 
     // Compare with solc
-    let solc_result = cli_tests::execute_solc(args)?;
+    let solc_result = cli::execute_solc(args)?;
     solc_result.code(zksolc_status);
 
     Ok(())
@@ -86,7 +78,7 @@ fn run_zksolc_with_output_dir_invalid_args_no_source() -> anyhow::Result<()> {
     ];
 
     // Execute zksolc with missing source
-    let result = cli_tests::execute_zksolc(zksolc_args)?;
+    let result = cli::execute_zksolc(zksolc_args)?;
     let zksolc_status = result
         .failure()
         .stderr(predicate::str::contains("No input sources specified"))
@@ -96,7 +88,7 @@ fn run_zksolc_with_output_dir_invalid_args_no_source() -> anyhow::Result<()> {
         .expect("No exit code.");
 
     // Compare with solc
-    let solc_result = cli_tests::execute_solc(solc_args)?;
+    let solc_result = cli::execute_solc(solc_args)?;
     solc_result.code(zksolc_status);
 
     Ok(())
@@ -109,20 +101,20 @@ fn run_zksolc_with_output_dir_specific_symbols() -> anyhow::Result<()> {
     let tmp_dir_solc = TempDir::with_prefix("File!and#$%-XXXXXX")?;
 
     let zksolc_args = &[
-        cli_tests::TEST_SOLIDITY_CONTRACT_PATH,
+        cli::TEST_SOLIDITY_CONTRACT_PATH,
         "--bin",
         "--output-dir",
         tmp_dir_zksolc.path().to_str().unwrap(),
     ];
     let solc_args = &[
-        cli_tests::TEST_SOLIDITY_CONTRACT_PATH,
+        cli::TEST_SOLIDITY_CONTRACT_PATH,
         "--bin",
         "--output-dir",
         tmp_dir_solc.path().to_str().unwrap(),
     ];
 
     // Execute zksolc command
-    let result = cli_tests::execute_zksolc(zksolc_args)?;
+    let result = cli::execute_zksolc(zksolc_args)?;
     let zksolc_status = result
         .success()
         .stderr(predicate::str::contains("Compiler run successful"))
@@ -135,7 +127,7 @@ fn run_zksolc_with_output_dir_specific_symbols() -> anyhow::Result<()> {
     assert!(tmp_dir_zksolc.path().exists());
 
     // Compare with solc
-    let solc_result = cli_tests::execute_solc(solc_args)?;
+    let solc_result = cli::execute_solc(solc_args)?;
     solc_result.code(zksolc_status);
 
     Ok(())

--- a/era-compiler-solidity/tests/cli/solc.rs
+++ b/era-compiler-solidity/tests/cli/solc.rs
@@ -1,9 +1,6 @@
-#![cfg(test)]
-
-pub mod cli_tests;
-pub mod common;
 use assert_cmd::Command;
 
+use crate::{cli, common};
 use predicates::prelude::predicate;
 
 #[test]
@@ -16,7 +13,7 @@ fn call_zksolc_with_solc_argument() -> anyhow::Result<()> {
             .executable;
 
     let assert = zksolc
-        .arg(cli_tests::TEST_SOLIDITY_CONTRACT_PATH)
+        .arg(cli::TEST_SOLIDITY_CONTRACT_PATH)
         .arg("--solc")
         .arg(solc_compiler)
         .assert();

--- a/era-compiler-solidity/tests/cli/standard_json.rs
+++ b/era-compiler-solidity/tests/cli/standard_json.rs
@@ -1,8 +1,4 @@
-#![cfg(test)]
-
-pub mod cli_tests;
-pub mod common;
-
+use crate::{cli, common};
 use predicates::prelude::*;
 
 #[test]
@@ -15,11 +11,11 @@ fn run_zksolc_with_standard_json_contract() -> anyhow::Result<()> {
         "--solc",
         solc_compiler.as_str(),
         "--standard-json",
-        cli_tests::TEST_JSON_CONTRACT_PATH,
+        cli::TEST_JSON_CONTRACT_PATH,
     ];
-    let args_solc = &["--standard-json", cli_tests::TEST_JSON_CONTRACT_PATH];
+    let args_solc = &["--standard-json", cli::TEST_JSON_CONTRACT_PATH];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     let zksolc_exit_code = result
         .success()
         .stdout(predicate::str::contains("bytecode"))
@@ -28,7 +24,7 @@ fn run_zksolc_with_standard_json_contract() -> anyhow::Result<()> {
         .code()
         .expect("No exit code.");
 
-    let solc_result = cli_tests::execute_solc(args_solc)?;
+    let solc_result = cli::execute_solc(args_solc)?;
     solc_result.code(zksolc_exit_code);
 
     Ok(())
@@ -37,9 +33,9 @@ fn run_zksolc_with_standard_json_contract() -> anyhow::Result<()> {
 #[test]
 fn run_zksolc_with_standard_json_incompatible_input() -> anyhow::Result<()> {
     let _ = common::setup();
-    let args = &["--standard-json", cli_tests::TEST_YUL_CONTRACT_PATH];
+    let args = &["--standard-json", cli::TEST_YUL_CONTRACT_PATH];
 
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     let zksolc_exit_code = result
         .success()
         .stdout(predicate::str::contains("parsing: expected value"))
@@ -48,7 +44,7 @@ fn run_zksolc_with_standard_json_incompatible_input() -> anyhow::Result<()> {
         .code()
         .expect("No exit code.");
 
-    let solc_result = cli_tests::execute_solc(args)?;
+    let solc_result = cli::execute_solc(args)?;
     solc_result.code(zksolc_exit_code);
 
     Ok(())

--- a/era-compiler-solidity/tests/cli/yul.rs
+++ b/era-compiler-solidity/tests/cli/yul.rs
@@ -1,19 +1,15 @@
-#![cfg(test)]
-
-pub mod cli_tests;
-pub mod common;
-
+use crate::{cli, common};
 use predicates::prelude::*;
 
 #[test]
 fn run_zksolc_with_yul_by_default() -> anyhow::Result<()> {
     let _ = common::setup();
-    let zksolc_args = &[cli_tests::TEST_YUL_CONTRACT_PATH, "--yul"];
-    let solc_args = &[cli_tests::TEST_YUL_CONTRACT_PATH, "--strict-assembly"];
+    let zksolc_args = &[cli::TEST_YUL_CONTRACT_PATH, "--yul"];
+    let solc_args = &[cli::TEST_YUL_CONTRACT_PATH, "--strict-assembly"];
     let invalid_args = &["--yul", "anyarg"];
 
     // Valid command
-    let result = cli_tests::execute_zksolc(zksolc_args)?;
+    let result = cli::execute_zksolc(zksolc_args)?;
     let zksolc_status = result
         .success()
         .stderr(predicate::str::contains("Compiler run successful"))
@@ -24,11 +20,11 @@ fn run_zksolc_with_yul_by_default() -> anyhow::Result<()> {
         .expect("No exit code.");
 
     // solc exit code comparison
-    let solc_result = cli_tests::execute_solc(solc_args)?;
+    let solc_result = cli::execute_solc(solc_args)?;
     solc_result.code(zksolc_status);
 
     // Invalid command
-    let invalid_result = cli_tests::execute_zksolc(invalid_args)?;
+    let invalid_result = cli::execute_zksolc(invalid_args)?;
     let invalid_status = invalid_result
         .failure()
         .stderr(predicate::str::contains("Error"))
@@ -38,7 +34,7 @@ fn run_zksolc_with_yul_by_default() -> anyhow::Result<()> {
         .expect("No exit code.");
 
     // Invalid solc vs zksolc exit code comparison
-    let solc_invalid_result = cli_tests::execute_solc(invalid_args)?;
+    let solc_invalid_result = cli::execute_solc(invalid_args)?;
     solc_invalid_result.code(invalid_status);
 
     Ok(())
@@ -47,10 +43,10 @@ fn run_zksolc_with_yul_by_default() -> anyhow::Result<()> {
 #[test]
 fn run_zksolc_with_double_yul_options() -> anyhow::Result<()> {
     let _ = common::setup();
-    let args = &[cli_tests::TEST_YUL_CONTRACT_PATH, "--yul", "--yul"];
+    let args = &[cli::TEST_YUL_CONTRACT_PATH, "--yul", "--yul"];
 
     // Execute zksolc with duplicate --yul
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     let zksolc_status = result
         .failure()
         .stderr(predicate::str::contains(
@@ -62,7 +58,7 @@ fn run_zksolc_with_double_yul_options() -> anyhow::Result<()> {
         .expect("No exit code.");
 
     // Compare with solc
-    let solc_result = cli_tests::execute_solc(args)?;
+    let solc_result = cli::execute_solc(args)?;
     solc_result.code(zksolc_status);
 
     Ok(())
@@ -71,10 +67,10 @@ fn run_zksolc_with_double_yul_options() -> anyhow::Result<()> {
 #[test]
 fn run_zksolc_with_incompatible_input_format_solidity_contract() -> anyhow::Result<()> {
     let _ = common::setup();
-    let args = &[cli_tests::TEST_SOLIDITY_CONTRACT_PATH, "--yul"];
+    let args = &[cli::TEST_SOLIDITY_CONTRACT_PATH, "--yul"];
 
     // Execute zksolc with incompatible Solidity contract and --yul flag
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     let zksolc_status = result
         .failure()
         .stderr(predicate::str::contains("Yul parsing"))
@@ -84,7 +80,7 @@ fn run_zksolc_with_incompatible_input_format_solidity_contract() -> anyhow::Resu
         .expect("No exit code.");
 
     // Compare with solc
-    let solc_result = cli_tests::execute_solc(args)?;
+    let solc_result = cli::execute_solc(args)?;
     solc_result.code(zksolc_status);
 
     Ok(())
@@ -94,14 +90,14 @@ fn run_zksolc_with_incompatible_input_format_solidity_contract() -> anyhow::Resu
 fn run_zksolc_with_incompatible_json_modes_combined_json() -> anyhow::Result<()> {
     let _ = common::setup();
     let args = &[
-        cli_tests::TEST_YUL_CONTRACT_PATH,
+        cli::TEST_YUL_CONTRACT_PATH,
         "--yul",
         "--combined-json",
         "anyarg",
     ];
 
     // Execute zksolc with incompatible --yul and --combined-json flags
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     let zksolc_status = result
         .failure()
         .stderr(predicate::str::contains(
@@ -113,7 +109,7 @@ fn run_zksolc_with_incompatible_json_modes_combined_json() -> anyhow::Result<()>
         .expect("No exit code.");
 
     // Compare with solc
-    let solc_result = cli_tests::execute_solc(args)?;
+    let solc_result = cli::execute_solc(args)?;
     solc_result.code(zksolc_status);
 
     Ok(())
@@ -122,14 +118,10 @@ fn run_zksolc_with_incompatible_json_modes_combined_json() -> anyhow::Result<()>
 #[test]
 fn run_zksolc_with_incompatible_json_modes_standard_json() -> anyhow::Result<()> {
     let _ = common::setup();
-    let args = &[
-        cli_tests::TEST_YUL_CONTRACT_PATH,
-        "--yul",
-        "--standard-json",
-    ];
+    let args = &[cli::TEST_YUL_CONTRACT_PATH, "--yul", "--standard-json"];
 
     // Execute zksolc with incompatible --yul and --standard-json flags
-    let result = cli_tests::execute_zksolc(args)?;
+    let result = cli::execute_zksolc(args)?;
     result
         .success()
         .stdout(predicate::str::contains(

--- a/era-compiler-solidity/tests/cli_tests.rs
+++ b/era-compiler-solidity/tests/cli_tests.rs
@@ -1,0 +1,4 @@
+#![cfg(test)]
+
+mod cli;
+pub mod common;

--- a/era-compiler-solidity/tests/common/mod.rs
+++ b/era-compiler-solidity/tests/common/mod.rs
@@ -2,8 +2,6 @@
 //! The Solidity compiler unit tests.
 //!
 
-#![cfg(test)]
-
 use assert_cmd::Command;
 use era_compiler_solidity::message_type::MessageType;
 use era_compiler_solidity::project::Project;

--- a/era-compiler-solidity/tests/regression/factory_dependency.rs
+++ b/era-compiler-solidity/tests/regression/factory_dependency.rs
@@ -2,14 +2,10 @@
 //! The Solidity compiler unit tests for factory dependencies.
 //!
 
-#![cfg(test)]
-
-pub mod common;
-
-use std::collections::BTreeMap;
-
+use crate::common;
 use era_compiler_solidity::solc::pipeline::Pipeline as SolcPipeline;
 use era_compiler_solidity::solc::Compiler as SolcCompiler;
+use std::collections::BTreeMap;
 
 #[test]
 #[cfg_attr(target_os = "windows", ignore)]

--- a/era-compiler-solidity/tests/regression/ir_artifacts.rs
+++ b/era-compiler-solidity/tests/regression/ir_artifacts.rs
@@ -4,14 +4,10 @@
 //! The tests check if the IR artifacts are kept in the final output.
 //!
 
-#![cfg(test)]
-
-pub mod common;
-
-use std::collections::BTreeMap;
-
+use crate::common;
 use era_compiler_solidity::solc::pipeline::Pipeline as SolcPipeline;
 use era_compiler_solidity::solc::Compiler as SolcCompiler;
+use std::collections::BTreeMap;
 
 #[test]
 #[cfg_attr(target_os = "windows", ignore)]

--- a/era-compiler-solidity/tests/regression/libraries.rs
+++ b/era-compiler-solidity/tests/regression/libraries.rs
@@ -2,14 +2,10 @@
 //! The Solidity compiler unit tests for libraries.
 //!
 
-#![cfg(test)]
-
-pub mod common;
-
-use std::collections::BTreeMap;
-
+use crate::common;
 use era_compiler_solidity::solc::pipeline::Pipeline as SolcPipeline;
 use era_compiler_solidity::solc::Compiler as SolcCompiler;
+use std::collections::BTreeMap;
 
 #[test]
 #[cfg_attr(target_os = "windows", ignore)]

--- a/era-compiler-solidity/tests/regression/messages.rs
+++ b/era-compiler-solidity/tests/regression/messages.rs
@@ -2,15 +2,11 @@
 //! The Solidity compiler unit tests for messages.
 //!
 
-#![cfg(test)]
-
-pub mod common;
-
-use std::collections::BTreeMap;
-
+use crate::common;
 use era_compiler_solidity::message_type::MessageType;
 use era_compiler_solidity::solc::pipeline::Pipeline as SolcPipeline;
 use era_compiler_solidity::solc::Compiler as SolcCompiler;
+use std::collections::BTreeMap;
 
 #[test]
 #[cfg_attr(target_os = "windows", ignore)]

--- a/era-compiler-solidity/tests/regression/mod.rs
+++ b/era-compiler-solidity/tests/regression/mod.rs
@@ -1,0 +1,8 @@
+mod factory_dependency;
+mod ir_artifacts;
+mod libraries;
+mod messages;
+mod optimizer;
+mod remappings;
+mod standard_json;
+mod unsupported_instructions;

--- a/era-compiler-solidity/tests/regression/optimizer.rs
+++ b/era-compiler-solidity/tests/regression/optimizer.rs
@@ -2,14 +2,10 @@
 //! The Solidity compiler unit tests for the optimizer.
 //!
 
-#![cfg(test)]
-
-pub mod common;
-
-use std::collections::BTreeMap;
-
+use crate::common;
 use era_compiler_solidity::solc::pipeline::Pipeline as SolcPipeline;
 use era_compiler_solidity::solc::Compiler as SolcCompiler;
+use std::collections::BTreeMap;
 
 #[test]
 #[cfg_attr(target_os = "windows", ignore)]

--- a/era-compiler-solidity/tests/regression/remappings.rs
+++ b/era-compiler-solidity/tests/regression/remappings.rs
@@ -2,15 +2,11 @@
 //! The Solidity compiler unit tests for remappings.
 //!
 
-#![cfg(test)]
-
-pub mod common;
-
-use std::collections::BTreeMap;
-use std::collections::BTreeSet;
-
+use crate::common;
 use era_compiler_solidity::solc::pipeline::Pipeline as SolcPipeline;
 use era_compiler_solidity::solc::Compiler as SolcCompiler;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 
 #[test]
 #[cfg_attr(target_os = "windows", ignore)]

--- a/era-compiler-solidity/tests/regression/standard_json.rs
+++ b/era-compiler-solidity/tests/regression/standard_json.rs
@@ -2,14 +2,10 @@
 //! The unit tests for standard JSON with different languages.
 //!
 
-#![cfg(test)]
-
-pub mod common;
-
-use std::path::PathBuf;
-
+use crate::common;
 use era_compiler_solidity::solc::standard_json::input::Input as SolcStandardJsonInput;
 use era_compiler_solidity::solc::Compiler as SolcCompiler;
+use std::path::PathBuf;
 
 #[test]
 fn standard_json_yul_default() {

--- a/era-compiler-solidity/tests/regression/unsupported_instructions.rs
+++ b/era-compiler-solidity/tests/regression/unsupported_instructions.rs
@@ -2,14 +2,10 @@
 //! The Solidity compiler unit tests for unsupported instructions.
 //!
 
-#![cfg(test)]
-
-pub mod common;
-
-use std::collections::BTreeMap;
-
+use crate::common;
 use era_compiler_solidity::solc::pipeline::Pipeline as SolcPipeline;
 use era_compiler_solidity::solc::Compiler as SolcCompiler;
+use std::collections::BTreeMap;
 
 #[test]
 #[cfg_attr(target_os = "windows", ignore)]

--- a/era-compiler-solidity/tests/regression_tests.rs
+++ b/era-compiler-solidity/tests/regression_tests.rs
@@ -1,0 +1,4 @@
+#![cfg(test)]
+
+pub mod common;
+mod regression;


### PR DESCRIPTION
# What ❔

* [x] Introduce only `cli` and `regression` test crates to execute with `cargo test`

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

`cargo test` by default runs each test crate (i.e. file in the `tests` directory in this case) sequentially. We get a significant speedup if we group the tests into fewer files. In this case, instead of 15 seconds, we go down to 2.5.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
