### PR TITLE
ci: add cross-dependency testing PoC workflow

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -1,0 +1,40 @@
+name: [PoC] Dependencies test
+
+on:
+  workflow_dispatch:
+    inputs:
+      dependencies_branch:
+        description: 'Branch of testing dependencies'
+        required: true
+        default: ''
+        type: string
+
+jobs:
+  dependencies-check:
+    runs-on: matterlabs-ci-runner
+    container:
+      image: ghcr.io/matter-labs/zksync-llvm-runner:latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.dependencies_branch }}
+
+      - name: Patch era-compiler-common
+        run: |
+          echo "[patch.\"https://github.com/matter-labs/era-compiler-common\"]" >> "Cargo.toml"
+          echo "era-compiler-common = { git = 'https://www.github.com/matter-labs/era-compiler-common', branch = '${{ inputs.dependencies_branch }}' }" >> "Cargo.toml"
+
+      - name: Patch era-compiler-llvm-context
+        run: |
+          echo "[patch.\"https://github.com/matter-labs/era-compiler-llvm-context\"]" >> "Cargo.toml"
+          echo "era-compiler-common = { git = 'https://www.github.com/matter-labs/era-compiler-llvm-context', branch = '${{ inputs.dependencies_branch }}' }" >> "Cargo.toml"
+
+      - name: Build LLVM
+        uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@v1
+        with:
+          enable-assertions: false
+
+      - name: Run tests
+        uses: ./.github/actions/unit-tests


### PR DESCRIPTION
# What ❔

Add initial WIP PoC workflow that can be triggered by dependencies to test VS `zksolc`.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

It is required to be in the `main` default branch to be tested for the first time. The code is just PoC and is only for testing purposes.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
