### PR TITLE
fix: rename solc_downloader to era_compiler_downloader

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -1,4 +1,4 @@
-name: [PoC] Dependencies test
+name: Dependencies test
 
 on:
   workflow_dispatch:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 [[package]]
 name = "era-compiler-common"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#da3a2ca37e9e2693d5d974346667276d0c90b6a8"
+source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#be47c80014b3519f4b4f428852952232bd240f53"
 dependencies = [
  "anyhow",
  "base58",
@@ -522,6 +522,19 @@ dependencies = [
  "serde_json",
  "serde_stacker",
  "sha3 0.10.8",
+]
+
+[[package]]
+name = "era-compiler-downloader"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#be47c80014b3519f4b4f428852952232bd240f53"
+dependencies = [
+ "anyhow",
+ "colored",
+ "openssl",
+ "reqwest",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -546,8 +559,8 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "era-compiler-common",
+ "era-compiler-downloader",
  "era-compiler-llvm-context",
- "era-solc-downloader",
  "hex",
  "inkwell",
  "mimalloc",
@@ -569,19 +582,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "which",
-]
-
-[[package]]
-name = "era-solc-downloader"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#9deb616c1498dc690a6b0abd446af83779304c6f"
-dependencies = [
- "anyhow",
- "colored",
- "openssl",
- "reqwest",
- "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/era-compiler-solidity/Cargo.toml
+++ b/era-compiler-solidity/Cargo.toml
@@ -42,7 +42,7 @@ assert_cmd = "2.0.16"
 predicates = "3.1.2"
 tempfile = "3.12.0"
 reqwest = { version = "0.11.27", features = ["blocking", "json"] }
-era-solc-downloader = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
+era-compiler-downloader = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 
 [dependencies.inkwell]
 git = "https://github.com/matter-labs-forks/inkwell"

--- a/era-compiler-solidity/tests/common/mod.rs
+++ b/era-compiler-solidity/tests/common/mod.rs
@@ -53,7 +53,7 @@ pub fn download_binaries() -> anyhow::Result<()> {
     http_client_builder = http_client_builder.timeout(Duration::from_secs(60));
     let http_client = http_client_builder.build()?;
     let config_path = Path::new(SOLC_BIN_CONFIG);
-    era_solc_downloader::Downloader::new(http_client.clone()).download(config_path)?;
+    era_compiler_downloader::Downloader::new(http_client.clone()).download(config_path)?;
     // Copy the latest `solc-*` binary to `solc` for CLI tests
     let latest_solc =
         PathBuf::from(get_solc_compiler(&SolcCompiler::LAST_SUPPORTED_VERSION)?.executable);


### PR DESCRIPTION
# What ❔

Rename solc_downloader to era_compiler_downloader.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Fix after common repo update.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
