### PR TITLE
feat: support solc v0.8.27

### DIFF
--- a/.github/actions/install-solc/action.yml
+++ b/.github/actions/install-solc/action.yml
@@ -8,11 +8,11 @@ inputs:
   solc-version-latest:
     description: 'The latest version of solc.'
     required: false
-    default: '0.8.26-1.0.1'
+    default: '0.8.27-1.0.1'
   solc-zksync-versions:
     description: 'Space-separated list of ZKsync solc versions to download.'
     required: false
-    default: '0.4.26-1.0.1 0.5.17-1.0.1 0.6.12-1.0.1 0.7.6-1.0.1 0.8.26-1.0.1'
+    default: '0.4.26-1.0.1 0.5.17-1.0.1 0.6.12-1.0.1 0.7.6-1.0.1 0.8.27-1.0.1'
   solc-upstream-versions:
     description: 'Space-separated list of upstream solc versions to download (on Windows only).'
     required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - The support for IPFS metadata hash type
 - The EraVM disassembler
+- The solc v0.8.27 support
 
 ## [1.5.3] - 2024-08-27
 

--- a/era-compiler-solidity/src/solc/mod.rs
+++ b/era-compiler-solidity/src/solc/mod.rs
@@ -50,7 +50,7 @@ impl Compiler {
     pub const FIRST_CANCUN_VERSION: semver::Version = semver::Version::new(0, 8, 24);
 
     /// The last supported version of `solc`.
-    pub const LAST_SUPPORTED_VERSION: semver::Version = semver::Version::new(0, 8, 26);
+    pub const LAST_SUPPORTED_VERSION: semver::Version = semver::Version::new(0, 8, 27);
 
     ///
     /// A shortcut constructor lazily using a thread-safe cell.

--- a/era-compiler-solidity/tests/solc-bin.json
+++ b/era-compiler-solidity/tests/solc-bin.json
@@ -24,7 +24,7 @@
       "source": "https://github.com/matter-labs/era-solidity/releases/download/${VERSION}-1.0.1/solc-${PLATFORM}-${VERSION}-1.0.1",
       "destination": "./solc-bin/solc-${VERSION}"
     },
-    "0.8.26": {
+    "0.8.27": {
       "is_enabled": true,
       "protocol": "https",
       "source": "https://github.com/matter-labs/era-solidity/releases/download/${VERSION}-1.0.1/solc-${PLATFORM}-${VERSION}-1.0.1",


### PR DESCRIPTION
# What ❔

Adds the support for solc v0.8.27.

## Why ❔

It was released by EF.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
