### PR TITLE
fix: correctly deserialize suppressed_warnings and suppressed-errors from standard json input

### DIFF
--- a/era-compiler-solidity/src/message_type.rs
+++ b/era-compiler-solidity/src/message_type.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 /// The compiler message type.
 ///
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum MessageType {
     /// The error for eponymous feature.
     SendTransfer,

--- a/era-compiler-solidity/tests/cli/mod.rs
+++ b/era-compiler-solidity/tests/cli/mod.rs
@@ -45,6 +45,14 @@ pub const TEST_LLVM_CONTRACT_PATH: &str = "tests/examples/contracts/llvm/contrac
 /// The standard JSON contract path
 pub const TEST_JSON_CONTRACT_PATH: &str = "tests/examples/contracts/json/contract.json";
 
+/// The standard JSON contract path with suppressed errors and warnings
+pub const TEST_JSON_CONTRACT_PATH_SUPPRESSED_ERRORS_AND_WARNINGS: &str =
+    "tests/examples/standard_json_input/contract_suppressed_warnings_and_errors.json";
+
+/// The standard JSON contract path with incorrect suppressed errors and warnings
+pub const TEST_JSON_CONTRACT_PATH_INCORRECT_SUPPRESSED_ERRORS_AND_WARNINGS: &str =
+    "tests/examples/standard_json_input/contract_incorrect_suppressed_warnings_and_errors.json";
+
 /// The binary bytecode sample path
 pub const TEST_BINARY_BYTECODE_PATH: &str = "tests/examples/bytecodes/bytecode.zbin";
 

--- a/era-compiler-solidity/tests/cli/standard_json.rs
+++ b/era-compiler-solidity/tests/cli/standard_json.rs
@@ -49,3 +49,58 @@ fn run_zksolc_with_standard_json_incompatible_input() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn run_zksolc_with_standard_json_suppressed_errors_and_warnings_deserialization(
+) -> anyhow::Result<()> {
+    let _ = common::setup();
+    let solc_compiler =
+        common::get_solc_compiler(&era_compiler_solidity::SolcCompiler::LAST_SUPPORTED_VERSION)?
+            .executable;
+    let args = &[
+        "--solc",
+        solc_compiler.as_str(),
+        "--standard-json",
+        cli::TEST_JSON_CONTRACT_PATH_SUPPRESSED_ERRORS_AND_WARNINGS,
+    ];
+    let args_solc = &[
+        "--standard-json",
+        cli::TEST_JSON_CONTRACT_PATH_SUPPRESSED_ERRORS_AND_WARNINGS,
+    ];
+
+    let result = cli::execute_zksolc(args)?;
+    let zksolc_exit_code = result
+        .success()
+        .stdout(predicate::str::contains("bytecode"))
+        .get_output()
+        .status
+        .code()
+        .expect("No exit code.");
+
+    let solc_result = cli::execute_solc(args_solc)?;
+    solc_result.code(zksolc_exit_code);
+
+    Ok(())
+}
+
+#[test]
+fn run_zksolc_with_incorrect_standard_json_suppressed_errors_and_warnings_deserialization(
+) -> anyhow::Result<()> {
+    let _ = common::setup();
+    let solc_compiler =
+        common::get_solc_compiler(&era_compiler_solidity::SolcCompiler::LAST_SUPPORTED_VERSION)?
+            .executable;
+    let args = &[
+        "--solc",
+        solc_compiler.as_str(),
+        "--standard-json",
+        cli::TEST_JSON_CONTRACT_PATH_INCORRECT_SUPPRESSED_ERRORS_AND_WARNINGS,
+    ];
+
+    let result = cli::execute_zksolc(args)?;
+    result.success().stdout(predicate::str::contains(
+        "unknown variant `INVALID_SUPPRESSED_MESSAGE_TYPE`",
+    ));
+
+    Ok(())
+}

--- a/era-compiler-solidity/tests/examples/standard_json_input/contract_incorrect_suppressed_warnings_and_errors.json
+++ b/era-compiler-solidity/tests/examples/standard_json_input/contract_incorrect_suppressed_warnings_and_errors.json
@@ -1,0 +1,16 @@
+{
+  "language": "Solidity",
+  "sources": {
+    "A": {
+      "content": "// SPDX-License-Identifier: GPL-3.0\npragma solidity >=0.0; contract C {}"
+    }
+  },
+  "settings": {
+    "optimizer": {
+      "enabled": true,
+      "runs": 200
+    }
+  },
+  "suppressedErrors": ["INVALID_SUPPRESSED_MESSAGE_TYPE"],
+  "suppressedWarnings": ["INVALID_SUPPRESSED_MESSAGE_TYPE"]
+}

--- a/era-compiler-solidity/tests/examples/standard_json_input/contract_suppressed_warnings_and_errors.json
+++ b/era-compiler-solidity/tests/examples/standard_json_input/contract_suppressed_warnings_and_errors.json
@@ -1,0 +1,16 @@
+{
+  "language": "Solidity",
+  "sources": {
+    "A": {
+      "content": "// SPDX-License-Identifier: GPL-3.0\npragma solidity >=0.0; contract C { function distribute(address payable recipient) public { recipient.send(1); recipient.transfer(1); payable(tx.origin).transfer(1); } }"
+    }
+  },
+  "settings": {
+    "optimizer": {
+      "enabled": true,
+      "runs": 200
+    }
+  },
+  "suppressedErrors": ["sendtransfer"],
+  "suppressedWarnings": ["txorigin"]
+}


### PR DESCRIPTION
# What ❔

This PR fixes the deserialisation of suppressed warnings and errors according to the error message in https://github.com/matter-labs/era-compiler-solidity/blob/4f20b3e6d220975cae4344c481ee1a5ffd87aa37/era-compiler-solidity/src/solc/standard_json/output/error/mod.rs#L157-L173

## Why ❔

I was trying to compile a contract, and then I stumbled upon this error:
```
Learn more about reentrancy at https://docs.soliditylang.org/en/latest/security-considerations.html#reentrancy

You may disable this error with:
    1. `suppressedErrors = ["sendtransfer"]` in standard JSON.
    2. `--suppress-errors sendtransfer` in the CLI.
    --> contracts/Safe.sol:243:19
```

I thought it was not a big deal, so I specified:
```
suppressedErrors: ["sendtransfer"]
```
In my standard JSON input. But then I got another error:
```
Error: Standard JSON parsing from stdin: unknown variant `sendtransfer`, expected `SendTransfer` or `TxOrigin` at line 1 column 575
```

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.

## Alternative solutions to be also considered
- Adjust the error message

I enabled edits by maintainers, so feel free to add quick fixes yourself.