### PR TITLE
feat: add a verbatim to return data from the constructor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,6 +584,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "which",
+ "zkevm_opcode_defs",
 ]
 
 [[package]]

--- a/era-compiler-solidity/Cargo.toml
+++ b/era-compiler-solidity/Cargo.toml
@@ -34,6 +34,8 @@ hex = "0.4"
 num = "0.4"
 sha3 = "0.10"
 
+zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_defs", branch = "v1.5.0" }
+
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
 era-yul = { path = "../era-yul" }

--- a/era-compiler-solidity/src/yul/parser/statement/expression/function_call/verbatim.rs
+++ b/era-compiler-solidity/src/yul/parser/statement/expression/function_call/verbatim.rs
@@ -941,6 +941,27 @@ where
             )
             .map(Some)
         }
+        identifier @ "return_deployed" => {
+            const ARGUMENTS_COUNT: usize = 2;
+            if input_size != ARGUMENTS_COUNT {
+                anyhow::bail!(
+                    "{} Internal function `{}` expected {} arguments, found {}",
+                    call.0.location,
+                    identifier,
+                    ARGUMENTS_COUNT,
+                    input_size
+                );
+            }
+
+            let arguments = call.pop_arguments_llvm::<D, ARGUMENTS_COUNT>(context)?;
+            context
+                .build_exit(
+                    context.llvm_runtime().r#return,
+                    arguments[0].into_int_value(),
+                    arguments[1].into_int_value(),
+                )
+                .map(|_| None)
+        }
         identifier => anyhow::bail!(
             "{} Found unknown internal function `{}`",
             call.0.location,

--- a/era-compiler-solidity/src/yul/parser/statement/expression/function_call/verbatim.rs
+++ b/era-compiler-solidity/src/yul/parser/statement/expression/function_call/verbatim.rs
@@ -954,13 +954,19 @@ where
             }
 
             let arguments = call.pop_arguments_llvm::<D, ARGUMENTS_COUNT>(context)?;
-            context
-                .build_exit(
-                    context.llvm_runtime().r#return,
-                    arguments[0].into_int_value(),
-                    arguments[1].into_int_value(),
-                )
-                .map(|_| None)
+            context.build_call(
+                context.llvm_runtime().r#return,
+                &[
+                    arguments[0],
+                    arguments[1],
+                    context
+                        .field_const(zkevm_opcode_defs::RetForwardPageType::UseHeap as u64)
+                        .as_basic_value_enum(),
+                ],
+                "return_deployed",
+            )?;
+            context.build_unreachable()?;
+            Ok(None)
         }
         identifier => anyhow::bail!(
             "{} Found unknown internal function `{}`",


### PR DESCRIPTION
# What ❔

Adds a verbatim to return arbitrary data from the constructor.

## Why ❔

It is needed for the EVM interpreter to return EVM bytecode from the constructor.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
