### PR TITLE
fix: output directory for non-Solidity contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - The compilation pipeline that was not run without output parameters
+- Broken `--output-dir` output paths for non-Solidity contracts
 
 ## [1.5.4] - 2024-09-24
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
@@ -240,9 +240,9 @@ checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cc"
-version = "1.1.21"
+version = "1.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
+checksum = "3bbb537bb4a30b90362caddba8f360c0a56bc13d3a5570028e7197204cb54a17"
 dependencies = [
  "shlex",
 ]
@@ -512,7 +512,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 [[package]]
 name = "era-compiler-common"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#20f20ca069c9bfea46e97d2cdadeac10ff198947"
+source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#3207c451486e49df6e241167d8c6577222ecbd8e"
 dependencies = [
  "anyhow",
  "base58",
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-downloader"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#20f20ca069c9bfea46e97d2cdadeac10ff198947"
+source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#3207c451486e49df6e241167d8c6577222ecbd8e"
 dependencies = [
  "anyhow",
  "colored",
@@ -541,7 +541,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#8ee09a90e1969f98b175c49442b08805a8ce474e"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#f11814aa79e37442d333e872fcfacc87eabdedae"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -1032,7 +1032,7 @@ source = "git+https://github.com/matter-labs-forks/inkwell?branch=llvm-17#993d38
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1119,9 +1119,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -1373,9 +1373,12 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -1406,7 +1409,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1546,6 +1549,12 @@ name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "ppv-lite86"
@@ -1735,18 +1744,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.4"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1756,9 +1765,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1773,9 +1782,9 @@ checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -1976,7 +1985,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2185,9 +2194,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2229,9 +2238,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -2272,7 +2281,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2345,9 +2354,9 @@ checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.21"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2517,7 +2526,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-shared",
 ]
 
@@ -2551,7 +2560,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2734,9 +2743,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
@@ -2784,7 +2793,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]

--- a/era-compiler-solidity/src/build_eravm/contract.rs
+++ b/era-compiler-solidity/src/build_eravm/contract.rs
@@ -6,6 +6,7 @@ use std::collections::HashSet;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
+use std::path::PathBuf;
 
 use crate::solc::combined_json::contract::Contract as CombinedJsonContract;
 use crate::solc::standard_json::output::contract::evm::EVM as StandardJsonOutputContractEVM;
@@ -16,8 +17,11 @@ use crate::solc::standard_json::output::contract::Contract as StandardJsonOutput
 ///
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Contract {
-    /// The contract path.
+    /// The absolute file path.
     pub path: String,
+    /// The contract name.
+    /// Is set for Solidity contracts only. Otherwise it would be equal to the file name.
+    pub name: Option<String>,
     /// The auxiliary identifier. Used to identify Yul objects.
     pub identifier: String,
     /// The LLVM module build.
@@ -34,6 +38,7 @@ impl Contract {
     ///
     pub fn new(
         path: String,
+        name: Option<String>,
         identifier: String,
         build: era_compiler_llvm_context::EraVMBuild,
         metadata_json: serde_json::Value,
@@ -41,6 +46,7 @@ impl Contract {
     ) -> Self {
         Self {
             path,
+            name,
             identifier,
             build,
             metadata_json,
@@ -80,79 +86,88 @@ impl Contract {
     ///
     pub fn write_to_directory(
         self,
-        path: &Path,
+        output_path: &Path,
         output_metadata: bool,
         output_binary: bool,
         overwrite: bool,
     ) -> anyhow::Result<()> {
-        let (file_name, contract_name) = Self::split_path(self.path.as_str());
+        let file_path = PathBuf::from(self.path);
+        let file_name = file_path
+            .file_name()
+            .expect("Always exists")
+            .to_str()
+            .expect("Always valid");
+
+        let mut output_path = output_path.to_owned();
+        output_path.push(file_name);
+        std::fs::create_dir_all(output_path.as_path())?;
 
         if output_metadata {
             let output_name = format!(
                 "{}_meta.{}",
-                contract_name,
+                self.name.as_deref().unwrap_or(file_name),
                 era_compiler_common::EXTENSION_JSON,
             );
-            let mut file_path = path.to_owned();
-            file_path.push(file_name.as_str());
-            std::fs::create_dir_all(file_path.as_path())?;
-            file_path.push(output_name.as_str());
+            let mut output_path = output_path.clone();
+            output_path.push(output_name.as_str());
 
-            if file_path.exists() && !overwrite {
+            if output_path.exists() && !overwrite {
                 anyhow::bail!(
-                    "Refusing to overwrite an existing file {file_path:?} (use --overwrite to force)."
+                    "Refusing to overwrite an existing file {output_path:?} (use --overwrite to force)."
                 );
             } else {
-                File::create(&file_path)
-                    .map_err(|error| anyhow::anyhow!("File {:?} creating: {}", file_path, error))?
+                File::create(&output_path)
+                    .map_err(|error| anyhow::anyhow!("File {:?} creating: {}", output_path, error))?
                     .write_all(self.metadata_json.to_string().as_bytes())
-                    .map_err(|error| anyhow::anyhow!("File {:?} writing: {}", file_path, error))?;
+                    .map_err(|error| {
+                        anyhow::anyhow!("File {:?} writing: {}", output_path, error)
+                    })?;
             }
         }
 
         if let Some(assembly) = self.build.assembly {
             let output_name = format!(
                 "{}.{}",
-                contract_name,
+                self.name.as_deref().unwrap_or(file_name),
                 era_compiler_common::EXTENSION_ERAVM_ASSEMBLY
             );
-            let mut file_path = path.to_owned();
-            file_path.push(file_name.as_str());
-            std::fs::create_dir_all(file_path.as_path())?;
-            file_path.push(output_name.as_str());
+            let mut output_path = output_path.clone();
+            output_path.push(output_name.as_str());
 
-            if file_path.exists() && !overwrite {
+            if output_path.exists() && !overwrite {
                 anyhow::bail!(
-                    "Refusing to overwrite an existing file {file_path:?} (use --overwrite to force)."
+                    "Refusing to overwrite an existing file {output_path:?} (use --overwrite to force)."
                 );
             } else {
-                File::create(&file_path)
-                    .map_err(|error| anyhow::anyhow!("File {:?} creating: {}", file_path, error))?
+                File::create(&output_path)
+                    .map_err(|error| anyhow::anyhow!("File {:?} creating: {}", output_path, error))?
                     .write_all(assembly.as_bytes())
-                    .map_err(|error| anyhow::anyhow!("File {:?} writing: {}", file_path, error))?;
+                    .map_err(|error| {
+                        anyhow::anyhow!("File {:?} writing: {}", output_path, error)
+                    })?;
             }
         }
 
         if output_binary {
             let output_name = format!(
                 "{}.{}",
-                contract_name,
+                self.name.as_deref().unwrap_or(file_name),
                 era_compiler_common::EXTENSION_ERAVM_BINARY
             );
-            let mut file_path = path.to_owned();
-            file_path.push(file_name.as_str());
-            std::fs::create_dir_all(file_path.as_path())?;
-            file_path.push(output_name.as_str());
+            let mut output_path = output_path.clone();
+            output_path.push(output_name.as_str());
 
-            if file_path.exists() && !overwrite {
+            if output_path.exists() && !overwrite {
                 anyhow::bail!(
-                    "Refusing to overwrite an existing file {file_path:?} (use --overwrite to force)."
+                    "Refusing to overwrite an existing file {output_path:?} (use --overwrite to force)."
                 );
             } else {
-                File::create(&file_path)
-                    .map_err(|error| anyhow::anyhow!("File {:?} creating: {}", file_path, error))?
+                File::create(&output_path)
+                    .map_err(|error| anyhow::anyhow!("File {:?} creating: {}", output_path, error))?
                     .write_all(hex::encode(self.build.bytecode.as_slice()).as_bytes())
-                    .map_err(|error| anyhow::anyhow!("File {:?} writing: {}", file_path, error))?;
+                    .map_err(|error| {
+                        anyhow::anyhow!("File {:?} writing: {}", output_path, error)
+                    })?;
             }
         }
 
@@ -201,16 +216,5 @@ impl Contract {
         standard_json_contract.hash = self.build.bytecode_hash.map(hex::encode);
 
         Ok(())
-    }
-
-    ///
-    /// Extracts the file and contract names from the full path.
-    ///
-    pub fn split_path(path: &str) -> (String, String) {
-        let path = path.trim().replace(['\\', ':'], "/");
-        let mut path_iterator = path.split('/').rev();
-        let contract_name = path_iterator.next().expect("Always exists");
-        let file_name = path_iterator.next().expect("Always exists");
-        (file_name.to_owned(), contract_name.to_owned())
     }
 }

--- a/era-compiler-solidity/src/build_eravm/contract.rs
+++ b/era-compiler-solidity/src/build_eravm/contract.rs
@@ -17,11 +17,8 @@ use crate::solc::standard_json::output::contract::Contract as StandardJsonOutput
 ///
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Contract {
-    /// The absolute file path.
-    pub path: String,
     /// The contract name.
-    /// Is set for Solidity contracts only. Otherwise it would be equal to the file name.
-    pub name: Option<String>,
+    pub name: era_compiler_common::ContractName,
     /// The auxiliary identifier. Used to identify Yul objects.
     pub identifier: String,
     /// The LLVM module build.
@@ -37,15 +34,13 @@ impl Contract {
     /// A shortcut constructor.
     ///
     pub fn new(
-        path: String,
-        name: Option<String>,
+        name: era_compiler_common::ContractName,
         identifier: String,
         build: era_compiler_llvm_context::EraVMBuild,
         metadata_json: serde_json::Value,
         factory_dependencies: HashSet<String>,
     ) -> Self {
         Self {
-            path,
             name,
             identifier,
             build,
@@ -91,7 +86,7 @@ impl Contract {
         output_binary: bool,
         overwrite: bool,
     ) -> anyhow::Result<()> {
-        let file_path = PathBuf::from(self.path);
+        let file_path = PathBuf::from(self.name.path);
         let file_name = file_path
             .file_name()
             .expect("Always exists")
@@ -105,7 +100,7 @@ impl Contract {
         if output_metadata {
             let output_name = format!(
                 "{}_meta.{}",
-                self.name.as_deref().unwrap_or(file_name),
+                self.name.name.as_deref().unwrap_or(file_name),
                 era_compiler_common::EXTENSION_JSON,
             );
             let mut output_path = output_path.clone();
@@ -128,7 +123,7 @@ impl Contract {
         if let Some(assembly) = self.build.assembly {
             let output_name = format!(
                 "{}.{}",
-                self.name.as_deref().unwrap_or(file_name),
+                self.name.name.as_deref().unwrap_or(file_name),
                 era_compiler_common::EXTENSION_ERAVM_ASSEMBLY
             );
             let mut output_path = output_path.clone();
@@ -151,7 +146,7 @@ impl Contract {
         if output_binary {
             let output_name = format!(
                 "{}.{}",
-                self.name.as_deref().unwrap_or(file_name),
+                self.name.name.as_deref().unwrap_or(file_name),
                 era_compiler_common::EXTENSION_ERAVM_BINARY
             );
             let mut output_path = output_path.clone();

--- a/era-compiler-solidity/src/build_evm/contract.rs
+++ b/era-compiler-solidity/src/build_evm/contract.rs
@@ -16,11 +16,8 @@ use crate::solc::standard_json::output::contract::Contract as StandardJsonOutput
 ///
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Contract {
-    /// The absolute file path.
-    pub path: String,
     /// The contract name.
-    /// Is set for Solidity contracts only. Otherwise it would be equal to the file name.
-    pub name: Option<String>,
+    pub name: era_compiler_common::ContractName,
     /// The auxiliary identifier. Used to identify Yul objects.
     pub identifier: String,
     /// The LLVM deploy code module build.
@@ -36,15 +33,13 @@ impl Contract {
     /// A shortcut constructor.
     ///
     pub fn new(
-        path: String,
-        name: Option<String>,
+        name: era_compiler_common::ContractName,
         identifier: String,
         deploy_build: era_compiler_llvm_context::EVMBuild,
         runtime_build: era_compiler_llvm_context::EVMBuild,
         metadata_json: serde_json::Value,
     ) -> Self {
         Self {
-            path,
             name,
             identifier,
             deploy_build,
@@ -93,7 +88,7 @@ impl Contract {
         output_binary: bool,
         overwrite: bool,
     ) -> anyhow::Result<()> {
-        let file_path = PathBuf::from(self.path);
+        let file_path = PathBuf::from(self.name.path);
         let file_name = file_path
             .file_name()
             .expect("Always exists")
@@ -114,7 +109,7 @@ impl Contract {
             {
                 let output_name = format!(
                     "{}.{}.{}",
-                    self.name.as_deref().unwrap_or(file_name),
+                    self.name.name.as_deref().unwrap_or(file_name),
                     code_type,
                     era_compiler_common::EXTENSION_EVM_BINARY
                 );

--- a/era-compiler-solidity/src/build_evm/contract.rs
+++ b/era-compiler-solidity/src/build_evm/contract.rs
@@ -5,6 +5,7 @@
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
+use std::path::PathBuf;
 
 use crate::solc::combined_json::contract::Contract as CombinedJsonContract;
 use crate::solc::standard_json::output::contract::evm::EVM as StandardJsonOutputContractEVM;
@@ -15,8 +16,11 @@ use crate::solc::standard_json::output::contract::Contract as StandardJsonOutput
 ///
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Contract {
-    /// The contract path.
+    /// The absolute file path.
     pub path: String,
+    /// The contract name.
+    /// Is set for Solidity contracts only. Otherwise it would be equal to the file name.
+    pub name: Option<String>,
     /// The auxiliary identifier. Used to identify Yul objects.
     pub identifier: String,
     /// The LLVM deploy code module build.
@@ -33,6 +37,7 @@ impl Contract {
     ///
     pub fn new(
         path: String,
+        name: Option<String>,
         identifier: String,
         deploy_build: era_compiler_llvm_context::EVMBuild,
         runtime_build: era_compiler_llvm_context::EVMBuild,
@@ -40,6 +45,7 @@ impl Contract {
     ) -> Self {
         Self {
             path,
+            name,
             identifier,
             deploy_build,
             runtime_build,
@@ -82,12 +88,21 @@ impl Contract {
     ///
     pub fn write_to_directory(
         self,
-        path: &Path,
+        output_path: &Path,
         _output_assembly: bool,
         output_binary: bool,
         overwrite: bool,
     ) -> anyhow::Result<()> {
-        let (file_name, contract_name) = Self::split_path(self.path.as_str());
+        let file_path = PathBuf::from(self.path);
+        let file_name = file_path
+            .file_name()
+            .expect("Always exists")
+            .to_str()
+            .expect("Always valid");
+
+        let mut output_path = output_path.to_owned();
+        output_path.push(file_name);
+        std::fs::create_dir_all(output_path.as_path())?;
 
         if output_binary {
             for (code_type, bytecode) in [
@@ -99,27 +114,25 @@ impl Contract {
             {
                 let output_name = format!(
                     "{}.{}.{}",
-                    contract_name,
+                    self.name.as_deref().unwrap_or(file_name),
                     code_type,
                     era_compiler_common::EXTENSION_EVM_BINARY
                 );
-                let mut file_path = path.to_owned();
-                file_path.push(file_name.as_str());
-                std::fs::create_dir_all(file_path.as_path())?;
-                file_path.push(output_name.as_str());
+                let mut output_path = output_path.clone();
+                output_path.push(output_name.as_str());
 
-                if file_path.exists() && !overwrite {
+                if output_path.exists() && !overwrite {
                     anyhow::bail!(
-                        "Refusing to overwrite an existing file {file_path:?} (use --overwrite to force)."
+                        "Refusing to overwrite an existing file {output_path:?} (use --overwrite to force)."
                     );
                 } else {
-                    File::create(&file_path)
+                    File::create(&output_path)
                         .map_err(|error| {
-                            anyhow::anyhow!("File {:?} creating: {}", file_path, error)
+                            anyhow::anyhow!("File {:?} creating: {}", output_path, error)
                         })?
                         .write_all(hex::encode(bytecode.as_slice()).as_bytes())
                         .map_err(|error| {
-                            anyhow::anyhow!("File {:?} writing: {}", file_path, error)
+                            anyhow::anyhow!("File {:?} writing: {}", output_path, error)
                         })?;
                 }
             }
@@ -182,16 +195,5 @@ impl Contract {
             .modify_evm(deploy_bytecode, runtime_bytecode);
 
         Ok(())
-    }
-
-    ///
-    /// Extracts the file and contract names from the full path.
-    ///
-    pub fn split_path(path: &str) -> (String, String) {
-        let path = path.trim().replace(['\\', ':'], "/");
-        let mut path_iterator = path.split('/').rev();
-        let contract_name = path_iterator.next().expect("Always exists");
-        let file_name = path_iterator.next().expect("Always exists");
-        (file_name.to_owned(), contract_name.to_owned())
     }
 }

--- a/era-compiler-solidity/src/process/mod.rs
+++ b/era-compiler-solidity/src/process/mod.rs
@@ -35,7 +35,8 @@ pub fn run(target: era_compiler_common::Target) {
                 .expect("Stdin reading error");
 
             let contract = input.contract.expect("Always exists");
-            let source_location = SolcStandardJsonOutputSourceLocation::new(contract.path.clone());
+            let source_location =
+                SolcStandardJsonOutputSourceLocation::new(contract.name.path.clone());
             let result = contract
                 .compile_to_eravm(
                     input.dependency_data,
@@ -59,7 +60,8 @@ pub fn run(target: era_compiler_common::Target) {
                 .expect("Stdin reading error");
 
             let contract = input.contract.expect("Always exists");
-            let source_location = SolcStandardJsonOutputSourceLocation::new(contract.path.clone());
+            let source_location =
+                SolcStandardJsonOutputSourceLocation::new(contract.name.path.clone());
             let result = contract
                 .compile_to_evm(
                     input.dependency_data,

--- a/era-compiler-solidity/src/project/mod.rs
+++ b/era-compiler-solidity/src/project/mod.rs
@@ -157,7 +157,8 @@ impl Project {
                     };
 
                     let contract = Contract::new(
-                        full_path.clone(),
+                        (*path).to_owned(),
+                        Some((*name).to_owned()),
                         source,
                         contract.metadata.to_owned().expect("Always exists"),
                     );
@@ -241,6 +242,7 @@ impl Project {
 
                 let contract = Contract::new(
                     path.clone(),
+                    None,
                     ContractIR::new_yul(object),
                     serde_json::json!({
                         "source_hash": source_hash.to_string(),
@@ -308,6 +310,7 @@ impl Project {
 
                 let contract = Contract::new(
                     path.clone(),
+                    None,
                     ContractIR::new_llvm_ir(path.clone(), source_code),
                     serde_json::json!({
                         "source_hash": source_hash.to_string(),
@@ -374,6 +377,7 @@ impl Project {
 
                 let contract = Contract::new(
                     path.clone(),
+                    None,
                     ContractIR::new_eravm_assembly(path.clone(), source_code),
                     serde_json::json!({
                         "source_hash": source_hash.to_string(),

--- a/era-compiler-solidity/src/project/mod.rs
+++ b/era-compiler-solidity/src/project/mod.rs
@@ -109,7 +109,10 @@ impl Project {
             .par_iter()
             .filter_map(
                 |(path, name, contract)| -> Option<(String, anyhow::Result<Contract>)> {
-                    let full_path = format!("{path}:{name}");
+                    let name = era_compiler_common::ContractName::new(
+                        (*path).to_owned(),
+                        Some((*name).to_owned()),
+                    );
 
                     let source = match pipeline {
                         SolcPipeline::Yul => {
@@ -123,11 +126,11 @@ impl Project {
 
                             if let Some(debug_config) = debug_config {
                                 if let Err(error) = debug_config.dump_yul(
-                                    full_path.as_str(),
+                                    name.full_path.as_str(),
                                     None,
                                     ir_optimized.as_str(),
                                 ) {
-                                    return Some((full_path, Err(error)));
+                                    return Some((name.full_path, Err(error)));
                                 }
                             }
 
@@ -136,7 +139,7 @@ impl Project {
                                 .map_err(|error| anyhow::anyhow!("Yul parsing: {error:?}"))
                             {
                                 Ok(object) => object,
-                                Err(error) => return Some((full_path, Err(error))),
+                                Err(error) => return Some((name.full_path, Err(error))),
                             };
 
                             ContractIR::new_yul(object)
@@ -156,9 +159,9 @@ impl Project {
                         }
                     };
 
+                    let full_path = name.full_path.clone();
                     let contract = Contract::new(
-                        (*path).to_owned(),
-                        Some((*name).to_owned()),
+                        name,
                         source,
                         contract.metadata.to_owned().expect("Always exists"),
                     );
@@ -241,8 +244,7 @@ impl Project {
                 };
 
                 let contract = Contract::new(
-                    path.clone(),
-                    None,
+                    era_compiler_common::ContractName::new(path.clone(), None),
                     ContractIR::new_yul(object),
                     serde_json::json!({
                         "source_hash": source_hash.to_string(),
@@ -309,8 +311,7 @@ impl Project {
                 let source_hash = era_compiler_common::Hash::keccak256(source_code.as_bytes());
 
                 let contract = Contract::new(
-                    path.clone(),
-                    None,
+                    era_compiler_common::ContractName::new(path.clone(), None),
                     ContractIR::new_llvm_ir(path.clone(), source_code),
                     serde_json::json!({
                         "source_hash": source_hash.to_string(),
@@ -376,8 +377,7 @@ impl Project {
                 let source_hash = era_compiler_common::Hash::keccak256(source_code.as_bytes());
 
                 let contract = Contract::new(
-                    path.clone(),
-                    None,
+                    era_compiler_common::ContractName::new(path.clone(), None),
                     ContractIR::new_eravm_assembly(path.clone(), source_code),
                     serde_json::json!({
                         "source_hash": source_hash.to_string(),

--- a/era-compiler-solidity/tests/cli/llvm_ir.rs
+++ b/era-compiler-solidity/tests/cli/llvm_ir.rs
@@ -4,7 +4,7 @@ use predicates::prelude::*;
 #[test]
 fn run_zksolc_with_llvm_ir_by_default() -> anyhow::Result<()> {
     let _ = common::setup();
-    let args = &[cli::TEST_LLVM_CONTRACT_PATH, "--llvm-ir"];
+    let args = &[cli::TEST_LLVM_IR_CONTRACT_PATH, "--llvm-ir"];
     let invalid_args = &["--llvm-ir", "anyarg"];
 
     let result = cli::execute_zksolc(args)?;
@@ -21,7 +21,7 @@ fn run_zksolc_with_llvm_ir_by_default() -> anyhow::Result<()> {
 #[test]
 fn run_zksolc_with_same_llvm_ir_flags() -> anyhow::Result<()> {
     let _ = common::setup();
-    let args = &[cli::TEST_LLVM_CONTRACT_PATH, "--llvm-ir", "--llvm-ir"];
+    let args = &[cli::TEST_LLVM_IR_CONTRACT_PATH, "--llvm-ir", "--llvm-ir"];
 
     let result = cli::execute_zksolc(args)?;
     result.failure().stderr(predicate::str::contains(
@@ -48,7 +48,7 @@ fn run_zksolc_with_wrong_input_format() -> anyhow::Result<()> {
 fn run_zksolc_with_incompatible_json_modes_combined_json() -> anyhow::Result<()> {
     let _ = common::setup();
     let args = &[
-        cli::TEST_LLVM_CONTRACT_PATH,
+        cli::TEST_LLVM_IR_CONTRACT_PATH,
         "--llvm-ir",
         "--combined-json",
         "anyarg",

--- a/era-compiler-solidity/tests/cli/mod.rs
+++ b/era-compiler-solidity/tests/cli/mod.rs
@@ -38,11 +38,11 @@ pub const SOLIDITY_ASM_OUTPUT_NAME: &str = "C.zasm";
 /// The Yul contract for testing.
 pub const TEST_YUL_CONTRACT_PATH: &str = "tests/examples/contracts/yul/contract.yul";
 
+/// The LLVM IR contract path.
+pub const TEST_LLVM_IR_CONTRACT_PATH: &str = "tests/examples/contracts/llvm/contract.ll";
+
 /// The EraVM assembly contract path.
 pub const TEST_ERAVM_ASSEMBLY_CONTRACT_PATH: &str = "tests/examples/contracts/eravm/contract.zasm";
-
-/// The LLVM IR contract path.
-pub const TEST_LLVM_CONTRACT_PATH: &str = "tests/examples/contracts/llvm/contract.ll";
 
 /// The standard JSON contract path.
 pub const TEST_JSON_CONTRACT_PATH: &str = "tests/examples/contracts/json/contract.json";

--- a/era-compiler-solidity/tests/cli/output_dir.rs
+++ b/era-compiler-solidity/tests/cli/output_dir.rs
@@ -1,5 +1,6 @@
 use crate::{cli, common};
 use predicates::prelude::*;
+use std::path::PathBuf;
 use tempfile::TempDir;
 
 #[test]
@@ -37,6 +38,111 @@ fn run_zksolc_with_output_dir_by_default() -> anyhow::Result<()> {
     // Compare with solc
     let solc_result = cli::execute_solc(solc_args)?;
     solc_result.code(zksolc_status);
+
+    Ok(())
+}
+
+#[test]
+fn run_zksolc_with_output_dir_yul() -> anyhow::Result<()> {
+    let _ = common::setup();
+    let tmp_dir_zksolc = TempDir::with_prefix("zksolc_output")?;
+
+    let input_path = PathBuf::from(cli::TEST_YUL_CONTRACT_PATH);
+    let input_file = input_path
+        .file_name()
+        .expect("Always exists")
+        .to_str()
+        .expect("Always valid");
+    let zksolc_args = &[
+        input_path.to_str().expect("Always valid"),
+        "--yul",
+        "--bin",
+        "--output-dir",
+        tmp_dir_zksolc.path().to_str().unwrap(),
+    ];
+
+    // Execute zksolc command
+    let result = cli::execute_zksolc(zksolc_args)?;
+    result
+        .success()
+        .stderr(predicate::str::contains("Compiler run successful"));
+
+    // Ensure the directory is created
+    let output_file = tmp_dir_zksolc.path().join(input_file).join(format!(
+        "{input_file}.{}",
+        era_compiler_common::EXTENSION_ERAVM_BINARY
+    ));
+    assert!(output_file.exists());
+
+    Ok(())
+}
+
+#[test]
+fn run_zksolc_with_output_dir_llvm_ir() -> anyhow::Result<()> {
+    let _ = common::setup();
+    let tmp_dir_zksolc = TempDir::with_prefix("zksolc_output")?;
+
+    let input_path = PathBuf::from(cli::TEST_LLVM_IR_CONTRACT_PATH);
+    let input_file = input_path
+        .file_name()
+        .expect("Always exists")
+        .to_str()
+        .expect("Always valid");
+    let zksolc_args = &[
+        input_path.to_str().expect("Always valid"),
+        "--llvm-ir",
+        "--bin",
+        "--output-dir",
+        tmp_dir_zksolc.path().to_str().unwrap(),
+    ];
+
+    // Execute zksolc command
+    let result = cli::execute_zksolc(zksolc_args)?;
+    result
+        .success()
+        .stderr(predicate::str::contains("Compiler run successful"));
+
+    // Ensure the directory is created
+    let output_file = tmp_dir_zksolc.path().join(input_file).join(format!(
+        "{input_file}.{}",
+        era_compiler_common::EXTENSION_ERAVM_BINARY
+    ));
+    assert!(output_file.exists());
+
+    Ok(())
+}
+
+#[test]
+fn run_zksolc_with_output_dir_eravm_assembly() -> anyhow::Result<()> {
+    let _ = common::setup();
+    let tmp_dir_zksolc = TempDir::with_prefix("zksolc_output")?;
+
+    let input_path = PathBuf::from(cli::TEST_ERAVM_ASSEMBLY_CONTRACT_PATH);
+    let input_file = input_path
+        .file_name()
+        .expect("Always exists")
+        .to_str()
+        .expect("Always valid");
+    let zksolc_args = &[
+        input_path.to_str().expect("Always valid"),
+        "--eravm-assembly",
+        "--bin",
+        "--output-dir",
+        tmp_dir_zksolc.path().to_str().unwrap(),
+    ];
+
+    // Execute zksolc command
+    let result = cli::execute_zksolc(zksolc_args)?;
+    result
+        .success()
+        .stderr(predicate::str::contains("Compiler run successful"));
+
+    // Ensure the directory is created
+    let output_file = tmp_dir_zksolc.path().join(input_file).join(format!(
+        "{input_file}.{}",
+        era_compiler_common::EXTENSION_ERAVM_BINARY
+    ));
+    assert!(output_file.exists());
 
     Ok(())
 }


### PR DESCRIPTION
# What ❔

Fixes the directory output for non-Solidity contracts.

## Why ❔

Only Solidity contracts contain a semicolon in their paths.
Contracts in other languages were assumed to have a semicolon, and the output path was malformed.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
