### PR TITLE
fix: the universal binary pre-release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -173,20 +173,29 @@ jobs:
             exit 1
           fi
 
-      - name: Prepare universal macos binary
-        if: github.ref_type == 'tag' || (inputs.release_macos_amd64 && inputs.release_macos_arm64)
+      - name: Prepare universal MacOS binary (pre-release)
+        if: github.ref_type != 'tag' && github.event_name == 'workflow_dispatch' && inputs.release_macos_amd64 && inputs.release_macos_arm64
         env:
           MACOSX_UNIVERSAL_SUFFIX: "macosx"
         run: |
           OUTDIR="./releases/release-${MACOSX_UNIVERSAL_SUFFIX}/${MACOSX_UNIVERSAL_SUFFIX}"
           mkdir -p "${OUTDIR}"
-          echo "${GITHUB_REF_NAME} ${TAG_SUFFIX} ${MACOSX_UNIVERSAL_SUFFIX}"
-          [ ! -z "$GITHUB_REF_NAME" ] && TAG_SUFFIX="v${GITHUB_REF_NAME}"
-          OUTPUT="${OUTDIR}/zksolc-${MACOSX_UNIVERSAL_SUFFIX}-${TAG_SUFFIX}"
-          ls -lAR './releases/'
+          OUTPUT="${OUTDIR}/zksolc-${MACOSX_UNIVERSAL_SUFFIX}-${{ github.event.inputs.prerelease_suffix }}"
           llvm-lipo -create -output "${OUTPUT}" \
-            ./releases/release-macosx-amd64/macosx-amd64/zksolc-macosx-amd64-${TAG_SUFFIX} \
-            ./releases/release-macosx-arm64/macosx-arm64/zksolc-macosx-arm64-${TAG_SUFFIX}
+            ./releases/release-macosx-amd64/macosx-amd64/zksolc-macosx-amd64-${{ github.event.inputs.prerelease_suffix }} \
+            ./releases/release-macosx-arm64/macosx-arm64/zksolc-macosx-arm64-${{ github.event.inputs.prerelease_suffix }}
+
+      - name: Prepare universal MacOS binary (release)
+        if: github.ref_type == 'tag'
+        env:
+          MACOSX_UNIVERSAL_SUFFIX: "macosx"
+        run: |
+          OUTDIR="./releases/release-${MACOSX_UNIVERSAL_SUFFIX}/${MACOSX_UNIVERSAL_SUFFIX}"
+          mkdir -p "${OUTDIR}"
+          OUTPUT="${OUTDIR}/zksolc-${MACOSX_UNIVERSAL_SUFFIX}-v${GITHUB_REF_NAME}"
+          llvm-lipo -create -output "${OUTPUT}" \
+            ./releases/release-macosx-amd64/macosx-amd64/zksolc-macosx-amd64-v${GITHUB_REF_NAME} \
+            ./releases/release-macosx-arm64/macosx-arm64/zksolc-macosx-arm64-v${GITHUB_REF_NAME}
 
       - name: Prepare release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,11 +180,11 @@ jobs:
         run: |
           OUTDIR="./releases/release-${MACOSX_UNIVERSAL_SUFFIX}/${MACOSX_UNIVERSAL_SUFFIX}"
           mkdir -p "${OUTDIR}"
-          [ ! -z "$GITHUB_REF_NAME" ] && TAG_SUFFIX="-v${GITHUB_REF_NAME}"
-          OUTPUT="${OUTDIR}/zksolc-${MACOSX_UNIVERSAL_SUFFIX}${TAG_SUFFIX}"
+          [ ! -z "$TAG_SUFFIX" ] && TAG_SUFFIX="v${GITHUB_REF_NAME}"
+          OUTPUT="${OUTDIR}/zksolc-${MACOSX_UNIVERSAL_SUFFIX}-${TAG_SUFFIX}"
           llvm-lipo -create -output "${OUTPUT}" \
-            ./releases/release-macosx-amd64/macosx-amd64/zksolc-macosx-amd64${TAG_SUFFIX} \
-            ./releases/release-macosx-arm64/macosx-arm64/zksolc-macosx-arm64${TAG_SUFFIX}
+            ./releases/release-macosx-amd64/macosx-amd64/zksolc-macosx-amd64-${TAG_SUFFIX} \
+            ./releases/release-macosx-arm64/macosx-arm64/zksolc-macosx-arm64-${TAG_SUFFIX}
 
       - name: Prepare release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,7 +180,7 @@ jobs:
         run: |
           OUTDIR="./releases/release-${MACOSX_UNIVERSAL_SUFFIX}/${MACOSX_UNIVERSAL_SUFFIX}"
           mkdir -p "${OUTDIR}"
-          [ ! -z "$GITHUB_REF_NAME" ] && TAG_SUFFIX="v${GITHUB_REF_NAME}"
+          [ ! -z "$GITHUB_REF_NAME" ] && TAG_SUFFIX="${GITHUB_REF_NAME}"
           OUTPUT="${OUTDIR}/zksolc-${MACOSX_UNIVERSAL_SUFFIX}-${TAG_SUFFIX}"
           llvm-lipo -create -output "${OUTPUT}" \
             ./releases/release-macosx-amd64/macosx-amd64/zksolc-macosx-amd64-${TAG_SUFFIX} \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,10 +180,10 @@ jobs:
         run: |
           OUTDIR="./releases/release-${MACOSX_UNIVERSAL_SUFFIX}/${MACOSX_UNIVERSAL_SUFFIX}"
           mkdir -p "${OUTDIR}"
-          echo "${GITHUB_REF_NAME} ${TAG_SUFFIX}"
+          echo "${GITHUB_REF_NAME} ${TAG_SUFFIX} ${MACOSX_UNIVERSAL_SUFFIX}"
           [ ! -z "$GITHUB_REF_NAME" ] && TAG_SUFFIX="v${GITHUB_REF_NAME}"
           OUTPUT="${OUTDIR}/zksolc-${MACOSX_UNIVERSAL_SUFFIX}-${TAG_SUFFIX}"
-          ls -lAR './releases/release-macosx-amd64/'
+          ls -lAR './releases/'
           llvm-lipo -create -output "${OUTPUT}" \
             ./releases/release-macosx-amd64/macosx-amd64/zksolc-macosx-amd64-${TAG_SUFFIX} \
             ./releases/release-macosx-arm64/macosx-arm64/zksolc-macosx-arm64-${TAG_SUFFIX}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -182,8 +182,8 @@ jobs:
           mkdir -p "${OUTDIR}"
           OUTPUT="${OUTDIR}/zksolc-${MACOSX_UNIVERSAL_SUFFIX}-${{ github.event.inputs.prerelease_suffix }}"
           llvm-lipo -create -output "${OUTPUT}" \
-            ./releases/release-macosx-amd64/macosx-amd64/zksolc-macosx-amd64-${{ github.event.inputs.prerelease_suffix }} \
-            ./releases/release-macosx-arm64/macosx-arm64/zksolc-macosx-arm64-${{ github.event.inputs.prerelease_suffix }}
+            ./releases/release-macosx-amd64-${{ github.event.inputs.prerelease_suffix }}/macosx-amd64-${{ github.event.inputs.prerelease_suffix }}/zksolc-macosx-amd64-${{ github.event.inputs.prerelease_suffix }} \
+            ./releases/release-macosx-arm64-${{ github.event.inputs.prerelease_suffix }}/macosx-arm64-${{ github.event.inputs.prerelease_suffix }}/zksolc-macosx-arm64-${{ github.event.inputs.prerelease_suffix }}
 
       - name: Prepare universal MacOS binary (release)
         if: github.ref_type == 'tag'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,7 +180,7 @@ jobs:
         run: |
           OUTDIR="./releases/release-${MACOSX_UNIVERSAL_SUFFIX}/${MACOSX_UNIVERSAL_SUFFIX}"
           mkdir -p "${OUTDIR}"
-          [ ! -z "$TAG_SUFFIX" ] && TAG_SUFFIX="v${GITHUB_REF_NAME}"
+          [ -z "$TAG_SUFFIX" ] && TAG_SUFFIX="v${GITHUB_REF_NAME}"
           OUTPUT="${OUTDIR}/zksolc-${MACOSX_UNIVERSAL_SUFFIX}-${TAG_SUFFIX}"
           llvm-lipo -create -output "${OUTPUT}" \
             ./releases/release-macosx-amd64/macosx-amd64/zksolc-macosx-amd64-${TAG_SUFFIX} \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,7 +180,7 @@ jobs:
         run: |
           OUTDIR="./releases/release-${MACOSX_UNIVERSAL_SUFFIX}/${MACOSX_UNIVERSAL_SUFFIX}"
           mkdir -p "${OUTDIR}"
-          [ -z "$TAG_SUFFIX" ] && TAG_SUFFIX="v${GITHUB_REF_NAME}"
+          [ ! -z "$GITHUB_REF_NAME" ] && TAG_SUFFIX="v${GITHUB_REF_NAME}"
           OUTPUT="${OUTDIR}/zksolc-${MACOSX_UNIVERSAL_SUFFIX}-${TAG_SUFFIX}"
           llvm-lipo -create -output "${OUTPUT}" \
             ./releases/release-macosx-amd64/macosx-amd64/zksolc-macosx-amd64-${TAG_SUFFIX} \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,8 +180,9 @@ jobs:
         run: |
           OUTDIR="./releases/release-${MACOSX_UNIVERSAL_SUFFIX}/${MACOSX_UNIVERSAL_SUFFIX}"
           mkdir -p "${OUTDIR}"
-          [ ! -z "$GITHUB_REF_NAME" ] && TAG_SUFFIX="${GITHUB_REF_NAME}"
+          [ ! -z "$GITHUB_REF_NAME" ] && TAG_SUFFIX="v${GITHUB_REF_NAME}"
           OUTPUT="${OUTDIR}/zksolc-${MACOSX_UNIVERSAL_SUFFIX}-${TAG_SUFFIX}"
+          ls -lAR './releases/release-macosx-amd64/'
           llvm-lipo -create -output "${OUTPUT}" \
             ./releases/release-macosx-amd64/macosx-amd64/zksolc-macosx-amd64-${TAG_SUFFIX} \
             ./releases/release-macosx-arm64/macosx-arm64/zksolc-macosx-arm64-${TAG_SUFFIX}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,6 +180,7 @@ jobs:
         run: |
           OUTDIR="./releases/release-${MACOSX_UNIVERSAL_SUFFIX}/${MACOSX_UNIVERSAL_SUFFIX}"
           mkdir -p "${OUTDIR}"
+          echo "${GITHUB_REF_NAME} ${TAG_SUFFIX}"
           [ ! -z "$GITHUB_REF_NAME" ] && TAG_SUFFIX="v${GITHUB_REF_NAME}"
           OUTPUT="${OUTDIR}/zksolc-${MACOSX_UNIVERSAL_SUFFIX}-${TAG_SUFFIX}"
           ls -lAR './releases/release-macosx-amd64/'


### PR DESCRIPTION
# What ❔

Fixes the universal binary pre-release.

# Why ❔

It was broken when switching to custom tag suffixes.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
