### PR TITLE
ci: fix release suffix for macos universal binary

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -173,29 +173,18 @@ jobs:
             exit 1
           fi
 
-      - name: Prepare universal MacOS binary (pre-release)
-        if: github.ref_type != 'tag' && github.event_name == 'workflow_dispatch' && inputs.release_macos_amd64 && inputs.release_macos_arm64
+      - name: Prepare universal macos binary
+        if: github.ref_type == 'tag' || (inputs.release_macos_amd64 && inputs.release_macos_arm64)
         env:
           MACOSX_UNIVERSAL_SUFFIX: "macosx"
+          RELEASE_SUFFIX: ${{ inputs.prerelease_suffix || format('v{0}', github.ref_name) }}
         run: |
-          OUTDIR="./releases/release-${MACOSX_UNIVERSAL_SUFFIX}/${MACOSX_UNIVERSAL_SUFFIX}"
+          OUTDIR="./releases/release-${MACOSX_UNIVERSAL_SUFFIX}-${RELEASE_SUFFIX}/${MACOSX_UNIVERSAL_SUFFIX}-${RELEASE_SUFFIX}"
           mkdir -p "${OUTDIR}"
-          OUTPUT="${OUTDIR}/zksolc-${MACOSX_UNIVERSAL_SUFFIX}-${{ github.event.inputs.prerelease_suffix }}"
+          OUTPUT="${OUTDIR}/zksolc-${MACOSX_UNIVERSAL_SUFFIX}-${RELEASE_SUFFIX}"
           llvm-lipo -create -output "${OUTPUT}" \
-            ./releases/release-macosx-amd64-${{ github.event.inputs.prerelease_suffix }}/macosx-amd64-${{ github.event.inputs.prerelease_suffix }}/zksolc-macosx-amd64-${{ github.event.inputs.prerelease_suffix }} \
-            ./releases/release-macosx-arm64-${{ github.event.inputs.prerelease_suffix }}/macosx-arm64-${{ github.event.inputs.prerelease_suffix }}/zksolc-macosx-arm64-${{ github.event.inputs.prerelease_suffix }}
-
-      - name: Prepare universal MacOS binary (release)
-        if: github.ref_type == 'tag'
-        env:
-          MACOSX_UNIVERSAL_SUFFIX: "macosx"
-        run: |
-          OUTDIR="./releases/release-${MACOSX_UNIVERSAL_SUFFIX}/${MACOSX_UNIVERSAL_SUFFIX}"
-          mkdir -p "${OUTDIR}"
-          OUTPUT="${OUTDIR}/zksolc-${MACOSX_UNIVERSAL_SUFFIX}-v${GITHUB_REF_NAME}"
-          llvm-lipo -create -output "${OUTPUT}" \
-            ./releases/release-macosx-amd64/macosx-amd64/zksolc-macosx-amd64-v${GITHUB_REF_NAME} \
-            ./releases/release-macosx-arm64/macosx-arm64/zksolc-macosx-arm64-v${GITHUB_REF_NAME}
+            ./releases/release-macosx-amd64-${RELEASE_SUFFIX}/macosx-amd64-${RELEASE_SUFFIX}/zksolc-macosx-amd64-${RELEASE_SUFFIX} \
+            ./releases/release-macosx-arm64-${RELEASE_SUFFIX}/macosx-arm64-${RELEASE_SUFFIX}/zksolc-macosx-arm64-${RELEASE_SUFFIX}
 
       - name: Prepare release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
# What ❔

Fix universal macos binary generation during release builds.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Tests

* [x] [Manual workflow with suffix](https://github.com/matter-labs/era-compiler-solidity/actions/runs/11213576769)
* [x] [Release workflow with the tag](https://github.com/matter-labs/era-compiler-solidity/actions/runs/11214462788)

## Why ❔

Broken by the recent update with the proper suffix.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
