### PR TITLE
fix: fragile LLVM options parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - The compilation pipeline that was not run without output parameters
 - Broken `--output-dir` output paths for non-Solidity contracts
+- Several issues with fragile parsing of `--llvm-options`
 
 ## [1.5.4] - 2024-09-24
 

--- a/era-compiler-solidity/src/zksolc/arguments.rs
+++ b/era-compiler-solidity/src/zksolc/arguments.rs
@@ -69,6 +69,8 @@ pub struct Arguments {
     pub fallback_to_optimizing_for_size: bool,
 
     /// Pass arbitary space-separated options to LLVM.
+    /// The argument must be a single quoted string following a `=` separator.
+    /// Example: `--llvm-options='-eravm-jump-table-density-threshold=10'`.
     #[structopt(long = "llvm-options")]
     pub llvm_options: Option<String>,
 

--- a/era-compiler-solidity/src/zksolc/main.rs
+++ b/era-compiler-solidity/src/zksolc/main.rs
@@ -114,7 +114,12 @@ fn main_inner(
     let llvm_options: Vec<String> = arguments
         .llvm_options
         .as_ref()
-        .map(|options| options.split(' ').map(|option| option.to_owned()).collect())
+        .map(|options| {
+            options
+                .split_whitespace()
+                .map(|option| option.to_owned())
+                .collect()
+        })
         .unwrap_or_default();
 
     let suppressed_errors = era_compiler_solidity::MessageType::try_from_strings(

--- a/era-compiler-solidity/tests/cli/llvm_options.rs
+++ b/era-compiler-solidity/tests/cli/llvm_options.rs
@@ -1,0 +1,19 @@
+use crate::{cli, common};
+use predicates::prelude::*;
+
+#[test]
+fn run_zksolc_with_llvm_options() -> anyhow::Result<()> {
+    let _ = common::setup();
+    let args = &[
+        cli::TEST_SOLIDITY_CONTRACT_PATH,
+        "--llvm-options='-eravm-disable-system-request-memoization 10'",
+    ];
+
+    let result = cli::execute_zksolc(args)?;
+
+    result.success().stderr(predicate::str::contains(
+        "Compiler run successful. No output requested.",
+    ));
+
+    Ok(())
+}

--- a/era-compiler-solidity/tests/cli/mod.rs
+++ b/era-compiler-solidity/tests/cli/mod.rs
@@ -15,6 +15,7 @@ mod eravm_assembly;
 mod libraries;
 mod linker;
 mod llvm_ir;
+mod llvm_options;
 mod metadata_hash;
 mod missing_lib;
 mod optimization;


### PR DESCRIPTION
# What ❔

Adds more resilience to `--llvm-options` parsing, and makes `--help` more informative.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
