### PR TITLE
fix: make solc visible in $PATH again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - The compilation pipeline that was not run without output parameters
 - Broken `--output-dir` output paths for non-Solidity contracts
+- `solc` that was not picked up from `${PATH}` in standard JSON mode
 - Several issues with fragile parsing of `--llvm-options`
 
 ## [1.5.4] - 2024-09-24

--- a/era-compiler-solidity/src/lib.rs
+++ b/era-compiler-solidity/src/lib.rs
@@ -420,7 +420,7 @@ pub fn standard_output_evm(
 /// Runs the standard JSON mode for EVM.
 ///
 pub fn standard_json_eravm(
-    solc_compiler: Option<&SolcCompiler>,
+    solc_compiler: Option<SolcCompiler>,
     force_evmla: bool,
     enable_eravm_extensions: bool,
     detect_missing_libraries: bool,
@@ -468,7 +468,10 @@ pub fn standard_json_eravm(
         .unwrap_or_default();
 
     let (mut solc_output, solc_version, project) = match (language, solc_compiler) {
-        (SolcStandardJsonInputLanguage::Solidity, Some(solc_compiler)) => {
+        (SolcStandardJsonInputLanguage::Solidity, solc_compiler) => {
+            let solc_compiler =
+                solc_compiler.unwrap_or(SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME)?);
+
             let solc_pipeline = SolcPipeline::new(&solc_compiler.version, force_evmla);
             solc_input.normalize(&solc_compiler.version.default, Some(solc_pipeline));
 
@@ -488,17 +491,14 @@ pub fn standard_json_eravm(
                 libraries,
                 solc_pipeline,
                 &mut solc_output,
-                solc_compiler,
+                &solc_compiler,
                 debug_config.as_ref(),
             )?;
             if solc_output.has_errors() {
                 solc_output.write_and_exit(prune_output);
             }
 
-            (solc_output, Some(&solc_compiler.version), project)
-        }
-        (SolcStandardJsonInputLanguage::Solidity, None) => {
-            anyhow::bail!("Compiling Solidity without `solc` is not supported")
+            (solc_output, Some(solc_compiler.version), project)
         }
         (SolcStandardJsonInputLanguage::Yul, Some(solc_compiler)) => {
             let mut solc_output =
@@ -518,7 +518,7 @@ pub fn standard_json_eravm(
                 solc_output.write_and_exit(prune_output);
             }
 
-            (solc_output, Some(&solc_compiler.version), project)
+            (solc_output, Some(solc_compiler.version), project)
         }
         (SolcStandardJsonInputLanguage::Yul, None) => {
             let mut solc_output = SolcStandardJsonOutput::new(&solc_input.sources, messages);
@@ -572,7 +572,7 @@ pub fn standard_json_eravm(
         let missing_libraries = project.get_missing_libraries();
         missing_libraries.write_to_standard_json(
             &mut solc_output,
-            solc_version,
+            solc_version.as_ref(),
             &zksolc_version,
         )?;
     } else {
@@ -586,7 +586,7 @@ pub fn standard_json_eravm(
             threads,
             debug_config,
         )?;
-        build.write_to_standard_json(&mut solc_output, solc_version, &zksolc_version)?;
+        build.write_to_standard_json(&mut solc_output, solc_version.as_ref(), &zksolc_version)?;
     }
     solc_output.write_and_exit(prune_output);
 }
@@ -595,7 +595,7 @@ pub fn standard_json_eravm(
 /// Runs the standard JSON mode for EVM.
 ///
 pub fn standard_json_evm(
-    solc_compiler: Option<&SolcCompiler>,
+    solc_compiler: Option<SolcCompiler>,
     force_evmla: bool,
     json_path: Option<PathBuf>,
     messages: &mut Vec<SolcStandardJsonOutputError>,
@@ -624,7 +624,10 @@ pub fn standard_json_evm(
         .unwrap_or(era_compiler_common::HashType::Keccak256);
 
     let (mut solc_output, solc_version, project) = match (language, solc_compiler) {
-        (SolcStandardJsonInputLanguage::Solidity, Some(solc_compiler)) => {
+        (SolcStandardJsonInputLanguage::Solidity, solc_compiler) => {
+            let solc_compiler =
+                solc_compiler.unwrap_or(SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME)?);
+
             let solc_pipeline = SolcPipeline::new(&solc_compiler.version, force_evmla);
             solc_input.normalize(&solc_compiler.version.default, Some(solc_pipeline));
 
@@ -644,17 +647,14 @@ pub fn standard_json_evm(
                 libraries,
                 solc_pipeline,
                 &mut solc_output,
-                solc_compiler,
+                &solc_compiler,
                 debug_config.as_ref(),
             )?;
             if solc_output.has_errors() {
                 solc_output.write_and_exit(prune_output);
             }
 
-            (solc_output, Some(&solc_compiler.version), project)
-        }
-        (SolcStandardJsonInputLanguage::Solidity, None) => {
-            anyhow::bail!("Compiling Solidity without `solc` is not supported")
+            (solc_output, Some(solc_compiler.version), project)
         }
         (SolcStandardJsonInputLanguage::Yul, Some(solc_compiler)) => {
             let mut solc_output =
@@ -674,7 +674,7 @@ pub fn standard_json_evm(
                 solc_output.write_and_exit(prune_output);
             }
 
-            (solc_output, Some(&solc_compiler.version), project)
+            (solc_output, Some(solc_compiler.version), project)
         }
         (SolcStandardJsonInputLanguage::Yul, None) => {
             let mut solc_output = SolcStandardJsonOutput::new(&solc_input.sources, messages);
@@ -719,7 +719,7 @@ pub fn standard_json_evm(
         threads,
         debug_config,
     )?;
-    build.write_to_standard_json(&mut solc_output, solc_version, &zksolc_version)?;
+    build.write_to_standard_json(&mut solc_output, solc_version.as_ref(), &zksolc_version)?;
     solc_output.write_and_exit(prune_output);
 }
 

--- a/era-compiler-solidity/src/zksolc/arguments.rs
+++ b/era-compiler-solidity/src/zksolc/arguments.rs
@@ -80,9 +80,10 @@ pub struct Arguments {
     #[structopt(long = "disable-solc-optimizer")]
     pub disable_solc_optimizer: bool,
 
-    /// Specify the path to the `solc` executable. By default, the one in `${PATH}` is used.
-    /// Yul mode: `solc` is used for source code validation, as `zksolc` itself assumes that the input Yul is valid.
-    /// LLVM IR mode: `solc` is unused.
+    /// Specify the path to a `solc` executable.
+    /// Solidity mode: if not provided, `solc` is also searched in `${PATH}`.
+    /// Yul mode: `solc` is optional for additional Yul validation, as `zksolc` has limited Yul verification capabilities.
+    /// LLVM IR and EraVM assembly modes: `solc` is unused.
     #[structopt(long = "solc")]
     pub solc: Option<String>,
 

--- a/era-compiler-solidity/src/zksolc/main.rs
+++ b/era-compiler-solidity/src/zksolc/main.rs
@@ -194,7 +194,7 @@ fn main_inner(
                     None => None,
                 };
                 era_compiler_solidity::standard_json_eravm(
-                    solc_compiler.as_ref(),
+                    solc_compiler,
                     arguments.force_evmla,
                     enable_eravm_extensions,
                     arguments.detect_missing_libraries,
@@ -331,7 +331,7 @@ fn main_inner(
                     None => None,
                 };
                 era_compiler_solidity::standard_json_evm(
-                    solc_compiler.as_ref(),
+                    solc_compiler,
                     arguments.force_evmla,
                     standard_json.map(PathBuf::from),
                     messages,

--- a/era-compiler-solidity/tests/cli/mod.rs
+++ b/era-compiler-solidity/tests/cli/mod.rs
@@ -85,7 +85,7 @@ pub const LIBRARY_LINKER: &str =
 /// Execute zksolc with the given arguments and return the result
 ///
 pub fn execute_zksolc(args: &[&str]) -> anyhow::Result<assert_cmd::assert::Assert> {
-    let mut cmd = Command::cargo_bin("zksolc")?;
+    let mut cmd = Command::cargo_bin(era_compiler_solidity::DEFAULT_EXECUTABLE_NAME)?;
     Ok(cmd
         .env(
             "PATH",

--- a/era-compiler-solidity/tests/cli/solc.rs
+++ b/era-compiler-solidity/tests/cli/solc.rs
@@ -7,7 +7,7 @@ use predicates::prelude::predicate;
 fn call_zksolc_with_solc_argument() -> anyhow::Result<()> {
     let _ = common::setup();
 
-    let mut zksolc = Command::cargo_bin("zksolc")?;
+    let mut zksolc = Command::cargo_bin(era_compiler_solidity::DEFAULT_EXECUTABLE_NAME)?;
     let solc_compiler =
         common::get_solc_compiler(&era_compiler_solidity::SolcCompiler::LAST_SUPPORTED_VERSION)?
             .executable;
@@ -29,7 +29,7 @@ fn call_zksolc_with_solc_argument() -> anyhow::Result<()> {
 fn call_zksolc_without_solc_argument() -> anyhow::Result<()> {
     let _ = common::setup();
 
-    let mut zksolc = Command::cargo_bin("zksolc")?;
+    let mut zksolc = Command::cargo_bin(era_compiler_solidity::DEFAULT_EXECUTABLE_NAME)?;
 
     let assert = zksolc.arg(cli::TEST_SOLIDITY_CONTRACT_PATH).assert();
 

--- a/era-compiler-solidity/tests/cli/solc.rs
+++ b/era-compiler-solidity/tests/cli/solc.rs
@@ -24,3 +24,18 @@ fn call_zksolc_with_solc_argument() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn call_zksolc_without_solc_argument() -> anyhow::Result<()> {
+    let _ = common::setup();
+
+    let mut zksolc = Command::cargo_bin("zksolc")?;
+
+    let assert = zksolc.arg(cli::TEST_SOLIDITY_CONTRACT_PATH).assert();
+
+    assert
+        .success()
+        .stderr(predicate::str::contains("Compiler run successful"));
+
+    Ok(())
+}

--- a/era-compiler-solidity/tests/common/mod.rs
+++ b/era-compiler-solidity/tests/common/mod.rs
@@ -76,7 +76,7 @@ pub fn setup() -> anyhow::Result<()> {
     });
 
     // Set the `zksolc` binary path
-    let zksolc_bin = Command::cargo_bin("zksolc")?;
+    let zksolc_bin = Command::cargo_bin(era_compiler_solidity::DEFAULT_EXECUTABLE_NAME)?;
     let _ = era_compiler_solidity::process::EXECUTABLE.set(PathBuf::from(zksolc_bin.get_program()));
 
     // Enable LLVM pretty stack trace

--- a/era-compiler-solidity/tests/common/mod.rs
+++ b/era-compiler-solidity/tests/common/mod.rs
@@ -20,7 +20,7 @@ use std::str::FromStr;
 use std::sync::Once;
 use std::time::Duration;
 
-/// Synchronization for solc downloads.
+/// Synchronization for `solc` downloads.
 static DOWNLOAD_SOLC: Once = Once::new();
 
 /// Download directory for `solc` binaries
@@ -52,14 +52,17 @@ pub fn download_binaries() -> anyhow::Result<()> {
     http_client_builder = http_client_builder.pool_idle_timeout(Duration::from_secs(60));
     http_client_builder = http_client_builder.timeout(Duration::from_secs(60));
     let http_client = http_client_builder.build()?;
+
     let config_path = Path::new(SOLC_BIN_CONFIG);
     era_compiler_downloader::Downloader::new(http_client.clone()).download(config_path)?;
+
     // Copy the latest `solc-*` binary to `solc` for CLI tests
     let latest_solc =
         PathBuf::from(get_solc_compiler(&SolcCompiler::LAST_SUPPORTED_VERSION)?.executable);
     let mut solc = latest_solc.clone();
     solc.set_file_name(format!("solc{}", std::env::consts::EXE_SUFFIX));
     std::fs::copy(latest_solc, solc)?;
+
     Ok(())
 }
 


### PR DESCRIPTION
# What ❔

Fixes the `solc` default in standard JSON mode with Solidity input.

## Why ❔

The `Option` was broken and the default was not set.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
