### PR TITLE
fix: add solc to PATH in cli tests

### DIFF
--- a/era-compiler-solidity/tests/cli/solc.rs
+++ b/era-compiler-solidity/tests/cli/solc.rs
@@ -31,7 +31,10 @@ fn call_zksolc_without_solc_argument() -> anyhow::Result<()> {
 
     let mut zksolc = Command::cargo_bin(era_compiler_solidity::DEFAULT_EXECUTABLE_NAME)?;
 
-    let assert = zksolc.arg(cli::TEST_SOLIDITY_CONTRACT_PATH).assert();
+    let assert = zksolc
+        .arg(cli::TEST_SOLIDITY_CONTRACT_PATH)
+        .env("PATH", "./solc-bin")
+        .assert();
 
     assert
         .success()


### PR DESCRIPTION
# What ❔

Adds `solc-bin` to `$PATH`.

## Why ❔

The default `solc` is not visible for e2e tests.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
