### PR TITLE
fix: set full semver for dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,7 +550,7 @@ dependencies = [
  "num",
  "semver",
  "serde",
- "zkevm_opcode_defs",
+ "zkevm_opcode_defs 0.150.0",
 ]
 
 [[package]]
@@ -584,7 +584,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "which",
- "zkevm_opcode_defs",
+ "zkevm_opcode_defs 0.150.5",
 ]
 
 [[package]]
@@ -2229,9 +2229,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -2797,6 +2797,22 @@ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 name = "zkevm_opcode_defs"
 version = "0.150.0"
 source = "git+https://github.com/matter-labs/era-zkevm_opcode_defs?branch=v1.5.0#cf5f9c18c580f845b32fc2a4d565a77380fd15bc"
+dependencies = [
+ "bitflags 2.6.0",
+ "blake2",
+ "ethereum-types",
+ "k256",
+ "lazy_static",
+ "p256",
+ "serde",
+ "sha2 0.10.8",
+ "sha3 0.10.8",
+]
+
+[[package]]
+name = "zkevm_opcode_defs"
+version = "0.150.5"
+source = "git+https://github.com/matter-labs/zksync-protocol#9bf5cf839f76a19f7c21981d8c56a7f8bbe03d7e"
 dependencies = [
  "bitflags 2.6.0",
  "blake2",

--- a/era-compiler-solidity/Cargo.toml
+++ b/era-compiler-solidity/Cargo.toml
@@ -15,36 +15,36 @@ path = "src/zksolc/main.rs"
 doctest = false
 
 [dependencies]
-structopt = { version = "0.3", default-features = false }
-thiserror = "1.0"
-anyhow = "1.0"
-which = "6.0"
-path-slash = "0.2"
-normpath = "1.2"
-rayon = "1.10"
-rusty_pool = { version = "0.7", default-features = false }
-num_cpus = "1.16"
+structopt = { version = "=0.3.26", default-features = false }
+thiserror = "=1.0.64"
+anyhow = "=1.0.89"
+which = "=6.0.3"
+path-slash = "=0.2.1"
+normpath = "=1.3.0"
+rayon = "=1.10.0"
+rusty_pool = { version = "=0.7.0", default-features = false }
+num_cpus = "=1.16.0"
 
-serde = { version = "1.0", "features" = [ "derive" ] }
-serde_json = { version = "1.0", features = [ "arbitrary_precision" ] }
-semver = { version = "1.0", features = [ "serde" ] }
-rand = "0.8"
-regex = "1.10"
-hex = "0.4"
-num = "0.4"
-sha3 = "0.10"
+serde = { version = "=1.0.210", "features" = [ "derive" ] }
+serde_json = { version = "=1.0.128", features = [ "arbitrary_precision" ] }
+semver = { version = "=1.0.23", features = [ "serde" ] }
+rand = "=0.8.5"
+regex = "=1.11.0"
+hex = "=0.4.3"
+num = "=0.4.3"
+sha3 = "=0.10.8"
 
-zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_defs", branch = "v1.5.0" }
+zkevm_opcode_defs = { git = "https://github.com/matter-labs/zksync-protocol", version = "=0.150.5" }
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
 era-yul = { path = "../era-yul" }
 
 [dev-dependencies]
-assert_cmd = "2.0.16"
-predicates = "3.1.2"
-tempfile = "3.12.0"
-reqwest = { version = "0.11.27", features = ["blocking", "json"] }
+assert_cmd = "=2.0.16"
+predicates = "=3.1.2"
+tempfile = "=3.12.0"
+reqwest = { version = "=0.11.27", features = ["blocking", "json"] }
 era-compiler-downloader = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 
 [dependencies.inkwell]

--- a/era-yul/Cargo.toml
+++ b/era-yul/Cargo.toml
@@ -10,8 +10,8 @@ description = "YUL parser and syntax manipulation facilities required by `era-so
 doctest = false
 
 [dependencies]
-thiserror = "1.0"
-anyhow = "1.0"
+thiserror = "=1.0.64"
+anyhow = "=1.0.89"
 
-serde = { version = "1.0", "features" = [ "derive" ] }
-regex = "1.10"
+serde = { version = "=1.0.210", "features" = [ "derive" ] }
+regex = "=1.11.0"


### PR DESCRIPTION
# What ❔

Adds the revision part for semver of all dependencies.
Also, zkevm_opcode_defs has been moved to zksync-protocol monorepo.

## Why ❔

`cargo update` will become more resilient.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
