### PR TITLE
fix: memcpy and event intrinsic argument order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,9 +240,9 @@ checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cc"
-version = "1.1.28"
+version = "1.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
+checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
 dependencies = [
  "shlex",
 ]
@@ -512,7 +512,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 [[package]]
 name = "era-compiler-common"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#3207c451486e49df6e241167d8c6577222ecbd8e"
+source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#ce91855778bd5e1821f9b46751f92bafafd88435"
 dependencies = [
  "anyhow",
  "base58",
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-downloader"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#3207c451486e49df6e241167d8c6577222ecbd8e"
+source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#ce91855778bd5e1821f9b46751f92bafafd88435"
 dependencies = [
  "anyhow",
  "colored",
@@ -541,7 +541,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#736a2011b8de90887b429ded48556dd49333d365"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#7de0c55b51bf0bab90624413665f97697eeea55b"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -550,7 +550,7 @@ dependencies = [
  "num",
  "semver",
  "serde",
- "zkevm_opcode_defs 0.150.0",
+ "zkevm_opcode_defs",
 ]
 
 [[package]]
@@ -584,7 +584,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "which",
- "zkevm_opcode_defs 0.150.5",
+ "zkevm_opcode_defs",
 ]
 
 [[package]]
@@ -1081,9 +1081,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2497,9 +2497,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2508,9 +2508,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
@@ -2523,9 +2523,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2535,9 +2535,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2545,9 +2545,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2558,15 +2558,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2792,22 +2792,6 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
-
-[[package]]
-name = "zkevm_opcode_defs"
-version = "0.150.0"
-source = "git+https://github.com/matter-labs/era-zkevm_opcode_defs?branch=v1.5.0#cf5f9c18c580f845b32fc2a4d565a77380fd15bc"
-dependencies = [
- "bitflags 2.6.0",
- "blake2",
- "ethereum-types",
- "k256",
- "lazy_static",
- "p256",
- "serde",
- "sha2 0.10.8",
- "sha3 0.10.8",
-]
 
 [[package]]
 name = "zkevm_opcode_defs"

--- a/era-compiler-solidity/src/evmla/ethereal_ir/function/block/element/mod.rs
+++ b/era-compiler-solidity/src/evmla/ethereal_ir/function/block/element/mod.rs
@@ -2145,9 +2145,9 @@ where
                 let arguments = self.pop_arguments_llvm_evm(context)?;
                 era_compiler_llvm_context::evm_event::log(
                     context,
-                    vec![],
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
+                    vec![],
                 )?;
                 Ok(None)
             }
@@ -2155,12 +2155,12 @@ where
                 let arguments = self.pop_arguments_llvm_evm(context)?;
                 era_compiler_llvm_context::evm_event::log(
                     context,
+                    arguments[0].into_int_value(),
+                    arguments[1].into_int_value(),
                     arguments[2..]
                         .iter()
                         .map(|argument| argument.into_int_value())
                         .collect(),
-                    arguments[0].into_int_value(),
-                    arguments[1].into_int_value(),
                 )?;
                 Ok(None)
             }
@@ -2168,12 +2168,12 @@ where
                 let arguments = self.pop_arguments_llvm_evm(context)?;
                 era_compiler_llvm_context::evm_event::log(
                     context,
+                    arguments[0].into_int_value(),
+                    arguments[1].into_int_value(),
                     arguments[2..]
                         .iter()
                         .map(|argument| argument.into_int_value())
                         .collect(),
-                    arguments[0].into_int_value(),
-                    arguments[1].into_int_value(),
                 )?;
                 Ok(None)
             }
@@ -2181,12 +2181,12 @@ where
                 let arguments = self.pop_arguments_llvm_evm(context)?;
                 era_compiler_llvm_context::evm_event::log(
                     context,
+                    arguments[0].into_int_value(),
+                    arguments[1].into_int_value(),
                     arguments[2..]
                         .iter()
                         .map(|argument| argument.into_int_value())
                         .collect(),
-                    arguments[0].into_int_value(),
-                    arguments[1].into_int_value(),
                 )?;
                 Ok(None)
             }
@@ -2194,12 +2194,12 @@ where
                 let arguments = self.pop_arguments_llvm_evm(context)?;
                 era_compiler_llvm_context::evm_event::log(
                     context,
+                    arguments[0].into_int_value(),
+                    arguments[1].into_int_value(),
                     arguments[2..]
                         .iter()
                         .map(|argument| argument.into_int_value())
                         .collect(),
-                    arguments[0].into_int_value(),
-                    arguments[1].into_int_value(),
                 )?;
                 Ok(None)
             }

--- a/era-compiler-solidity/src/yul/parser/statement/expression/function_call/mod.rs
+++ b/era-compiler-solidity/src/yul/parser/statement/expression/function_call/mod.rs
@@ -1911,9 +1911,9 @@ impl FunctionCall {
                 let arguments = self.pop_arguments_llvm_evm::<D, 2>(context)?;
                 era_compiler_llvm_context::evm_event::log(
                     context,
-                    vec![],
                     arguments[0].into_int_value(),
                     arguments[1].into_int_value(),
+                    vec![],
                 )?;
                 Ok(None)
             }
@@ -1921,12 +1921,12 @@ impl FunctionCall {
                 let arguments = self.pop_arguments_llvm_evm::<D, 3>(context)?;
                 era_compiler_llvm_context::evm_event::log(
                     context,
+                    arguments[0].into_int_value(),
+                    arguments[1].into_int_value(),
                     arguments[2..]
                         .iter()
                         .map(|argument| argument.into_int_value())
                         .collect(),
-                    arguments[0].into_int_value(),
-                    arguments[1].into_int_value(),
                 )?;
                 Ok(None)
             }
@@ -1934,12 +1934,12 @@ impl FunctionCall {
                 let arguments = self.pop_arguments_llvm_evm::<D, 4>(context)?;
                 era_compiler_llvm_context::evm_event::log(
                     context,
+                    arguments[0].into_int_value(),
+                    arguments[1].into_int_value(),
                     arguments[2..]
                         .iter()
                         .map(|argument| argument.into_int_value())
                         .collect(),
-                    arguments[0].into_int_value(),
-                    arguments[1].into_int_value(),
                 )?;
                 Ok(None)
             }
@@ -1947,12 +1947,12 @@ impl FunctionCall {
                 let arguments = self.pop_arguments_llvm_evm::<D, 5>(context)?;
                 era_compiler_llvm_context::evm_event::log(
                     context,
+                    arguments[0].into_int_value(),
+                    arguments[1].into_int_value(),
                     arguments[2..]
                         .iter()
                         .map(|argument| argument.into_int_value())
                         .collect(),
-                    arguments[0].into_int_value(),
-                    arguments[1].into_int_value(),
                 )?;
                 Ok(None)
             }
@@ -1960,12 +1960,12 @@ impl FunctionCall {
                 let arguments = self.pop_arguments_llvm_evm::<D, 6>(context)?;
                 era_compiler_llvm_context::evm_event::log(
                     context,
+                    arguments[0].into_int_value(),
+                    arguments[1].into_int_value(),
                     arguments[2..]
                         .iter()
                         .map(|argument| argument.into_int_value())
                         .collect(),
-                    arguments[0].into_int_value(),
-                    arguments[1].into_int_value(),
                 )?;
                 Ok(None)
             }

--- a/era-yul/Cargo.toml
+++ b/era-yul/Cargo.toml
@@ -4,7 +4,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 version.workspace = true
-description = "YUL parser and syntax manipulation facilities required by `era-solidity-compiler` and other crates."
+description = "Yul parser and syntax manipulation facilities required by `era-solidity-compiler` and other crates."
 
 [lib]
 doctest = false

--- a/era-yul/README.md
+++ b/era-yul/README.md
@@ -1,4 +1,4 @@
 # era-yul
 
-YUL parser and syntax manipulation facilities required by
+Yul parser and syntax manipulation facilities required by
 `era-solidity-compiler` and other crates.

--- a/era-yul/src/lib.rs
+++ b/era-yul/src/lib.rs
@@ -1,5 +1,5 @@
 //!
-//! YUL parser.
+//! Yul parser.
 //!
 
 #![allow(non_camel_case_types)]

--- a/era-yul/src/util/printer/mod.rs
+++ b/era-yul/src/util/printer/mod.rs
@@ -1,12 +1,12 @@
 //!
-//! YUL pretty printer.
+//! Yul pretty printer.
 //!
 
 use anyhow::Result;
 pub mod write_printer;
 
 ///
-/// Interface to YUL pretty printer.
+/// Interface to Yul pretty printer.
 ///
 pub trait IPrinter {
     ///

--- a/era-yul/src/yul/parser/identifier.rs
+++ b/era-yul/src/yul/parser/identifier.rs
@@ -1,5 +1,5 @@
 //!
-//! The YUL source code identifier.
+//! The Yul source code identifier.
 //!
 
 use crate::yul::error::Error;
@@ -11,7 +11,7 @@ use crate::yul::lexer::Lexer;
 use crate::yul::parser::r#type::Type;
 
 ///
-/// The YUL source code identifier.
+/// The Yul source code identifier.
 ///
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq)]
 pub struct Identifier {

--- a/era-yul/src/yul/parser/mod.rs
+++ b/era-yul/src/yul/parser/mod.rs
@@ -1,5 +1,5 @@
 //!
-//! The YUL code block.
+//! The Yul code block.
 //!
 
 pub mod dialect;

--- a/era-yul/src/yul/parser/statement/code.rs
+++ b/era-yul/src/yul/parser/statement/code.rs
@@ -1,5 +1,5 @@
 //!
-//! The YUL code.
+//! The Yul code.
 //!
 
 use std::collections::HashSet;
@@ -15,7 +15,7 @@ use crate::yul::parser::error::Error as ParserError;
 use crate::yul::parser::statement::block::Block;
 
 ///
-/// The YUL code entity, which is the first block of the object.
+/// The Yul code entity, which is the first block of the object.
 ///
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq)]
 #[serde(bound = "P: serde::de::DeserializeOwned")]

--- a/era-yul/src/yul/parser/statement/expression/literal.rs
+++ b/era-yul/src/yul/parser/statement/expression/literal.rs
@@ -1,5 +1,5 @@
 //!
-//! The YUL source code literal.
+//! The Yul source code literal.
 //!
 
 use crate::yul::error::Error;
@@ -13,7 +13,7 @@ use crate::yul::parser::error::Error as ParserError;
 use crate::yul::parser::r#type::Type;
 
 ///
-/// Represents a literal in YUL without differentiating its type.
+/// Represents a literal in Yul without differentiating its type.
 ///
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq)]
 pub struct Literal {

--- a/era-yul/src/yul/parser/statement/object.rs
+++ b/era-yul/src/yul/parser/statement/object.rs
@@ -1,5 +1,5 @@
 //!
-//! The YUL object.
+//! The Yul object.
 //!
 
 use std::collections::HashSet;
@@ -17,7 +17,7 @@ use crate::yul::parser::error::Error as ParserError;
 use crate::yul::parser::statement::code::Code;
 
 ///
-/// The upper-level YUL object, representing the deploy code.
+/// The upper-level Yul object, representing the deploy code.
 ///
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq)]
 #[serde(bound = "P: serde::de::DeserializeOwned")]

--- a/era-yul/src/yul/parser/type.rs
+++ b/era-yul/src/yul/parser/type.rs
@@ -1,5 +1,5 @@
 //!
-//! The YUL source code type.
+//! The Yul source code type.
 //!
 
 use crate::yul::error::Error;
@@ -10,7 +10,7 @@ use crate::yul::lexer::Lexer;
 use crate::yul::parser::error::Error as ParserError;
 
 ///
-/// The YUL source code type.
+/// The Yul source code type.
 ///
 /// The type is not currently in use, so all values have the `uint256` type by default.
 ///

--- a/era-yul/src/yul/printer.rs
+++ b/era-yul/src/yul/printer.rs
@@ -1,5 +1,5 @@
 //!
-//! Printers for all YUL AST node types
+//! Printers for all Yul AST node types
 //!
 
 use crate::util::printer::print_list_comma_separated;
@@ -191,7 +191,7 @@ where
     }
 }
 
-/// Shows how an instance of [`Name`] is displayed in YUL code.
+/// Shows how an instance of [`Name`] is displayed in Yul code.
 pub fn name_identifier(name: &Name) -> String {
     if let Name::Verbatim {
         input_size,

--- a/era-yul/src/yul/visitor/mod.rs
+++ b/era-yul/src/yul/visitor/mod.rs
@@ -1,5 +1,5 @@
 //!
-//! Implementation of a visitor pattern for YUL syntax tree.
+//! Implementation of a visitor pattern for Yul syntax tree.
 //!
 
 use std::collections::BTreeSet;
@@ -47,7 +47,7 @@ where
 
 #[allow(unused_variables)]
 ///
-/// Visitor for YUL syntax tree.
+/// Visitor for Yul syntax tree.
 ///
 pub trait Visitor<P>
 where
@@ -60,98 +60,98 @@ where
     const MSG_METHOD_NOT_IMPLEMENTED: &'static str = "Method not implemented for this visitor.";
 
     ///
-    /// Visit `switch` statement in YUL syntax tree.
+    /// Visit `switch` statement in Yul syntax tree.
     ///
     fn visit_switch(&mut self, switch: &Switch<P>) {
         unreachable!("{}", Self::MSG_METHOD_NOT_IMPLEMENTED)
     }
 
     ///
-    /// Visit YUL object in YUL syntax tree.
+    /// Visit Yul object in Yul syntax tree.
     ///
     fn visit_object(&mut self, object: &Object<P>) {
         unreachable!("{}", Self::MSG_METHOD_NOT_IMPLEMENTED)
     }
 
     ///
-    /// Visit `for` statement in YUL syntax tree.
+    /// Visit `for` statement in Yul syntax tree.
     ///
     fn visit_for_loop(&mut self, for_loop: &ForLoop<P>) {
         unreachable!("{}", Self::MSG_METHOD_NOT_IMPLEMENTED)
     }
 
     ///
-    /// Visit a variable declaration in YUL syntax tree: `var x` or `var x = <initializer>`.
+    /// Visit a variable declaration in Yul syntax tree: `var x` or `var x = <initializer>`.
     ///
     fn visit_variable_declaration(&mut self, variable_declaration: &VariableDeclaration) {
         unreachable!("{}", Self::MSG_METHOD_NOT_IMPLEMENTED)
     }
 
     ///
-    /// Visit a function definition in YUL syntax tree.
+    /// Visit a function definition in Yul syntax tree.
     ///
     fn visit_function_definition(&mut self, function_definition: &FunctionDefinition<P>) {
         unreachable!("{}", Self::MSG_METHOD_NOT_IMPLEMENTED)
     }
 
     ///
-    /// Visit an identifier in YUL syntax tree: a user defined one, or one of the predefined set like `lt`.
+    /// Visit an identifier in Yul syntax tree: a user defined one, or one of the predefined set like `lt`.
     ///
     fn visit_name(&mut self, name: &Name) {
         unreachable!("{}", Self::MSG_METHOD_NOT_IMPLEMENTED)
     }
 
     ///
-    /// Visit a function call in YUL syntax tree.
+    /// Visit a function call in Yul syntax tree.
     ///
     fn visit_function_call(&mut self, call: &FunctionCall) {
         unreachable!("{}", Self::MSG_METHOD_NOT_IMPLEMENTED)
     }
 
     ///
-    /// Visit an `if` statement in YUL syntax tree.
+    /// Visit an `if` statement in Yul syntax tree.
     ///
     fn visit_if_conditional(&mut self, if_conditional: &IfConditional<P>) {
         unreachable!("{}", Self::MSG_METHOD_NOT_IMPLEMENTED)
     }
 
     ///
-    /// Visit a literal (e.g. integer) in YUL syntax tree.
+    /// Visit a literal (e.g. integer) in Yul syntax tree.
     ///
     fn visit_literal(&mut self, lit: &Literal) {
         unreachable!("{}", Self::MSG_METHOD_NOT_IMPLEMENTED)
     }
 
     ///
-    /// Visit an arbitrary YUL expression in YUL syntax tree.
+    /// Visit an arbitrary Yul expression in Yul syntax tree.
     ///
     fn visit_expression(&mut self, expr: &Expression) {
         unreachable!("{}", Self::MSG_METHOD_NOT_IMPLEMENTED)
     }
 
     ///
-    /// Visit an assignment in YUL syntax tree.
+    /// Visit an assignment in Yul syntax tree.
     ///
     fn visit_assignment(&mut self, assignment: &Assignment) {
         unreachable!("{}", Self::MSG_METHOD_NOT_IMPLEMENTED)
     }
 
     ///
-    /// Visit an arbitrary statement in YUL syntax tree.
+    /// Visit an arbitrary statement in Yul syntax tree.
     ///
     fn visit_statement(&mut self, stmt: &Statement<P>) {
         unreachable!("{}", Self::MSG_METHOD_NOT_IMPLEMENTED)
     }
 
     ///
-    /// Visit a block of statements in YUL syntax tree.
+    /// Visit a block of statements in Yul syntax tree.
     ///
     fn visit_block(&mut self, block: &Block<P>) {
         unreachable!("{}", Self::MSG_METHOD_NOT_IMPLEMENTED)
     }
 
     ///
-    /// Visit a `code` block of an object in YUL syntax tree.
+    /// Visit a `code` block of an object in Yul syntax tree.
     ///
     fn visit_code(&mut self, code: &Code<P>) {
         unreachable!("{}", Self::MSG_METHOD_NOT_IMPLEMENTED)

--- a/era-yul/tests/printer.rs
+++ b/era-yul/tests/printer.rs
@@ -1,5 +1,5 @@
 //!
-//! Tests for the YUL pretty printer.
+//! Tests for the Yul pretty printer.
 //!
 
 #![cfg(test)]


### PR DESCRIPTION
# What ❔

1. Memcpy declaration pointer order.
2. Event intrinsics argument order.

## Checklist

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
