### PR TITLE
fix: solc discovery fallback in standard json mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # The `zksolc` changelog
 
+## [1.5.6] - 2024-10-16
+
+### Fixed
+
+- An error about `solc` discovery when it is not present in `${PATH}`
+
 ## [1.5.5] - 2024-10-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "era-compiler-solidity"
-version = "1.5.5"
+version = "1.5.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "era-yul"
-version = "1.5.5"
+version = "1.5.6"
 dependencies = [
  "anyhow",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ authors = [
 ]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-version = "1.5.5"
+version = "1.5.6"

--- a/era-compiler-solidity/src/lib.rs
+++ b/era-compiler-solidity/src/lib.rs
@@ -469,8 +469,9 @@ pub fn standard_json_eravm(
 
     let (mut solc_output, solc_version, project) = match (language, solc_compiler) {
         (SolcStandardJsonInputLanguage::Solidity, solc_compiler) => {
-            let solc_compiler =
-                solc_compiler.unwrap_or(SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME)?);
+            let solc_compiler = solc_compiler.unwrap_or_else(|| {
+                SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME).expect("Error")
+            });
 
             let solc_pipeline = SolcPipeline::new(&solc_compiler.version, force_evmla);
             solc_input.normalize(&solc_compiler.version.default, Some(solc_pipeline));
@@ -625,8 +626,9 @@ pub fn standard_json_evm(
 
     let (mut solc_output, solc_version, project) = match (language, solc_compiler) {
         (SolcStandardJsonInputLanguage::Solidity, solc_compiler) => {
-            let solc_compiler =
-                solc_compiler.unwrap_or(SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME)?);
+            let solc_compiler = solc_compiler.unwrap_or_else(|| {
+                SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME).expect("Error")
+            });
 
             let solc_pipeline = SolcPipeline::new(&solc_compiler.version, force_evmla);
             solc_input.normalize(&solc_compiler.version.default, Some(solc_pipeline));

--- a/era-compiler-solidity/src/lib.rs
+++ b/era-compiler-solidity/src/lib.rs
@@ -469,9 +469,10 @@ pub fn standard_json_eravm(
 
     let (mut solc_output, solc_version, project) = match (language, solc_compiler) {
         (SolcStandardJsonInputLanguage::Solidity, solc_compiler) => {
-            let solc_compiler = solc_compiler.unwrap_or_else(|| {
-                SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME).expect("Error")
-            });
+            let solc_compiler = match solc_compiler {
+                Some(solc_compiler) => solc_compiler,
+                None => SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME)?,
+            };
 
             let solc_pipeline = SolcPipeline::new(&solc_compiler.version, force_evmla);
             solc_input.normalize(&solc_compiler.version.default, Some(solc_pipeline));
@@ -626,9 +627,10 @@ pub fn standard_json_evm(
 
     let (mut solc_output, solc_version, project) = match (language, solc_compiler) {
         (SolcStandardJsonInputLanguage::Solidity, solc_compiler) => {
-            let solc_compiler = solc_compiler.unwrap_or_else(|| {
-                SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME).expect("Error")
-            });
+            let solc_compiler = match solc_compiler {
+                Some(solc_compiler) => solc_compiler,
+                None => SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME)?,
+            };
 
             let solc_pipeline = SolcPipeline::new(&solc_compiler.version, force_evmla);
             solc_input.normalize(&solc_compiler.version.default, Some(solc_pipeline));

--- a/era-compiler-solidity/src/solc/mod.rs
+++ b/era-compiler-solidity/src/solc/mod.rs
@@ -70,7 +70,7 @@ impl Compiler {
         let mut executables = Self::executables().write().expect("Sync");
 
         if let Err(error) = which::which(executable) {
-            anyhow::bail!("The `{executable}` executable not found in ${{PATH}}: {error}");
+            anyhow::bail!("The `{executable}` executable not found in ${{PATH}}: {error}. Please add it to ${{PATH}} or provide it explicitly with the `--solc` option.");
         }
         let version = Self::parse_version(executable)?;
         let compiler = Self {

--- a/era-compiler-solidity/tests/cli/solc.rs
+++ b/era-compiler-solidity/tests/cli/solc.rs
@@ -26,6 +26,45 @@ fn call_zksolc_with_solc_argument() -> anyhow::Result<()> {
 }
 
 #[test]
+fn call_zksolc_with_solc_in_standard_json_mode() -> anyhow::Result<()> {
+    let _ = common::setup();
+
+    let mut zksolc = Command::cargo_bin(era_compiler_solidity::DEFAULT_EXECUTABLE_NAME)?;
+    let solc_compiler =
+        common::get_solc_compiler(&era_compiler_solidity::SolcCompiler::LAST_SUPPORTED_VERSION)?
+            .executable;
+
+    let assert = zksolc
+        .arg("--solc")
+        .arg(solc_compiler)
+        .arg("--standard-json")
+        .arg(cli::TEST_JSON_CONTRACT_PATH)
+        .assert();
+
+    assert
+        .success()
+        .stdout(predicate::str::contains("bytecode"));
+
+    Ok(())
+}
+
+#[test]
+fn call_zksolc_without_solc_in_standard_json_mode() -> anyhow::Result<()> {
+    let _ = common::setup();
+
+    let mut zksolc = Command::cargo_bin(era_compiler_solidity::DEFAULT_EXECUTABLE_NAME)?;
+
+    let assert = zksolc
+        .arg("--standard-json")
+        .arg(cli::TEST_JSON_CONTRACT_PATH)
+        .assert();
+
+    assert.failure().stderr(predicate::str::contains("Error"));
+
+    Ok(())
+}
+
+#[test]
 fn call_zksolc_without_solc_argument() -> anyhow::Result<()> {
     let _ = common::setup();
 

--- a/era-compiler-solidity/tests/cli/solc.rs
+++ b/era-compiler-solidity/tests/cli/solc.rs
@@ -26,6 +26,24 @@ fn call_zksolc_with_solc_argument() -> anyhow::Result<()> {
 }
 
 #[test]
+fn call_zksolc_without_solc_argument() -> anyhow::Result<()> {
+    let _ = common::setup();
+
+    let mut zksolc = Command::cargo_bin(era_compiler_solidity::DEFAULT_EXECUTABLE_NAME)?;
+
+    let assert = zksolc
+        .arg(cli::TEST_SOLIDITY_CONTRACT_PATH)
+        .env("PATH", "./solc-bin")
+        .assert();
+
+    assert
+        .success()
+        .stderr(predicate::str::contains("Compiler run successful"));
+
+    Ok(())
+}
+
+#[test]
 fn call_zksolc_with_solc_in_standard_json_mode() -> anyhow::Result<()> {
     let _ = common::setup();
 
@@ -59,25 +77,9 @@ fn call_zksolc_without_solc_in_standard_json_mode() -> anyhow::Result<()> {
         .arg(cli::TEST_JSON_CONTRACT_PATH)
         .assert();
 
-    assert.failure().stderr(predicate::str::contains("Error"));
-
-    Ok(())
-}
-
-#[test]
-fn call_zksolc_without_solc_argument() -> anyhow::Result<()> {
-    let _ = common::setup();
-
-    let mut zksolc = Command::cargo_bin(era_compiler_solidity::DEFAULT_EXECUTABLE_NAME)?;
-
-    let assert = zksolc
-        .arg(cli::TEST_SOLIDITY_CONTRACT_PATH)
-        .env("PATH", "./solc-bin")
-        .assert();
-
-    assert
-        .success()
-        .stderr(predicate::str::contains("Compiler run successful"));
+    assert.success().stdout(predicate::str::contains(
+        "The `solc` executable not found in ${PATH}",
+    ));
 
     Ok(())
 }


### PR DESCRIPTION
# What ❔

Bugfix for `solc` discovery bug with `1.5.5` in standard json mode caused by  https://github.com/matter-labs/era-compiler-solidity/commit/3b98e84df38c779128e7928ceac79da1338495e4#diff-f646ff6f8b3bf0d3732b0b590ea2da417a4a016da8f2132ba51bd9ccf521e1bcR422

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

`unwrap_or` fallback value is evaluated before `unwrap_or` is called, it caused issues in the case of `--standard-json` mode in use, `--solc` argument is provided, but there is no `solc` in the `PATH` available.

It is proposed to use `unwrap_or_else` to get the lazy evaluation of the fallback value.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
