### PR TITLE
fix: move suppressed messages to settings

### DIFF
--- a/era-compiler-solidity/src/error_type.rs
+++ b/era-compiler-solidity/src/error_type.rs
@@ -1,25 +1,22 @@
 //!
-//! The compiler message type.
+//! The compiler error type.
 //!
 
 use std::str::FromStr;
 
 ///
-/// The compiler message type.
+/// The compiler error type.
 ///
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
-pub enum MessageType {
-    /// The error for eponymous feature.
+pub enum ErrorType {
+    /// The eponymous feature.
     SendTransfer,
-
-    /// The warning for eponymous feature.
-    TxOrigin,
 }
 
-impl MessageType {
+impl ErrorType {
     ///
-    /// Converts string arguments into an array of messages.
+    /// Converts string arguments into an array of errors.
     ///
     pub fn try_from_strings(strings: &[String]) -> Result<Vec<Self>, anyhow::Error> {
         strings
@@ -29,13 +26,12 @@ impl MessageType {
     }
 }
 
-impl FromStr for MessageType {
+impl FromStr for ErrorType {
     type Err = anyhow::Error;
 
     fn from_str(string: &str) -> Result<Self, Self::Err> {
         match string {
             "sendtransfer" => Ok(Self::SendTransfer),
-            "txorigin" => Ok(Self::TxOrigin),
             r#type => Err(anyhow::anyhow!("Invalid suppressed message type: {type}")),
         }
     }

--- a/era-compiler-solidity/src/lib.rs
+++ b/era-compiler-solidity/src/lib.rs
@@ -12,20 +12,21 @@
 pub mod build_eravm;
 pub mod build_evm;
 pub mod r#const;
+pub mod error_type;
 pub mod evmla;
 pub mod libraries;
-pub mod message_type;
 pub mod process;
 pub mod project;
 pub mod solc;
+pub mod warning_type;
 pub mod yul;
 
 pub use self::build_eravm::contract::Contract as EraVMContractBuild;
 pub use self::build_eravm::Build as EraVMBuild;
 pub use self::build_evm::contract::Contract as EVMContractBuild;
 pub use self::build_evm::Build as EVMBuild;
+pub use self::error_type::ErrorType;
 pub use self::libraries::Libraries;
-pub use self::message_type::MessageType;
 pub use self::process::input_eravm::Input as EraVMProcessInput;
 pub use self::process::input_evm::Input as EVMProcessInput;
 pub use self::process::output_eravm::Output as EraVMProcessOutput;
@@ -56,6 +57,7 @@ pub use self::solc::standard_json::output::error::Error as SolcStandardJsonOutpu
 pub use self::solc::standard_json::output::Output as SolcStandardJsonOutput;
 pub use self::solc::version::Version as SolcVersion;
 pub use self::solc::Compiler as SolcCompiler;
+pub use self::warning_type::WarningType;
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
@@ -265,8 +267,8 @@ pub fn standard_output_eravm(
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
     llvm_options: Vec<String>,
     output_assembly: bool,
-    suppressed_errors: Vec<MessageType>,
-    suppressed_warnings: Vec<MessageType>,
+    suppressed_errors: Vec<ErrorType>,
+    suppressed_warnings: Vec<WarningType>,
     threads: Option<usize>,
     debug_config: Option<era_compiler_llvm_context::DebugConfig>,
 ) -> anyhow::Result<EraVMBuild> {
@@ -751,8 +753,8 @@ pub fn combined_json_eravm(
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
     llvm_options: Vec<String>,
     output_assembly: bool,
-    suppressed_errors: Vec<MessageType>,
-    suppressed_warnings: Vec<MessageType>,
+    suppressed_errors: Vec<ErrorType>,
+    suppressed_warnings: Vec<WarningType>,
     threads: Option<usize>,
     debug_config: Option<era_compiler_llvm_context::DebugConfig>,
 ) -> anyhow::Result<()> {

--- a/era-compiler-solidity/src/solc/mod.rs
+++ b/era-compiler-solidity/src/solc/mod.rs
@@ -164,16 +164,35 @@ impl Compiler {
         });
         errors.append(messages);
 
+        if input.suppressed_errors.is_some() {
+            errors.push(StandardJsonOutputError::new_warning(
+                "`suppressedErrors` at the root of standard JSON input are deprecated. Please move them to `settings`.",
+                None,
+                None,
+            ));
+        }
+        if input.suppressed_warnings.is_some() {
+            errors.push(StandardJsonOutputError::new_warning(
+                "`suppressedWarnings` at the root of standard JSON input are deprecated. Please move them to `settings`.",
+                None,
+                None,
+            ));
+        }
+
         if let Some(pipeline) = pipeline {
-            let mut suppressed_messages = input.suppressed_errors.to_owned().unwrap_or_default();
-            suppressed_messages.extend(input.suppressed_warnings.to_owned().unwrap_or_default());
+            let mut suppressed_errors = input.suppressed_errors.clone().unwrap_or_default();
+            suppressed_errors.extend_from_slice(input.settings.suppressed_errors.as_slice());
+
+            let mut suppressed_warnings = input.suppressed_warnings.clone().unwrap_or_default();
+            suppressed_warnings.extend_from_slice(input.settings.suppressed_warnings.as_slice());
 
             input.resolve_sources();
             solc_output.preprocess_ast(
                 &input.sources,
                 &self.version,
                 pipeline,
-                suppressed_messages.as_slice(),
+                suppressed_errors.as_slice(),
+                suppressed_warnings.as_slice(),
             )?;
         }
         solc_output.remove_evm();

--- a/era-compiler-solidity/src/solc/standard_json/input/mod.rs
+++ b/era-compiler-solidity/src/solc/standard_json/input/mod.rs
@@ -15,12 +15,13 @@ use rayon::iter::IntoParallelIterator;
 use rayon::iter::IntoParallelRefMutIterator;
 use rayon::iter::ParallelIterator;
 
+use crate::error_type::ErrorType;
 use crate::libraries::Libraries;
-use crate::message_type::MessageType;
 use crate::solc::pipeline::Pipeline as SolcPipeline;
 use crate::solc::standard_json::input::settings::metadata::Metadata as SolcStandardJsonInputSettingsMetadata;
 use crate::solc::standard_json::input::settings::optimizer::Optimizer as SolcStandardJsonInputSettingsOptimizer;
 use crate::solc::standard_json::input::settings::selection::Selection as SolcStandardJsonInputSettingsSelection;
+use crate::warning_type::WarningType;
 
 use self::language::Language;
 use self::settings::Settings;
@@ -40,11 +41,11 @@ pub struct Input {
     pub settings: Settings,
 
     /// The suppressed errors.
-    #[serde(skip_serializing)]
-    pub suppressed_errors: Option<Vec<MessageType>>,
+    #[serde(default, skip_serializing)]
+    pub suppressed_errors: Option<Vec<ErrorType>>,
     /// The suppressed warnings.
-    #[serde(skip_serializing)]
-    pub suppressed_warnings: Option<Vec<MessageType>>,
+    #[serde(default, skip_serializing)]
+    pub suppressed_warnings: Option<Vec<WarningType>>,
 }
 
 impl Input {
@@ -98,8 +99,8 @@ impl Input {
         enable_eravm_extensions: bool,
         detect_missing_libraries: bool,
         llvm_options: Vec<String>,
-        suppressed_errors: Vec<MessageType>,
-        suppressed_warnings: Vec<MessageType>,
+        suppressed_errors: Vec<ErrorType>,
+        suppressed_warnings: Vec<WarningType>,
     ) -> anyhow::Result<Self> {
         let mut paths: BTreeSet<PathBuf> = paths.iter().cloned().collect();
         let libraries = Libraries::into_standard_json(libraries)?;
@@ -130,6 +131,8 @@ impl Input {
                 optimizer,
                 llvm_options,
                 metadata,
+                suppressed_errors.clone(),
+                suppressed_warnings.clone(),
             ),
             suppressed_errors: Some(suppressed_errors),
             suppressed_warnings: Some(suppressed_warnings),
@@ -152,8 +155,8 @@ impl Input {
         enable_eravm_extensions: bool,
         detect_missing_libraries: bool,
         llvm_options: Vec<String>,
-        suppressed_errors: Vec<MessageType>,
-        suppressed_warnings: Vec<MessageType>,
+        suppressed_errors: Vec<ErrorType>,
+        suppressed_warnings: Vec<WarningType>,
     ) -> anyhow::Result<Self> {
         let sources = sources
             .into_iter()
@@ -175,6 +178,8 @@ impl Input {
                 optimizer,
                 llvm_options,
                 metadata,
+                suppressed_errors.clone(),
+                suppressed_warnings.clone(),
             ),
             suppressed_errors: Some(suppressed_errors),
             suppressed_warnings: Some(suppressed_warnings),
@@ -211,6 +216,8 @@ impl Input {
                 optimizer,
                 llvm_options,
                 None,
+                vec![],
+                vec![],
             ),
             suppressed_errors: None,
             suppressed_warnings: None,
@@ -252,6 +259,8 @@ impl Input {
                 optimizer,
                 llvm_options,
                 None,
+                vec![],
+                vec![],
             ),
             suppressed_errors: None,
             suppressed_warnings: None,

--- a/era-compiler-solidity/src/solc/standard_json/input/settings/mod.rs
+++ b/era-compiler-solidity/src/solc/standard_json/input/settings/mod.rs
@@ -10,7 +10,9 @@ use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::collections::HashSet;
 
+use crate::error_type::ErrorType;
 use crate::solc::pipeline::Pipeline as SolcPipeline;
+use crate::warning_type::WarningType;
 
 use self::metadata::Metadata;
 use self::optimizer::Optimizer;
@@ -59,6 +61,12 @@ pub struct Settings {
     /// The metadata settings.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Metadata>,
+    /// The suppressed errors.
+    #[serde(default, skip_serializing)]
+    pub suppressed_errors: Vec<ErrorType>,
+    /// The suppressed warnings.
+    #[serde(default, skip_serializing)]
+    pub suppressed_warnings: Vec<WarningType>,
 }
 
 impl Settings {
@@ -77,6 +85,8 @@ impl Settings {
         optimizer: Optimizer,
         llvm_options: Vec<String>,
         metadata: Option<Metadata>,
+        suppressed_errors: Vec<ErrorType>,
+        suppressed_warnings: Vec<WarningType>,
     ) -> Self {
         Self {
             evm_version,
@@ -98,6 +108,8 @@ impl Settings {
             optimizer,
             llvm_options: Some(llvm_options),
             metadata,
+            suppressed_errors,
+            suppressed_warnings,
         }
     }
 

--- a/era-compiler-solidity/src/solc/standard_json/output/mod.rs
+++ b/era-compiler-solidity/src/solc/standard_json/output/mod.rs
@@ -13,14 +13,15 @@ use rayon::iter::IntoParallelIterator;
 use rayon::iter::IntoParallelRefIterator;
 use rayon::iter::ParallelIterator;
 
+use crate::error_type::ErrorType;
 use crate::evmla::assembly::instruction::Instruction;
 use crate::evmla::assembly::Assembly;
-use crate::message_type::MessageType;
 use crate::solc::pipeline::Pipeline as SolcPipeline;
 use crate::solc::standard_json::input::settings::selection::file::flag::Flag as SelectionFlag;
 use crate::solc::standard_json::input::source::Source as StandardJSONInputSource;
 use crate::solc::standard_json::output::contract::evm::EVM as StandardJSONOutputContractEVM;
 use crate::solc::version::Version as SolcVersion;
+use crate::warning_type::WarningType;
 
 use self::contract::Contract;
 use self::error::collectable::Collectable as CollectableError;
@@ -221,7 +222,8 @@ impl Output {
         sources: &BTreeMap<String, StandardJSONInputSource>,
         version: &SolcVersion,
         pipeline: SolcPipeline,
-        suppressed_messages: &[MessageType],
+        suppressed_errors: &[ErrorType],
+        suppressed_warnings: &[WarningType],
     ) -> anyhow::Result<()> {
         let source_asts = match self.sources.as_ref() {
             Some(sources) => sources,
@@ -245,7 +247,8 @@ impl Output {
                             sources,
                             version,
                             pipeline,
-                            suppressed_messages,
+                            suppressed_errors,
+                            suppressed_warnings,
                         )
                     })
                     .unwrap_or_default()

--- a/era-compiler-solidity/src/solc/standard_json/output/source.rs
+++ b/era-compiler-solidity/src/solc/standard_json/output/source.rs
@@ -4,11 +4,12 @@
 
 use std::collections::BTreeMap;
 
-use crate::message_type::MessageType;
+use crate::error_type::ErrorType;
 use crate::solc::pipeline::Pipeline as SolcPipeline;
 use crate::solc::standard_json::input::source::Source as StandardJSONInputSource;
 use crate::solc::standard_json::output::error::Error as SolcStandardJsonOutputError;
 use crate::solc::version::Version as SolcVersion;
+use crate::warning_type::WarningType;
 
 ///
 /// The `solc --standard-json` output source.
@@ -220,10 +221,11 @@ impl Source {
         sources: &BTreeMap<String, StandardJSONInputSource>,
         solc_version: &SolcVersion,
         solc_pipeline: SolcPipeline,
-        suppressed_messages: &[MessageType],
+        suppressed_errors: &[ErrorType],
+        suppressed_warnings: &[WarningType],
     ) -> Vec<SolcStandardJsonOutputError> {
         let mut messages = Vec::new();
-        if !suppressed_messages.contains(&MessageType::SendTransfer) {
+        if !suppressed_errors.contains(&ErrorType::SendTransfer) {
             if let Some(message) =
                 Self::check_send_and_transfer(solc_version, ast, id_paths, sources)
             {
@@ -238,7 +240,7 @@ impl Source {
                 messages.push(message);
             }
         }
-        if !suppressed_messages.contains(&MessageType::TxOrigin) {
+        if !suppressed_warnings.contains(&WarningType::TxOrigin) {
             if let Some(message) = Self::check_assembly_origin(solc_version, ast, id_paths, sources)
             {
                 messages.push(message);
@@ -257,7 +259,8 @@ impl Source {
                         sources,
                         solc_version,
                         solc_pipeline,
-                        suppressed_messages,
+                        suppressed_errors,
+                        suppressed_warnings,
                     ));
                 }
             }
@@ -269,7 +272,8 @@ impl Source {
                         sources,
                         solc_version,
                         solc_pipeline,
-                        suppressed_messages,
+                        suppressed_errors,
+                        suppressed_warnings,
                     ));
                 }
             }

--- a/era-compiler-solidity/src/warning_type.rs
+++ b/era-compiler-solidity/src/warning_type.rs
@@ -1,0 +1,38 @@
+//!
+//! The compiler warning type.
+//!
+
+use std::str::FromStr;
+
+///
+/// The compiler warning type.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WarningType {
+    /// The eponymous feature.
+    TxOrigin,
+}
+
+impl WarningType {
+    ///
+    /// Converts string arguments into an array of warnings.
+    ///
+    pub fn try_from_strings(strings: &[String]) -> Result<Vec<Self>, anyhow::Error> {
+        strings
+            .iter()
+            .map(|string| Self::from_str(string))
+            .collect()
+    }
+}
+
+impl FromStr for WarningType {
+    type Err = anyhow::Error;
+
+    fn from_str(string: &str) -> Result<Self, Self::Err> {
+        match string {
+            "txorigin" => Ok(Self::TxOrigin),
+            r#type => Err(anyhow::anyhow!("Invalid suppressed warning type: {type}")),
+        }
+    }
+}

--- a/era-compiler-solidity/src/zksolc/main.rs
+++ b/era-compiler-solidity/src/zksolc/main.rs
@@ -119,10 +119,10 @@ fn main_inner(
         })
         .unwrap_or_default();
 
-    let suppressed_errors = era_compiler_solidity::MessageType::try_from_strings(
+    let suppressed_errors = era_compiler_solidity::ErrorType::try_from_strings(
         arguments.suppressed_errors.unwrap_or_default().as_slice(),
     )?;
-    let suppressed_warnings = era_compiler_solidity::MessageType::try_from_strings(
+    let suppressed_warnings = era_compiler_solidity::WarningType::try_from_strings(
         arguments.suppressed_warnings.unwrap_or_default().as_slice(),
     )?;
 

--- a/era-compiler-solidity/tests/cli/standard_json.rs
+++ b/era-compiler-solidity/tests/cli/standard_json.rs
@@ -99,7 +99,7 @@ fn run_zksolc_with_incorrect_standard_json_suppressed_errors_and_warnings_deseri
 
     let result = cli::execute_zksolc(args)?;
     result.success().stdout(predicate::str::contains(
-        "unknown variant `INVALID_SUPPRESSED_MESSAGE_TYPE`",
+        "unknown variant `INVALID_SUPPRESSED_ERROR_TYPE`",
     ));
 
     Ok(())

--- a/era-compiler-solidity/tests/common/mod.rs
+++ b/era-compiler-solidity/tests/common/mod.rs
@@ -3,7 +3,7 @@
 //!
 
 use assert_cmd::Command;
-use era_compiler_solidity::message_type::MessageType;
+use era_compiler_solidity::error_type::ErrorType;
 use era_compiler_solidity::project::Project;
 use era_compiler_solidity::solc::pipeline::Pipeline as SolcPipeline;
 use era_compiler_solidity::solc::standard_json::input::settings::optimizer::Optimizer as SolcStandardJsonInputSettingsOptimizer;
@@ -13,6 +13,7 @@ use era_compiler_solidity::solc::standard_json::input::Input as SolcStandardJson
 use era_compiler_solidity::solc::standard_json::output::error::collectable::Collectable as CollectableError;
 use era_compiler_solidity::solc::standard_json::output::Output as SolcStandardJsonOutput;
 use era_compiler_solidity::solc::Compiler as SolcCompiler;
+use era_compiler_solidity::warning_type::WarningType;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -405,7 +406,8 @@ pub fn check_solidity_message(
     solc_version: &semver::Version,
     solc_pipeline: SolcPipeline,
     skip_for_zksync_edition: bool,
-    suppressed_warnings: Vec<MessageType>,
+    suppressed_errors: Vec<ErrorType>,
+    suppressed_warnings: Vec<WarningType>,
 ) -> anyhow::Result<bool> {
     setup()?;
 
@@ -430,7 +432,7 @@ pub fn check_solidity_message(
         false,
         false,
         vec![],
-        vec![],
+        suppressed_errors,
         suppressed_warnings,
     )?;
 

--- a/era-compiler-solidity/tests/common/mod.rs
+++ b/era-compiler-solidity/tests/common/mod.rs
@@ -131,7 +131,6 @@ pub fn build_solidity(
         vec![],
         None,
     )?;
-    solc_output.take_and_write_warnings();
     solc_output.collect_errors()?;
 
     let project = Project::try_from_solc_output(
@@ -141,7 +140,6 @@ pub fn build_solidity(
         &solc_compiler,
         None,
     )?;
-    solc_output.take_and_write_warnings();
     solc_output.collect_errors()?;
 
     let build = project.compile_to_eravm(
@@ -160,7 +158,6 @@ pub fn build_solidity(
         &semver::Version::from_str(env!("CARGO_PKG_VERSION"))?,
     )?;
 
-    solc_output.take_and_write_warnings();
     solc_output.collect_errors()?;
     Ok(solc_output)
 }
@@ -225,7 +222,6 @@ pub fn build_solidity_and_detect_missing_libraries(
         &semver::Version::from_str(env!("CARGO_PKG_VERSION"))?,
     )?;
 
-    solc_output.take_and_write_warnings();
     solc_output.collect_errors()?;
     Ok(solc_output)
 }
@@ -267,7 +263,6 @@ pub fn build_yul(sources: BTreeMap<String, String>) -> anyhow::Result<SolcStanda
     )?;
     build.write_to_standard_json(&mut solc_output, None, &zksolc_version)?;
 
-    solc_output.take_and_write_warnings();
     solc_output.collect_errors()?;
     Ok(solc_output)
 }
@@ -321,7 +316,6 @@ pub fn build_yul_standard_json(
     )?;
     build.write_to_standard_json(&mut solc_output, solc_version, &zksolc_version)?;
 
-    solc_output.take_and_write_warnings();
     solc_output.collect_errors()?;
     Ok(solc_output)
 }
@@ -356,7 +350,6 @@ pub fn build_llvm_ir_standard_json(
     )?;
     build.write_to_standard_json(&mut output, None, &zksolc_version)?;
 
-    output.take_and_write_warnings();
     output.collect_errors()?;
     Ok(output)
 }
@@ -391,7 +384,6 @@ pub fn build_eravm_assembly_standard_json(
     )?;
     build.write_to_standard_json(&mut output, None, &zksolc_version)?;
 
-    output.take_and_write_warnings();
     output.collect_errors()?;
     Ok(output)
 }

--- a/era-compiler-solidity/tests/examples/standard_json_input/contract_incorrect_suppressed_warnings_and_errors.json
+++ b/era-compiler-solidity/tests/examples/standard_json_input/contract_incorrect_suppressed_warnings_and_errors.json
@@ -11,6 +11,6 @@
       "runs": 200
     }
   },
-  "suppressedErrors": ["INVALID_SUPPRESSED_MESSAGE_TYPE"],
-  "suppressedWarnings": ["INVALID_SUPPRESSED_MESSAGE_TYPE"]
+  "suppressedErrors": ["INVALID_SUPPRESSED_ERROR_TYPE"],
+  "suppressedWarnings": ["INVALID_SUPPRESSED_WARNING_TYPE"]
 }

--- a/era-compiler-solidity/tests/regression/messages.rs
+++ b/era-compiler-solidity/tests/regression/messages.rs
@@ -3,9 +3,10 @@
 //!
 
 use crate::common;
-use era_compiler_solidity::message_type::MessageType;
+use era_compiler_solidity::error_type::ErrorType;
 use era_compiler_solidity::solc::pipeline::Pipeline as SolcPipeline;
 use era_compiler_solidity::solc::Compiler as SolcCompiler;
+use era_compiler_solidity::warning_type::WarningType;
 use std::collections::BTreeMap;
 
 #[test]
@@ -447,6 +448,7 @@ fn send(version: semver::Version, pipeline: SolcPipeline, source_code: &str) {
         pipeline,
         false,
         vec![],
+        vec![],
     )
     .expect("Test failure"));
 }
@@ -459,7 +461,8 @@ fn send_suppressed(version: semver::Version, pipeline: SolcPipeline, source_code
         &version,
         pipeline,
         false,
-        vec![MessageType::SendTransfer],
+        vec![ErrorType::SendTransfer],
+        vec![],
     )
     .expect("Test failure"));
 }
@@ -500,6 +503,7 @@ fn transfer(version: semver::Version, pipeline: SolcPipeline, source_code: &str)
         pipeline,
         false,
         vec![],
+        vec![],
     )
     .expect("Test failure"));
 }
@@ -512,7 +516,8 @@ fn transfer_suppressed(version: semver::Version, pipeline: SolcPipeline, source_
         &version,
         pipeline,
         false,
-        vec![MessageType::SendTransfer],
+        vec![ErrorType::SendTransfer],
+        vec![],
     )
     .expect("Test failure"));
 }
@@ -538,6 +543,7 @@ fn runtime_code(version: semver::Version, pipeline: SolcPipeline) {
         &version,
         pipeline,
         false,
+        vec![],
         vec![],
     )
     .expect("Test failure"));
@@ -583,6 +589,7 @@ contract InternalFunctionPointerExample {
         SolcPipeline::EVMLA,
         true,
         vec![],
+        vec![],
     )
     .expect("Test failure"));
 }
@@ -620,6 +627,7 @@ contract StackFunctionPointerExample {
         &version,
         SolcPipeline::EVMLA,
         true,
+        vec![],
         vec![],
     )
     .expect("Test failure"));
@@ -666,6 +674,7 @@ contract StorageFunctionPointerExample {
         SolcPipeline::EVMLA,
         true,
         vec![],
+        vec![],
     )
     .expect("Test failure"));
 }
@@ -687,6 +696,7 @@ fn tx_origin(version: semver::Version, pipeline: SolcPipeline) {
         pipeline,
         false,
         vec![],
+        vec![],
     )
     .expect("Test failure"));
 }
@@ -699,7 +709,8 @@ fn tx_origin_suppressed(version: semver::Version, pipeline: SolcPipeline) {
         &version,
         pipeline,
         false,
-        vec![MessageType::TxOrigin],
+        vec![],
+        vec![WarningType::TxOrigin],
     )
     .expect("Test failure"));
 }
@@ -723,6 +734,7 @@ fn tx_origin_assembly(version: semver::Version, pipeline: SolcPipeline) {
         pipeline,
         false,
         vec![],
+        vec![],
     )
     .expect("Test failure"));
 }
@@ -735,7 +747,8 @@ fn tx_origin_assembly_suppressed(version: semver::Version, pipeline: SolcPipelin
         &version,
         pipeline,
         false,
-        vec![MessageType::TxOrigin],
+        vec![],
+        vec![WarningType::TxOrigin],
     )
     .expect("Test failure"));
 }


### PR DESCRIPTION
# What ❔

1. Moves suppressed warnings and errors from the root of standard JSON input to `settings`.
2. Splits suppressed messages enum into warnings and errors, fixing the bug that a warning could be parsed as error, and vice versa. 

## Why ❔

1. Toolkits (Hardhat, Foundry) are only exposing the `settings` object to users, so hacks are needed in the toolkit's sources in order to move fields to the root.
2. Anyway, suppressed warnings and errors shouldn't have been added to the root in the first place.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
