### PR TITLE
docs: add text specifier for output to fix mdbook test

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -1,18 +1,26 @@
-name: Deploy docs to GH pages
+name: Deploy docs
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - "main"
+    tags:
+      - "*.*.*"
     paths:
       - 'docs/**'
       - '.github/workflows/deploy-docs.yaml'
   workflow_dispatch:
-
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+    inputs:
+      version:
+        type: string
+        description: "Version of the documentation to deploy"
+        required: false
+        default: "latest"
+      docs-dir:
+        type: string
+        description: "Directory with the documentation"
+        required: false
+        default: "docs"
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -21,36 +29,20 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+
+  deploy-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install latest mdbook
-        run: |
-          TAG=$(curl 'https://api.github.com/repos/rust-lang/mdbook/releases/latest' | jq -r '.tag_name')
-          URL="https://github.com/rust-lang/mdbook/releases/download/${TAG}/mdbook-${TAG}-x86_64-unknown-linux-gnu.tar.gz"
-          MDBOOK_DIR=mdbook
-          mkdir -p "${MDBOOK_DIR}"
-          curl -sSL ${URL} | tar -xz --directory=${MDBOOK_DIR}
-          echo "${PWD}/mdbook" >> "${GITHUB_PATH}"
-
-      - name: Build Book
-        working-directory: docs
-        run: mdbook build
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Deploy
+        uses: matter-labs/deploy-mdbooks@v1
         with:
-          path: 'docs/book'
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          version: ${{ inputs.version || github.ref_name }}
+          docs-dir: ${{ inputs.docs-dir || 'docs' }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          force-orphan: true
+          enable-tests: true

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ To run the unit and CLI tests, execute the following command from the repository
 cargo test
 ```
 
+## Documentation
+
+Documentation is using [mdBook](https://github.com/rust-lang/mdBook) utility and is available in the `docs/` directory.
+To build the documentation, follow the [instructions](./docs/README.md).
+
 ## Troubleshooting
 
 If you have multiple LLVM builds in your system, ensure that you choose the correct one to build the compiler.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,57 @@
+# ZKsync Solidity Compiler Toolchain Documentation
+
+This directory contains an `mdBook` project for ZKsync Solidity Compiler Toolchain documentation.
+This README will guide you on how to build and test the book locally.
+
+## Prerequisites
+
+Before you begin, ensure you have the `mdbook` installed:
+
+  ```bash
+  cargo install mdbook
+  ```
+
+## Build the Book
+
+To build the book, use the following command:
+
+```bash
+mdbook build
+```
+
+This command generates the static HTML files in the `book/` directory. You can open `book/index.html` in your browser to view the generated book.
+
+## Serve the Book Locally
+
+For easier development and to preview changes as you edit, you can serve the book locally with:
+
+```bash
+mdbook serve
+```
+
+This will start a local web server and open the book in your default browser. Any changes made to the markdown files will automatically reload the book.
+
+By default, the book will be accessible at: `http://localhost:3000`.
+
+## Testing the Book
+
+To ensure your book is correctly built and formatted, you can use the built-in `mdBook` linter by running:
+
+```bash
+mdbook test
+```
+
+This will check for common issues such as broken links or missing files.
+
+## Directory Structure
+
+- `src/`: This directory contains all the markdown files for the chapters.
+- `book/`: This is the output directory where the built HTML files are generated.
+- `book.toml`: Configuration file for the `mdBook`.
+
+## Deployment
+
+The book is automatically deployed each time a commit is pushed to the `main` branch or a new release tag is created.
+The generated HTML files are hosted on GitHub Pages and are accessible at:
+* https://matter-labs.github.io/era-compiler-solidity/latest/ for the latest documentation.
+* https://matter-labs.github.io/era-compiler-solidity/vX.Y.Z/ for the specific version documentation.

--- a/docs/src/02-command-line-interface.md
+++ b/docs/src/02-command-line-interface.md
@@ -52,7 +52,7 @@ zksolc './Simple.sol' --bin
 
 Output:
 
-```
+```text
 ======= Simple.sol:Simple =======
 Binary:
 0000008003000039000000400030043f0000000100200190000000130000c13d...
@@ -66,7 +66,7 @@ zksolc './Simple.sol'
 
 Output:
 
-```
+```text
 Compiler run successful. No output requested. Use flags --metadata, --asm, --bin.
 ```
 
@@ -116,7 +116,7 @@ zksolc Simple.sol --asm
 
 Output:
 
-```
+```text
 ======= Simple.sol:Simple =======
 EraVM assembly:
         .text
@@ -151,7 +151,7 @@ zksolc Simple.sol --metadata
 
 Output:
 
-```
+```text
 ======= Simple.sol:Simple =======
 Metadata:
 {"llvm_options":[],"optimizer_settings":{"is_debug_logging_enabled":false,"is_fallback_to_size_enabled":false,"is_verify_each_enabled":false,"level_back_end":"Aggressive","level_middle_end":"Aggressive","level_middle_end_size":"Zero"},"solc_version":"<masked>","solc_zkvm_edition":null,"source_metadata":{...},"zk_version":"<masked>"}
@@ -200,7 +200,7 @@ zksolc --yul Simple.yul --bin
 
 Output:
 
-```
+```text
 ======= Simple.yul =======
 Binary:
 0000000100200190000000060000c13d0000002a01000039000000000010043f...
@@ -230,7 +230,7 @@ zksolc --llvm-ir Simple.ll --bin
 
 Output:
 
-```
+```text
 ======= Simple.ll =======
 Binary:
 000000000002004b000000070000613d0000002001000039000000000010043f...
@@ -254,7 +254,7 @@ zksolc --eravm-assembly Simple.zasm --bin
 
 Output:
 
-```
+```text
 ======= Simple.zasm =======
 Binary:
 000000000120008c000000070000613d00000020010000390000000000100435...
@@ -294,7 +294,7 @@ cat './input.hex'
 
 Output:
 
-```
+```text
 0x0000008003000039000000400030043f0000000100200190000000140000c13d00000000020...
 ```
 
@@ -307,7 +307,7 @@ zksolc --disassemble './input.hex'
 
 Output:
 
-```
+```text
 File `input.hex` disassembly:
 
        0: 00 00 00 80 03 00 00 39       add     128, r0, r3
@@ -350,7 +350,7 @@ zksolc Simple.sol --bin --target evm
 
 Output:
 
-```
+```text
 ======= Simple.sol:Simple =======
 Binary:
 5b60806040523415600e575f5ffd5b630000007f630000002760808282823960808092505050f35b5f5f6080604052369150600482106032575f3560e01c9050633df4ddf48114603657635a8ac02d81811480915050605a575b5f5ffd5b3415603f575f5ffd5b60015f036004830313604f575f5ffd5b602a60805260206080f35b34156063575f5ffd5b60015f0360048303136073575f5ffd5b60405160638152602090f3


### PR DESCRIPTION
# What ❔

Add `text` specifier for empty text sections.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To disallow [testing of these sections as Rust code](https://rust-lang.github.io/mdBook/cli/test.html#:~:text=rustdoc%20does%20test%20code%20blocks%20which%20have%20no%20language%20specified%3A) by the `mdbook test` command.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
