### PR TITLE
docs: add versioned mdbook support

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -44,5 +44,4 @@ jobs:
           version: ${{ inputs.version || github.ref_name }}
           docs-dir: ${{ inputs.docs-dir || 'docs' }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          force-orphan: true
           enable-tests: true

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -8,3 +8,7 @@ language = "en"
 multilingual = false
 src = "src"
 title = "ZKsync Solidity Compiler Toolchain Documentation"
+
+[output.html]
+additional-js = ["js/version-box.js"]
+additional-css = ["css/version-box.css"]

--- a/docs/css/version-box.css
+++ b/docs/css/version-box.css
@@ -1,0 +1,46 @@
+#version-box {
+    display: flex;
+    align-items: center;
+    margin-right: 15px; /* Space from the right side */
+    background-color: transparent; /* Make the box background transparent */
+}
+
+/* Base styles for the version selector */
+#version-selector {
+    background-color: transparent; /* Remove background color */
+    border: 1px solid #4a5568;     /* Subtle border */
+    border-radius: 4px;            /* Rounded edges */
+    padding: 5px 10px;             /* Padding inside dropdown */
+    font-size: 0.9em;
+    font-weight: normal;
+    outline: none;                 /* Removes default focus outline */
+    cursor: pointer;
+}
+
+/* Text color for dark themes */
+.theme-navy #version-selector,
+.theme-coal #version-selector {
+    color: #f7fafc; /* Light text color for dark backgrounds */
+}
+
+/* Text color for light theme */
+.theme-light #version-selector {
+    color: #333333; /* Dark text color for light background */
+}
+
+/* Hover effect for better user feedback */
+#version-selector:hover {
+    background-color: rgba(255, 255, 255, 0.1); /* Light hover effect */
+}
+
+/* Optional: Style for when the selector is focused */
+#version-selector:focus {
+    border-color: #63b3ed; /* Accent color for focused state */
+}
+
+.right-buttons {
+    display: flex;
+    flex-direction: row;     /* Aligns items in a row, left to right */
+    align-items: center;     /* Centers items vertically */
+    gap: 10px;               /* Adds space between items */
+}

--- a/docs/js/version-box.js
+++ b/docs/js/version-box.js
@@ -1,0 +1,61 @@
+document.addEventListener("DOMContentLoaded", function() {
+    // Get the base URL from the mdBook configuration
+    const baseUrl = document.location.pathname.split('/').slice(0, -2).join('/');
+
+    // Function to create version selector
+    function createVersionSelector(versions) {
+        const versionSelector = document.createElement("select");
+        versionSelector.id = "version-selector";
+
+        // Get the current path
+        const currentPath = window.location.pathname;
+
+        // Iterate over the versions object
+        for (const [versionName, versionUrl] of Object.entries(versions)) {
+            const option = document.createElement("option");
+            option.value = baseUrl + versionUrl; // Prepend base URL
+            option.textContent = versionName;
+
+            // Check if the current URL matches this option's value
+            if (currentPath === option.value + '/') {
+                option.selected = true; // Set this option as selected
+            }
+
+            versionSelector.appendChild(option);
+        }
+
+        // Event listener to handle version change
+        versionSelector.addEventListener("change", function() {
+            const selectedVersion = versionSelector.value;
+            // Redirect to the selected version URL
+            window.location.href = selectedVersion;
+        });
+
+        return versionSelector;
+    }
+
+    // Fetch versions from JSON file
+    fetch(baseUrl + '/versions.json')
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('Network response was not ok ' + response.statusText);
+            }
+            return response.json();
+        })
+        .then(data => {
+            const versionSelector = createVersionSelector(data);
+            const nav = document.querySelector(".right-buttons");
+
+            if (nav) {
+                const versionBox = document.createElement("div");
+                versionBox.id = "version-box";
+                versionBox.appendChild(versionSelector);
+                nav.appendChild(versionBox); // Append to the .right-buttons container
+            } else {
+                console.error(".right-buttons element not found.");
+            }
+        })
+        .catch(error => {
+            console.error('There has been a problem with your fetch operation:', error);
+        });
+});


### PR DESCRIPTION
# What ❔

Add versioning box to `mdbook` documentation website.

<img width="135" alt="image" src="https://github.com/user-attachments/assets/93d1a50c-d0e1-476a-b70d-b75383715510">


<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To be able to dynamically switch between documentation versions.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
