### PR TITLE
fix: default for outputSelection

### DIFF
--- a/era-solc/src/standard_json/input/settings/selection/file/mod.rs
+++ b/era-solc/src/standard_json/input/settings/selection/file/mod.rs
@@ -14,10 +14,10 @@ use self::flag::Flag as SelectionFlag;
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct File {
     /// The per-file output selections.
-    #[serde(rename = "", skip_serializing_if = "HashSet::is_empty")]
+    #[serde(default, rename = "", skip_serializing_if = "HashSet::is_empty")]
     pub per_file: HashSet<SelectionFlag>,
     /// The per-contract output selections.
-    #[serde(rename = "*", skip_serializing_if = "HashSet::is_empty")]
+    #[serde(default, rename = "*", skip_serializing_if = "HashSet::is_empty")]
     pub per_contract: HashSet<SelectionFlag>,
 }
 


### PR DESCRIPTION
# What ❔

Fixes `#[serde(default)]` in `outputSelection`.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
