### PR TITLE
feat: always emit missing libraries

### DIFF
--- a/era-compiler-solidity/src/lib.rs
+++ b/era-compiler-solidity/src/lib.rs
@@ -544,23 +544,26 @@ pub fn standard_json_eravm(
         }
     };
 
+    let missing_libraries = project.get_missing_libraries();
     if detect_missing_libraries {
-        let missing_libraries = project.get_missing_libraries();
         missing_libraries.write_to_standard_json(&mut solc_output, solc_version.as_ref());
-    } else {
-        let build = project.compile_to_eravm(
-            messages,
-            enable_eravm_extensions,
-            linker_symbols,
-            metadata_hash_type,
-            optimizer_settings,
-            llvm_options,
-            output_assembly,
-            threads,
-            debug_config,
-        )?;
-        build.write_to_standard_json(&mut solc_output, solc_version.as_ref())?;
+        solc_output.write_and_exit(prune_output);
     }
+
+    let build = project.compile_to_eravm(
+        messages,
+        enable_eravm_extensions,
+        linker_symbols,
+        metadata_hash_type,
+        optimizer_settings,
+        llvm_options,
+        output_assembly,
+        threads,
+        debug_config,
+    )?;
+    build.write_to_standard_json(&mut solc_output, solc_version.as_ref())?;
+    missing_libraries.write_to_standard_json(&mut solc_output, solc_version.as_ref());
+
     solc_output.write_and_exit(prune_output);
 }
 

--- a/era-compiler-solidity/src/missing_libraries.rs
+++ b/era-compiler-solidity/src/missing_libraries.rs
@@ -35,7 +35,7 @@ impl MissingLibraries {
                 let missing_libraries = self.contract_libraries.remove(full_name.as_str());
 
                 if let Some(missing_libraries) = missing_libraries {
-                    contract.missing_libraries = Some(missing_libraries);
+                    contract.missing_libraries = missing_libraries;
                 }
             }
         }

--- a/era-compiler-solidity/tests/unit/libraries.rs
+++ b/era-compiler-solidity/tests/unit/libraries.rs
@@ -142,8 +142,6 @@ fn not_specified(version: semver::Version, codegen: era_solc::StandardJsonInputC
             .get("SimpleContract")
             .expect("Always exists")
             .missing_libraries
-            .as_ref()
-            .expect("Always exists")
             .contains("test.sol:SimpleLibrary"),
         "Missing library not detected"
     );
@@ -172,9 +170,6 @@ fn specified(version: semver::Version, codegen: era_solc::StandardJsonInputCodeg
             .get("SimpleContract")
             .expect("Always exists")
             .missing_libraries
-            .as_ref()
-            .cloned()
-            .unwrap_or_default()
             .is_empty(),
         "The list of missing libraries must be empty"
     );

--- a/era-solc/src/standard_json/output/contract/mod.rs
+++ b/era-solc/src/standard_json/output/contract/mod.rs
@@ -51,10 +51,9 @@ pub struct Contract {
     /// The contract factory dependencies.
     #[serde(default, skip_deserializing)]
     pub factory_dependencies: BTreeMap<String, String>,
-
     /// The contract missing libraries.
-    #[serde(default, skip_serializing_if = "Option::is_none", skip_deserializing)]
-    pub missing_libraries: Option<HashSet<String>>,
+    #[serde(default, skip_deserializing)]
+    pub missing_libraries: HashSet<String>,
 }
 
 impl Contract {
@@ -73,6 +72,6 @@ impl Contract {
             && self.eravm.is_none()
             && self.hash.is_none()
             && self.factory_dependencies.is_empty()
-            && self.missing_libraries.is_none()
+            && self.missing_libraries.is_empty()
     }
 }


### PR DESCRIPTION
# What ❔

Always emits missing libraries in standard JSON.

## Why ❔

It decreases the number of calls to *zksolc* Foundry has to make.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
