### PR TITLE
ci: remove main trigger for docs deployment

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -2,8 +2,6 @@ name: Deploy docs
 
 on:
   push:
-    branches:
-      - "main"
     tags:
       - "*.*.*"
     paths:
@@ -18,8 +16,7 @@ on:
       version:
         type: string
         description: "Version of the documentation to deploy"
-        required: false
-        default: "latest"
+        required: true
       docs-dir:
         type: string
         description: "Directory with the documentation"
@@ -50,3 +47,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           enable-tests: true
           deploy: ${{ github.event_name != 'pull_request' }}
+          create-latest-symlink: true


### PR DESCRIPTION
# What ❔

Remove `main` branch trigger for docs deployment.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

`latest` should point to the `latest` stable release of docs, not to main.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
