### PR TITLE
fix: replace structopt with clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,10 +27,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "anyhow"
@@ -272,14 +315,49 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
 dependencies = [
- "bitflags 1.3.2",
- "textwrap",
- "unicode-width",
+ "clap_builder",
+ "clap_derive",
 ]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "colored"
@@ -576,6 +654,7 @@ version = "1.5.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "clap",
  "era-compiler-common",
  "era-compiler-downloader",
  "era-compiler-llvm-context",
@@ -595,7 +674,6 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "structopt",
  "tempfile",
  "test-case",
  "thiserror",
@@ -875,12 +953,9 @@ checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1223,6 +1298,12 @@ name = "ipnet"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -1784,30 +1865,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2315,28 +2372,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "structopt"
-version = "0.3.26"
+name = "strsim"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -2460,15 +2499,6 @@ dependencies = [
  "quote",
  "syn 2.0.87",
  "test-case-core",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -2621,18 +2651,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
 name = "unsigned-varint"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2666,6 +2684,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vcpkg"

--- a/era-compiler-solidity/Cargo.toml
+++ b/era-compiler-solidity/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/zksolc/main.rs"
 doctest = false
 
 [dependencies]
-structopt = { version = "=0.3.26", default-features = false }
+clap = { version = "=4.5.21", features = ["derive"] }
 thiserror = "=1.0.64"
 anyhow = "=1.0.89"
 path-slash = "=0.2.1"

--- a/era-compiler-solidity/tests/cli/asm.rs
+++ b/era-compiler-solidity/tests/cli/asm.rs
@@ -56,7 +56,7 @@ fn with_asm_duplicate_flag(target: Target) -> anyhow::Result<()> {
     let status_code = result
         .failure()
         .stderr(predicate::str::contains(
-            "The argument '--asm' was provided more than once",
+            "error: the argument '--asm' cannot be used multiple times",
         ))
         .get_output()
         .status

--- a/era-compiler-solidity/tests/cli/basic.rs
+++ b/era-compiler-solidity/tests/cli/basic.rs
@@ -14,7 +14,7 @@ fn without_any_args() -> anyhow::Result<()> {
     let status_code = result
         .failure()
         .stderr(predicate::str::contains(
-            "Compiles the provided Solidity input files",
+            "Error: No input sources specified",
         ))
         .get_output()
         .status

--- a/era-compiler-solidity/tests/cli/bin.rs
+++ b/era-compiler-solidity/tests/cli/bin.rs
@@ -56,7 +56,7 @@ fn with_bin_duplicate_flag(target: Target) -> anyhow::Result<()> {
     let status_code = result
         .failure()
         .stderr(predicate::str::contains(
-            "The argument '--bin' was provided more than once",
+            "error: the argument '--bin' cannot be used multiple times",
         ))
         .get_output()
         .status

--- a/era-compiler-solidity/tests/cli/codegen.rs
+++ b/era-compiler-solidity/tests/cli/codegen.rs
@@ -145,7 +145,7 @@ fn with_codegen_invalid(target: Target) -> anyhow::Result<()> {
     let result = cli::execute_zksolc_with_target(args, target)?;
     result
         .failure()
-        .stderr(predicate::str::contains("Invalid value for \'--codegen <codegen>\': Invalid codegen: `invalid`. Available options: evmla, yul"));
+        .stderr(predicate::str::contains("error: invalid value 'invalid' for '--codegen <CODEGEN>': Invalid codegen: `invalid`. Available options: evmla, yul"));
 
     Ok(())
 }

--- a/era-compiler-solidity/tests/cli/combined_json.rs
+++ b/era-compiler-solidity/tests/cli/combined_json.rs
@@ -69,7 +69,7 @@ fn with_combined_json_two_files(target: Target) -> anyhow::Result<()> {
 
 #[test_case(Target::EraVM)]
 #[test_case(Target::EVM)]
-fn with_combined_json_no_args(target: Target) -> anyhow::Result<()> {
+fn with_combined_json_no_argument(target: Target) -> anyhow::Result<()> {
     common::setup()?;
 
     let args = &["--combined-json"];
@@ -78,7 +78,7 @@ fn with_combined_json_no_args(target: Target) -> anyhow::Result<()> {
     let status_code = result
         .failure()
         .stderr(predicate::str::contains(
-            "requires a value but none was supplied",
+            "error: a value is required for \'--combined-json <COMBINED_JSON>\' but none was supplied",
         ))
         .get_output()
         .status

--- a/era-compiler-solidity/tests/cli/eravm/eravm_assembly.rs
+++ b/era-compiler-solidity/tests/cli/eravm/eravm_assembly.rs
@@ -29,7 +29,7 @@ fn with_eravm_assembly_duplicate_flag() -> anyhow::Result<()> {
 
     let result = cli::execute_zksolc(args)?;
     result.failure().stderr(predicate::str::contains(
-        "The argument '--eravm-assembly' was provided more than once",
+        "error: the argument \'--eravm-assembly\' cannot be used multiple times",
     ));
 
     Ok(())

--- a/era-compiler-solidity/tests/cli/eravm/llvm_ir.rs
+++ b/era-compiler-solidity/tests/cli/eravm/llvm_ir.rs
@@ -22,7 +22,7 @@ fn with_llvm_ir_duplicate_flag() -> anyhow::Result<()> {
 
     let result = cli::execute_zksolc(args)?;
     result.failure().stderr(predicate::str::contains(
-        "The argument '--llvm-ir' was provided more than once",
+        "error: the argument '--llvm-ir' cannot be used multiple times",
     ));
 
     Ok(())

--- a/era-compiler-solidity/tests/cli/libraries.rs
+++ b/era-compiler-solidity/tests/cli/libraries.rs
@@ -29,7 +29,7 @@ fn without_input(target: Target) -> anyhow::Result<()> {
 
     let result = cli::execute_zksolc_with_target(args, target)?;
     result.failure().stderr(predicate::str::contains(
-        "requires a value but none was supplied",
+        "error: a value is required for '--libraries <LIBRARIES>' but none was supplied",
     ));
 
     Ok(())

--- a/era-compiler-solidity/tests/cli/metadata.rs
+++ b/era-compiler-solidity/tests/cli/metadata.rs
@@ -60,7 +60,7 @@ fn with_metadata_duplicate_flag(target: Target) -> anyhow::Result<()> {
     let status_code = result
         .failure()
         .stderr(predicate::str::contains(
-            "The argument '--metadata' was provided more than once",
+            "error: the argument '--metadata' cannot be used multiple times",
         ))
         .get_output()
         .status

--- a/era-compiler-solidity/tests/cli/metadata_hash.rs
+++ b/era-compiler-solidity/tests/cli/metadata_hash.rs
@@ -38,7 +38,7 @@ fn with_metadata_hash_no_argument(target: Target) -> anyhow::Result<()> {
     let zksolc_result = result
         .failure()
         .stderr(predicate::str::contains(
-            "requires a value but none was supplied",
+            "error: a value is required for '--metadata-hash <METADATA_HASH>' but none was supplied",
         ))
         .get_output()
         .status

--- a/era-compiler-solidity/tests/cli/optimization.rs
+++ b/era-compiler-solidity/tests/cli/optimization.rs
@@ -47,7 +47,7 @@ fn with_invalid_optimization_option(target: Target) -> anyhow::Result<()> {
     let result = cli::execute_zksolc_with_target(args, target)?;
     result.failure().stderr(
         predicate::str::contains("Unexpected optimization option")
-            .or(predicate::str::contains("Invalid value for")),
+            .or(predicate::str::contains("error: invalid value \'99\' for \'--optimization <OPTIMIZATION>\': too many characters in string")),
     );
 
     Ok(())

--- a/era-compiler-solidity/tests/cli/output_dir.rs
+++ b/era-compiler-solidity/tests/cli/output_dir.rs
@@ -145,8 +145,13 @@ fn with_output_dir_invalid_arg_no_path(target: Target) -> anyhow::Result<()> {
     let result = cli::execute_zksolc_with_target(args, target)?;
     let status = result
         .failure()
-        .stderr(predicate::str::contains("error: The argument '--output-dir <output-directory>' requires a value but none was supplied"))
-        .get_output().status.code().expect("No exit code.");
+        .stderr(predicate::str::contains(
+            "error: a value is required for '--output-dir <OUTPUT_DIR>' but none was supplied",
+        ))
+        .get_output()
+        .status
+        .code()
+        .expect("No exit code.");
 
     let solc_result = cli::execute_solc(args)?;
     solc_result.code(status);

--- a/era-compiler-solidity/tests/cli/yul.rs
+++ b/era-compiler-solidity/tests/cli/yul.rs
@@ -52,7 +52,7 @@ fn with_yul_invalid_against_solc(target: Target) -> anyhow::Result<()> {
 
 #[test_case(Target::EraVM)]
 #[test_case(Target::EVM)]
-fn with_yul_double_against_solc(target: Target) -> anyhow::Result<()> {
+fn with_yul_duplicate_flag_against_solc(target: Target) -> anyhow::Result<()> {
     common::setup()?;
 
     let args = &[common::TEST_YUL_CONTRACT_PATH, "--yul", "--yul"];
@@ -61,7 +61,7 @@ fn with_yul_double_against_solc(target: Target) -> anyhow::Result<()> {
     let status = result
         .failure()
         .stderr(predicate::str::contains(
-            "The argument '--yul' was provided more than once",
+            "the argument '--yul' cannot be used multiple times",
         ))
         .get_output()
         .status


### PR DESCRIPTION
# What ❔

Fixes https://github.com/matter-labs/era-compiler-solidity/issues/206

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
