### PR TITLE
fix(eravm): resets return data after calling CREATE

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@
 <!-- Check your PR fulfills the following items. -->
 <!-- For draft PRs check the boxes as you complete them. -->
 
-- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
+- [ ] PR title corresponds to the body of PR.
 - [ ] Tests for the changes have been added / updated.
 - [ ] Documentation comments have been added / updated.
 - [ ] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - Disassembler now only works with files with hexadecimal strings
 - Updated to Rust v1.82.0
 
+### Fixed
+
+- Cleared return data after calling `CREATE`/`CREATE2`
+
 ## [1.5.7] - 2024-10-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#47d3a2143a6b063af9eed5a801e9a4ae90bbc5da"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#5f88ca511f972dae2d67fb91598b9f9b434c1731"
 dependencies = [
  "anyhow",
  "era-compiler-common",


### PR DESCRIPTION
# What ❔

Cleares return data after calling `CREATE`/`CREATE2` (`ContractDeployer` system contract for EraVM).

## Why ❔

It is cleared on EVM, but not on EraVM.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
