### PR TITLE
feat: use the new API for factory deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#5f88ca511f972dae2d67fb91598b9f9b434c1731"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-link-factory-dependencies#f494f55196398c557d8ae69c32da2608f3acc6f8"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -1248,7 +1248,7 @@ dependencies = [
 [[package]]
 name = "inkwell"
 version = "0.4.0"
-source = "git+https://github.com/matter-labs-forks/inkwell?branch=llvm-17#2b02c986508b68a38f9eb0f46919d5d1a1b0bfc1"
+source = "git+https://github.com/matter-labs-forks/inkwell?branch=az-link-factory-dependencies#e10524377498be01a7c7138b272c1b700fdd9d0f"
 dependencies = [
  "either",
  "inkwell_internals",
@@ -1263,7 +1263,7 @@ dependencies = [
 [[package]]
 name = "inkwell_internals"
 version = "0.9.0"
-source = "git+https://github.com/matter-labs-forks/inkwell?branch=llvm-17#2b02c986508b68a38f9eb0f46919d5d1a1b0bfc1"
+source = "git+https://github.com/matter-labs-forks/inkwell?branch=az-link-factory-dependencies#e10524377498be01a7c7138b272c1b700fdd9d0f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1400,7 +1400,7 @@ checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 [[package]]
 name = "llvm-sys"
 version = "170.0.1"
-source = "git+https://github.com/matter-labs-forks/llvm-sys.rs?branch=llvm-17.0#b06c3d1989fa5d77e491e6aea709dd5c76621aff"
+source = "git+https://github.com/matter-labs-forks/llvm-sys.rs?branch=az-link-factory-dependencies#06e688f7aca46125bebce1bedc881e3a127ab65e"
 dependencies = [
  "anyhow",
  "cc",

--- a/era-compiler-solidity/Cargo.toml
+++ b/era-compiler-solidity/Cargo.toml
@@ -33,7 +33,7 @@ num = "=0.4.3"
 zkevm_opcode_defs = "=0.150.6"
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
+era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-link-factory-dependencies" }
 era-solc = { path = "../era-solc" }
 era-yul = { path = "../era-yul" }
 
@@ -47,7 +47,7 @@ era-compiler-downloader = { git = "https://github.com/matter-labs/era-compiler-c
 
 [dependencies.inkwell]
 git = "https://github.com/matter-labs-forks/inkwell"
-branch = "llvm-17"
+branch = "az-link-factory-dependencies"
 default-features = false
 features = ["llvm17-0", "no-libffi-linking", "target-eravm", "target-evm"]
 

--- a/era-compiler-solidity/src/build_eravm/contract.rs
+++ b/era-compiler-solidity/src/build_eravm/contract.rs
@@ -2,7 +2,6 @@
 //! The Solidity contract build.
 //!
 
-use std::collections::HashSet;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
@@ -20,8 +19,6 @@ pub struct Contract {
     pub build: era_compiler_llvm_context::EraVMBuild,
     /// The metadata JSON.
     pub metadata_json: serde_json::Value,
-    /// The factory dependencies.
-    pub factory_dependencies: HashSet<String>,
 }
 
 impl Contract {
@@ -33,14 +30,12 @@ impl Contract {
         identifier: String,
         build: era_compiler_llvm_context::EraVMBuild,
         metadata_json: serde_json::Value,
-        factory_dependencies: HashSet<String>,
     ) -> Self {
         Self {
             name,
             identifier,
             build,
             metadata_json,
-            factory_dependencies,
         }
     }
 
@@ -180,9 +175,6 @@ impl Contract {
             .assembly
             .map(serde_json::Value::String)
             .unwrap_or_default();
-        combined_json_contract
-            .factory_deps
-            .extend(self.build.factory_dependencies);
 
         Ok(())
     }
@@ -206,9 +198,6 @@ impl Contract {
             .evm
             .get_or_insert_with(era_solc::StandardJsonOutputContractEVM::default)
             .modify_eravm(bytecode, assembly);
-        standard_json_contract
-            .factory_dependencies
-            .extend(self.build.factory_dependencies);
         standard_json_contract.hash = self.build.bytecode_hash.map(hex::encode);
 
         Ok(())

--- a/era-compiler-solidity/src/evmla/assembly/instruction/jump.rs
+++ b/era-compiler-solidity/src/evmla/assembly/instruction/jump.rs
@@ -65,6 +65,7 @@ where
 
     let condition_pointer = context
         .evmla()
+        .expect("Always exists")
         .get_element(stack_height)
         .to_llvm()
         .into_pointer_value();

--- a/era-compiler-solidity/src/evmla/assembly/instruction/stack.rs
+++ b/era-compiler-solidity/src/evmla/assembly/instruction/stack.rs
@@ -56,7 +56,10 @@ pub fn dup<'ctx, C>(
 where
     C: era_compiler_llvm_context::IContext<'ctx>,
 {
-    let element = context.evmla().get_element(height - offset - 1);
+    let element = context
+        .evmla()
+        .expect("Always exists")
+        .get_element(height - offset - 1);
     let value = context.build_load(
         era_compiler_llvm_context::Pointer::new_stack_field(
             context,
@@ -77,14 +80,22 @@ pub fn swap<'ctx, C>(context: &mut C, offset: usize, height: usize) -> anyhow::R
 where
     C: era_compiler_llvm_context::IContext<'ctx>,
 {
-    let top_element = context.evmla().get_element(height - 1).to_owned();
+    let top_element = context
+        .evmla()
+        .expect("Always exists")
+        .get_element(height - 1)
+        .to_owned();
     let top_pointer = era_compiler_llvm_context::Pointer::new_stack_field(
         context,
         top_element.to_llvm().into_pointer_value(),
     );
     let top_value = context.build_load(top_pointer, format!("swap{offset}_top_value").as_str())?;
 
-    let swap_element = context.evmla().get_element(height - offset - 1).to_owned();
+    let swap_element = context
+        .evmla()
+        .expect("Always exists")
+        .get_element(height - offset - 1)
+        .to_owned();
     let swap_pointer = era_compiler_llvm_context::Pointer::new_stack_field(
         context,
         swap_element.to_llvm().into_pointer_value(),
@@ -95,11 +106,13 @@ where
     if let Some(original) = swap_element.original {
         context
             .evmla_mut()
+            .expect("Always exists")
             .set_original(height - 1, original.to_owned());
     }
     if let Some(original) = top_element.original {
         context
             .evmla_mut()
+            .expect("Always exists")
             .set_original(height - offset - 1, original.to_owned());
     }
 

--- a/era-compiler-solidity/src/evmla/assembly/mod.rs
+++ b/era-compiler-solidity/src/evmla/assembly/mod.rs
@@ -360,7 +360,7 @@ where
             debug_config.dump_evmla(full_path.as_str(), None, self.to_string().as_str())?;
         }
         let deploy_code_blocks = EtherealIR::get_blocks(
-            context.evmla().version.to_owned(),
+            context.evmla().expect("Always exists").version.to_owned(),
             era_compiler_common::CodeSegment::Deploy,
             self.code
                 .as_deref()
@@ -387,7 +387,7 @@ where
             }
         };
         let runtime_code_blocks = EtherealIR::get_blocks(
-            context.evmla().version.to_owned(),
+            context.evmla().expect("Always exists").version.to_owned(),
             era_compiler_common::CodeSegment::Runtime,
             runtime_code_instructions.as_slice(),
         )?;
@@ -395,7 +395,7 @@ where
         let mut blocks = deploy_code_blocks;
         blocks.extend(runtime_code_blocks);
         let mut ethereal_ir = EtherealIR::new(
-            context.evmla().version.to_owned(),
+            context.evmla().expect("Always exists").version.to_owned(),
             self.extra_metadata.unwrap_or_default(),
             None,
             blocks,
@@ -441,7 +441,7 @@ where
 
         let (code_segment, blocks) = if let Ok(runtime_code) = self.get_runtime_code() {
             let deploy_code_blocks = EtherealIR::get_blocks(
-                context.evmla().version.to_owned(),
+                context.evmla().expect("Always exists").version.to_owned(),
                 era_compiler_common::CodeSegment::Deploy,
                 self.code
                     .as_deref()
@@ -460,7 +460,7 @@ where
                 .as_ref()
                 .ok_or_else(|| anyhow::anyhow!("Runtime code instructions not found"))?;
             let runtime_code_blocks = EtherealIR::get_blocks(
-                context.evmla().version.to_owned(),
+                context.evmla().expect("Always exists").version.to_owned(),
                 era_compiler_common::CodeSegment::Runtime,
                 runtime_code_instructions.as_slice(),
             )?;
@@ -470,7 +470,7 @@ where
             (era_compiler_common::CodeSegment::Deploy, blocks)
         } else {
             let blocks = EtherealIR::get_blocks(
-                context.evmla().version.to_owned(),
+                context.evmla().expect("Always exists").version.to_owned(),
                 era_compiler_common::CodeSegment::Runtime,
                 self.code
                     .as_deref()
@@ -480,7 +480,7 @@ where
         };
 
         let mut ethereal_ir = EtherealIR::new(
-            context.evmla().version.to_owned(),
+            context.evmla().expect("Always exists").version.to_owned(),
             self.extra_metadata.unwrap_or_default(),
             Some(code_segment),
             blocks,

--- a/era-compiler-solidity/src/evmla/ethereal_ir/function/block/element/mod.rs
+++ b/era-compiler-solidity/src/evmla/ethereal_ir/function/block/element/mod.rs
@@ -57,11 +57,13 @@ impl Element {
     where
         D: era_compiler_llvm_context::Dependency,
     {
-        let input_size = self.instruction.input_size(&context.evmla().version);
+        let input_size = self
+            .instruction
+            .input_size(&context.evmla().expect("Always exists").version);
         let output_size = self.instruction.output_size();
         let mut arguments = Vec::with_capacity(input_size);
         for index in 0..input_size {
-            let pointer = context.evmla().stack
+            let pointer = context.evmla().expect("Always exists").stack
                 [self.stack.elements.len() + input_size - output_size - 1 - index]
                 .to_llvm()
                 .into_pointer_value();
@@ -86,11 +88,13 @@ impl Element {
     where
         D: era_compiler_llvm_context::Dependency,
     {
-        let input_size = self.instruction.input_size(&context.evmla().version);
+        let input_size = self
+            .instruction
+            .input_size(&context.evmla().expect("Always exists").version);
         let output_size = self.instruction.output_size();
         let mut arguments = Vec::with_capacity(input_size);
         for index in 0..input_size {
-            let pointer = context.evmla().stack
+            let pointer = context.evmla().expect("Always exists").stack
                 [self.stack.elements.len() + input_size - output_size - 1 - index]
                 .to_llvm()
                 .into_pointer_value();
@@ -801,6 +805,7 @@ where
 
                 let offset = context
                     .solidity_mut()
+                    .expect("Always exists")
                     .get_or_allocate_immutable(key.as_str());
 
                 let index = context.field_const(offset as u64);
@@ -814,7 +819,10 @@ where
                     .value
                     .ok_or_else(|| anyhow::anyhow!("Instruction value missing"))?;
 
-                let offset = context.solidity_mut().allocate_immutable(key.as_str());
+                let offset = context
+                    .solidity_mut()
+                    .expect("Always exists")
+                    .allocate_immutable(key.as_str());
 
                 let index = context.field_const(offset as u64);
                 let value = arguments.pop().expect("Always exists").into_int_value();
@@ -1301,7 +1309,7 @@ where
                 )?;
                 match result {
                     Some(value) if value.is_int_value() => {
-                        let pointer = context.evmla().stack
+                        let pointer = context.evmla().expect("Always exists").stack
                             [self.stack.elements.len() - output_size]
                             .to_llvm()
                             .into_pointer_value();
@@ -1324,7 +1332,7 @@ where
                             let pointer = era_compiler_llvm_context::Pointer::new(
                                 context.field_type(),
                                 era_compiler_llvm_context::EraVMAddressSpace::Stack,
-                                context.evmla().stack
+                                context.evmla().expect("Always exists").stack
                                     [self.stack.elements.len() - output_size + index]
                                     .to_llvm()
                                     .into_pointer_value(),
@@ -1382,14 +1390,16 @@ where
         }?;
 
         if let Some(result) = result {
-            let pointer = context.evmla().stack[self.stack.elements.len() - 1]
+            let pointer = context.evmla().expect("Always exists").stack
+                [self.stack.elements.len() - 1]
                 .to_llvm()
                 .into_pointer_value();
             context.build_store(
                 era_compiler_llvm_context::Pointer::new_stack_field(context, pointer),
                 result,
             )?;
-            context.evmla_mut().stack[self.stack.elements.len() - 1].original = original;
+            context.evmla_mut().expect("Always exists").stack[self.stack.elements.len() - 1]
+                .original = original;
         }
 
         Ok(())
@@ -2441,7 +2451,7 @@ where
                 )?;
                 match result {
                     Some(value) if value.is_int_value() => {
-                        let pointer = context.evmla().stack
+                        let pointer = context.evmla().expect("Always exists").stack
                             [self.stack.elements.len() - output_size]
                             .to_llvm()
                             .into_pointer_value();
@@ -2461,7 +2471,7 @@ where
                             let pointer = era_compiler_llvm_context::Pointer::new(
                                 context.field_type(),
                                 era_compiler_llvm_context::EVMAddressSpace::Stack,
-                                context.evmla().stack
+                                context.evmla().expect("Always exists").stack
                                     [self.stack.elements.len() - output_size + index]
                                     .to_llvm()
                                     .into_pointer_value(),
@@ -2519,14 +2529,16 @@ where
         }?;
 
         if let Some(result) = result {
-            let pointer = context.evmla().stack[self.stack.elements.len() - 1]
+            let pointer = context.evmla().expect("Always exists").stack
+                [self.stack.elements.len() - 1]
                 .to_llvm()
                 .into_pointer_value();
             context.build_store(
                 era_compiler_llvm_context::Pointer::new_stack_field(context, pointer),
                 result,
             )?;
-            context.evmla_mut().stack[self.stack.elements.len() - 1].original = original;
+            context.evmla_mut().expect("Always exists").stack[self.stack.elements.len() - 1]
+                .original = original;
         }
 
         Ok(())

--- a/era-compiler-solidity/src/evmla/ethereal_ir/function/mod.rs
+++ b/era-compiler-solidity/src/evmla/ethereal_ir/function/mod.rs
@@ -1262,7 +1262,7 @@ where
                 pointer.value.as_basic_value_enum(),
             ));
         }
-        context.evmla_mut().stack = stack_variables;
+        context.evmla_mut().expect("Always exists").stack = stack_variables;
 
         match self.r#type {
             Type::Initial => {
@@ -1439,7 +1439,7 @@ where
                 pointer.value.as_basic_value_enum(),
             ));
         }
-        context.evmla_mut().stack = stack_variables;
+        context.evmla_mut().expect("Always exists").stack = stack_variables;
 
         match self.r#type {
             Type::Initial => {

--- a/era-compiler-solidity/src/evmla/ethereal_ir/mod.rs
+++ b/era-compiler-solidity/src/evmla/ethereal_ir/mod.rs
@@ -119,7 +119,7 @@ where
         self,
         context: &mut era_compiler_llvm_context::EraVMContext<D>,
     ) -> anyhow::Result<()> {
-        context.evmla_mut().stack = vec![];
+        context.evmla_mut().expect("Always exists").stack = vec![];
 
         self.entry_function.into_llvm(context)?;
 
@@ -152,7 +152,7 @@ where
         self,
         context: &mut era_compiler_llvm_context::EVMContext<D>,
     ) -> anyhow::Result<()> {
-        context.evmla_mut().stack = vec![];
+        context.evmla_mut().expect("Always exists").stack = vec![];
 
         self.entry_function.into_llvm(context)?;
 

--- a/era-compiler-solidity/src/process/input_eravm/dependency_data.rs
+++ b/era-compiler-solidity/src/process/input_eravm/dependency_data.rs
@@ -36,21 +36,6 @@ impl DependencyData {
 }
 
 impl era_compiler_llvm_context::Dependency for DependencyData {
-    fn get(&self, identifier: &str) -> anyhow::Result<String> {
-        let path = self.resolve_path(identifier)?;
-        let contract = self
-            .dependencies
-            .get(path.as_str())
-            .cloned()
-            .ok_or_else(|| anyhow::anyhow!("dependency `{path}` not found in the project"))?;
-        match contract.build.bytecode_hash {
-            Some(bytecode_hash) => Ok(hex::encode(bytecode_hash)),
-            None => anyhow::bail!(
-                "dependency `{path}` has no bytecode hash, as it may require library linkage"
-            ),
-        }
-    }
-
     fn resolve_path(&self, identifier: &str) -> anyhow::Result<String> {
         self.identifier_paths
             .get(identifier.strip_suffix("_deployed").unwrap_or(identifier))

--- a/era-compiler-solidity/src/process/input_evm/dependency_data.rs
+++ b/era-compiler-solidity/src/process/input_evm/dependency_data.rs
@@ -4,8 +4,6 @@
 
 use std::collections::BTreeMap;
 
-use crate::build_evm::contract::Contract as EVMContractBuild;
-
 ///
 /// The EVM dependency data.
 ///
@@ -15,8 +13,6 @@ pub struct DependencyData {
     pub solc_version: Option<era_solc::Version>,
     /// The mapping of auxiliary identifiers, e.g. Yul object names, to full contract paths.
     pub identifier_paths: BTreeMap<String, String>,
-    /// The dependencies required by specific contract.
-    pub dependencies: BTreeMap<String, EVMContractBuild>,
 }
 
 impl DependencyData {
@@ -30,22 +26,11 @@ impl DependencyData {
         Self {
             solc_version,
             identifier_paths,
-            dependencies: BTreeMap::new(),
         }
     }
 }
 
 impl era_compiler_llvm_context::Dependency for DependencyData {
-    fn get(&self, identifier: &str) -> anyhow::Result<String> {
-        let path = self.resolve_path(identifier)?;
-        let _contract = self
-            .dependencies
-            .get(path.as_str())
-            .cloned()
-            .ok_or_else(|| anyhow::anyhow!("dependency `{path}` not found in the project"))?;
-        unimplemented!()
-    }
-
     fn resolve_path(&self, identifier: &str) -> anyhow::Result<String> {
         self.identifier_paths
             .get(identifier.strip_suffix("_deployed").unwrap_or(identifier))

--- a/era-compiler-solidity/src/project/thread_pool_evm.rs
+++ b/era-compiler-solidity/src/project/thread_pool_evm.rs
@@ -79,28 +79,13 @@ impl ThreadPool {
             })
             .collect();
 
-        'outer: for path in contracts_satisfied.into_iter() {
+        for path in contracts_satisfied.into_iter() {
             let contract = match self.contracts.write().expect("Sync").remove(path.as_str()) {
                 Some(contract) => contract,
                 None => continue,
             };
 
-            let mut dependencies = BTreeMap::new();
-            for dependency in contract.get_factory_dependencies().into_iter() {
-                let output = match self
-                    .results
-                    .read()
-                    .expect("Sync")
-                    .get(dependency)
-                    .expect("Always exists")
-                {
-                    Ok(contract) => contract.to_owned(),
-                    Err(_error) => continue 'outer,
-                };
-                dependencies.insert(dependency.to_owned(), output);
-            }
-
-            self.evaluate(path, contract, dependencies);
+            self.evaluate(path, contract);
         }
     }
 
@@ -120,15 +105,9 @@ impl ThreadPool {
     ///
     /// Afterwards, the evaluation loop is restarted to check if any other contracts' dependencies are now satisfied.
     ///
-    fn evaluate(
-        &self,
-        path: String,
-        contract: Contract,
-        dependencies: BTreeMap<String, EVMContractBuild>,
-    ) {
+    fn evaluate(&self, path: String, contract: Contract) {
         let mut input = self.input_template.to_owned();
         input.contract = Some(contract);
-        input.dependency_data.dependencies.extend(dependencies);
 
         let results = self.results.clone();
         let pool = self.to_owned();

--- a/era-compiler-solidity/src/yul/parser/statement/expression/function_call/mod.rs
+++ b/era-compiler-solidity/src/yul/parser/statement/expression/function_call/mod.rs
@@ -487,7 +487,8 @@ impl FunctionCall {
 
                 let offset = context
                     .solidity_mut()
-                    .get_or_allocate_immutable(key.as_str());
+                    .map(|data| data.get_or_allocate_immutable(key.as_str()))
+                    .unwrap_or_default();
 
                 let index = context.field_const(offset as u64);
 
@@ -503,7 +504,10 @@ impl FunctionCall {
                     return Ok(None);
                 }
 
-                let offset = context.solidity_mut().allocate_immutable(key.as_str());
+                let offset = context
+                    .solidity_mut()
+                    .map(|data| data.allocate_immutable(key.as_str()))
+                    .unwrap_or_default();
 
                 let index = context.field_const(offset as u64);
                 let value = arguments[2].value.into_int_value();

--- a/era-compiler-solidity/tests/unit/linker.rs
+++ b/era-compiler-solidity/tests/unit/linker.rs
@@ -136,7 +136,7 @@ fn library_not_passed_post_compile_time(
         false,
     );
     let memory_buffer_linked = memory_buffer
-        .link_module_eravm(&BTreeMap::new())
+        .link_module_eravm(&BTreeMap::new(), &BTreeMap::new())
         .expect("Link failure");
     assert!(
         memory_buffer_linked.is_elf_eravm(),
@@ -243,7 +243,7 @@ fn library_passed_post_compile_time(
         false,
     );
     let memory_buffer_linked = memory_buffer
-        .link_module_eravm(&linker_symbols)
+        .link_module_eravm(&linker_symbols, &BTreeMap::new())
         .expect("Link failure");
     assert!(
         !memory_buffer_linked.is_elf_eravm(),
@@ -303,10 +303,10 @@ fn library_passed_post_compile_time_second_call(
         false,
     );
     let memory_buffer_linked_empty = memory_buffer
-        .link_module_eravm(&BTreeMap::new())
+        .link_module_eravm(&BTreeMap::new(), &BTreeMap::new())
         .expect("Link failure");
     let memory_buffer_linked = memory_buffer_linked_empty
-        .link_module_eravm(&linker_symbols)
+        .link_module_eravm(&linker_symbols, &BTreeMap::new())
         .expect("Link failure");
     assert!(
         !memory_buffer_linked.is_elf_eravm(),
@@ -369,7 +369,7 @@ fn library_passed_post_compile_time_redundant_args(
         false,
     );
     let memory_buffer_linked = memory_buffer
-        .link_module_eravm(&linker_symbols)
+        .link_module_eravm(&linker_symbols, &BTreeMap::new())
         .expect("Link failure");
     assert!(
         !memory_buffer_linked.is_elf_eravm(),
@@ -429,10 +429,10 @@ fn library_passed_post_compile_time_non_elf(
         false,
     );
     let memory_buffer_linked = memory_buffer
-        .link_module_eravm(&libraries)
+        .link_module_eravm(&libraries, &BTreeMap::new())
         .expect("Link failure");
     let _memory_buffer_linked_non_elf = memory_buffer_linked
-        .link_module_eravm(&libraries)
+        .link_module_eravm(&libraries, &BTreeMap::new())
         .expect("Link failure");
 }
 
@@ -493,7 +493,7 @@ fn library_produce_equal_bytecode_in_both_cases(
             false,
         );
     let memory_buffer_linked_post_compile_time = memory_buffer_post_compile_time
-        .link_module_eravm(&linker_symbols)
+        .link_module_eravm(&linker_symbols, &BTreeMap::new())
         .expect("Link failure");
 
     assert!(


### PR DESCRIPTION
# What ❔

Adds the support for linking factory dependencies for EraVM.

## Why ❔

Contracts with unlinked libraries are not ready for deployment, and they cannot have the bytecode hash either.
It means that we need to link EraVM in two iterations: libraries first, factory dependencies later.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
