### PR TITLE
ci: remove pr-checks from docs to fix required checks

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -48,16 +48,3 @@ jobs:
           enable-tests: true
           deploy: ${{ github.event_name != 'pull_request' }}
           create-latest-symlink: true
-
-  # Special job that allows some of the jobs to be skipped or failed
-  # requiring others to be successful
-  pr-checks:
-    runs-on: ubuntu-latest
-    if: always()
-    needs:
-      - deploy-docs
-    steps:
-      - name: Decide on PR checks
-        uses: re-actors/alls-green@release/v1
-        with:
-          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
# What ❔

Remove pr-checks from docs.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To fix required checks for PRs containing docs and src changes.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
