### PR TITLE
fix(evm): supports EVMLA PUSHSIZE

### DIFF
--- a/era-compiler-solidity/src/evmla/ethereal_ir/function/block/element/mod.rs
+++ b/era-compiler-solidity/src/evmla/ethereal_ir/function/block/element/mod.rs
@@ -2124,7 +2124,11 @@ where
                 )?;
                 Ok(None)
             }
-            InstructionName::PUSHSIZE => Ok(Some(context.field_const(0).as_basic_value_enum())),
+            InstructionName::PUSHSIZE => {
+                let object_name = context.module().get_name().to_string_lossy().to_string();
+                era_compiler_llvm_context::evm_code::data_size(context, object_name.as_str())
+                    .map(Some)
+            }
             InstructionName::RETURNDATASIZE => {
                 era_compiler_llvm_context::evm_return_data::size(context).map(Some)
             }


### PR DESCRIPTION
The support for it was missing, leading to failures or constructors with args, including ERC20.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
