### PR TITLE
fix: remove the branch replacing call(0x04) with memcopy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Fixed
 
 - Cleared return data after calling `CREATE`/`CREATE2`
+- Calls to precompile `0x04` are not replaced with `memcopy` anymore
 - Standard JSON input parsing if `outputSelection` arrays are unset
 - Missing bytecode for files with multiple contracts in combined JSON mode
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#050e09791561286b1faf116eb5ee4cd6a010dd9a"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-identity-precompile-no-memcopy#3068d634773ec2074b9baf98be694d45782a17dc"
 dependencies = [
  "anyhow",
  "era-compiler-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-identity-precompile-no-memcopy#3068d634773ec2074b9baf98be694d45782a17dc"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#0902a3c9e777e1f3b22ad54c81f1a74f475a375c"
 dependencies = [
  "anyhow",
  "era-compiler-common",

--- a/era-compiler-solidity/Cargo.toml
+++ b/era-compiler-solidity/Cargo.toml
@@ -33,7 +33,7 @@ num = "=0.4.3"
 zkevm_opcode_defs = "=0.150.6"
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-identity-precompile-no-memcopy" }
+era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
 era-solc = { path = "../era-solc" }
 era-yul = { path = "../era-yul" }
 

--- a/era-compiler-solidity/Cargo.toml
+++ b/era-compiler-solidity/Cargo.toml
@@ -33,7 +33,7 @@ num = "=0.4.3"
 zkevm_opcode_defs = "=0.150.6"
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
+era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-identity-precompile-no-memcopy" }
 era-solc = { path = "../era-solc" }
 era-yul = { path = "../era-yul" }
 


### PR DESCRIPTION
Removes the branch replacing call(0x04) with memcopy.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
