### PR TITLE
fix: do not prune the evm object

### DIFF
--- a/era-solc/src/solc.rs
+++ b/era-solc/src/solc.rs
@@ -194,7 +194,7 @@ impl Compiler {
             suppressed_errors.as_slice(),
             suppressed_warnings.as_slice(),
         )?;
-        solc_output.remove_evm();
+        solc_output.remove_evm_artifacts();
 
         Ok(solc_output)
     }

--- a/era-solc/src/standard_json/output/mod.rs
+++ b/era-solc/src/standard_json/output/mod.rs
@@ -16,7 +16,6 @@ use crate::standard_json::input::settings::selection::file::flag::Flag as Select
 use crate::standard_json::input::settings::selection::Selection;
 use crate::standard_json::input::settings::warning_type::WarningType as StandardJsonInputSettingsWarningType;
 use crate::standard_json::input::source::Source as StandardJSONInputSource;
-use crate::standard_json::output::contract::evm::EVM as StandardJSONOutputContractEVM;
 use crate::version::Version;
 
 use self::contract::Contract;
@@ -127,14 +126,6 @@ impl Output {
                 }
                 evm.extra_metadata = None;
             }
-            if contract
-                .evm
-                .as_ref()
-                .map(StandardJSONOutputContractEVM::is_empty)
-                .unwrap_or_default()
-            {
-                contract.evm = None;
-            }
         }
 
         self.contracts.retain(|_, contracts| {
@@ -149,7 +140,7 @@ impl Output {
     ///
     /// Removes EVM artifacts to prevent their accidental usage.
     ///
-    pub fn remove_evm(&mut self) {
+    pub fn remove_evm_artifacts(&mut self) {
         for (_, file) in self.contracts.iter_mut() {
             for (_, contract) in file.iter_mut() {
                 if let Some(evm) = contract.evm.as_mut() {


### PR DESCRIPTION
# What ❔

Do not prune the `evm` object from standard JSON output.

## Why ❔

It is required for upgradable Hardhat plugin.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
