### PR TITLE
feat: add warnings for codegen in standard JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - JSON interface for the EraVM linker
 - Missing libraries output in standard JSON mode
 - Transient storage layout to combined JSON output
+- A warning about `forceEVMLA` and `codegen` options in standard JSON mode
 
 ### Changed
 

--- a/era-compiler-solidity/tests/cli/codegen.rs
+++ b/era-compiler-solidity/tests/cli/codegen.rs
@@ -149,3 +149,21 @@ fn with_codegen_invalid(target: Target) -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test_case(Target::EraVM)]
+#[test_case(Target::EVM)]
+fn standard_json_missing(target: Target) -> anyhow::Result<()> {
+    common::setup()?;
+
+    let args = &[
+        "--standard-json",
+        common::TEST_SOLIDITY_STANDARD_JSON_ZKSOLC_FORCE_EVMLA,
+    ];
+
+    let result = cli::execute_zksolc_with_target(args, target)?;
+    result.success().stdout(predicate::str::contains(
+        "The `codegen` setting will become mandatory in future versions of zksolc. Please set it to either `evmla` or `yul`.",
+    ));
+
+    Ok(())
+}

--- a/era-compiler-solidity/tests/cli/force_evmla.rs
+++ b/era-compiler-solidity/tests/cli/force_evmla.rs
@@ -100,3 +100,21 @@ fn with_force_evmla_standard_json_mode(target: Target) -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test_case(Target::EraVM)]
+#[test_case(Target::EVM)]
+fn standard_json_deprecated(target: Target) -> anyhow::Result<()> {
+    common::setup()?;
+
+    let args = &[
+        "--standard-json",
+        common::TEST_SOLIDITY_STANDARD_JSON_ZKSOLC_FORCE_EVMLA,
+    ];
+
+    let result = cli::execute_zksolc_with_target(args, target)?;
+    result.success().stdout(predicate::str::contains(
+        "The `forceEVMLA` setting is deprecated. Please use `codegen: 'evmla'` instead.",
+    ));
+
+    Ok(())
+}

--- a/era-compiler-solidity/tests/common/const.rs
+++ b/era-compiler-solidity/tests/common/const.rs
@@ -122,6 +122,10 @@ pub const TEST_SOLIDITY_STANDARD_JSON_ZKSOLC_INVALID_PATH: &str =
     "tests/data/standard_json_input/solidity_zksolc_invalid.json";
 
 /// A test input file.
+pub const TEST_SOLIDITY_STANDARD_JSON_ZKSOLC_FORCE_EVMLA: &str =
+    "tests/data/standard_json_input/solidity_zksolc_force_evmla.json";
+
+/// A test input file.
 pub const TEST_YUL_STANDARD_JSON_SOLC_PATH: &str = "tests/data/standard_json_input/yul_solc.json";
 
 /// A test input file.

--- a/era-compiler-solidity/tests/data/standard_json_input/solidity_zksolc_force_evmla.json
+++ b/era-compiler-solidity/tests/data/standard_json_input/solidity_zksolc_force_evmla.json
@@ -1,0 +1,31 @@
+{
+  "language": "Solidity",
+  "sources":
+  {
+    "Test":
+    {
+      "urls": [
+        "tests/data/contracts/solidity/Test.sol"
+      ]
+    }
+  },
+  "settings": {
+    "optimizer": {
+      "mode": "3",
+      "fallbackToOptimizingForSize": true
+    },
+    "outputSelection": {
+      "*": {
+        "": [
+          "metadata"
+        ],
+        "*": [
+          "abi",
+          "evm.methodIdentifiers"
+        ]
+      }
+    },
+    "libraries": {},
+    "forceEVMLA": true
+  }
+}

--- a/era-solc/src/solc.rs
+++ b/era-solc/src/solc.rs
@@ -180,6 +180,22 @@ impl Compiler {
                 None,
             ));
         }
+        if input.settings.force_evmla {
+            solc_output
+                .errors
+                .push(StandardJsonOutputError::new_warning(
+                r#"The `forceEVMLA` setting is deprecated. Please use `codegen: 'evmla'` instead."#,
+                None,
+                None,
+            ));
+        }
+        if input.settings.codegen.is_none() {
+            solc_output.errors.push(StandardJsonOutputError::new_warning(
+                "The `codegen` setting will become mandatory in future versions of zksolc. Please set it to either `evmla` or `yul`.",
+                None,
+                None,
+            ));
+        }
 
         let mut suppressed_errors = input.suppressed_errors.clone();
         suppressed_errors.extend_from_slice(input.settings.suppressed_errors.as_slice());


### PR DESCRIPTION
Adds warnings for `forceEVMLA` and `codegen` in standard JSON.
The former is deprecated, whereas the latter will be made mandatory in future versions.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
