### PR TITLE
chore: remove redundant comment

### DIFF
--- a/era-compiler-solidity/build.rs
+++ b/era-compiler-solidity/build.rs
@@ -3,8 +3,6 @@
 //!
 
 ///
-/// The default build script for `zksolc`.
-///
-/// Is required for `rust-link-lib` flags to work.
+/// Required for `rust-link-lib` flags to work.
 ///
 fn main() {}


### PR DESCRIPTION
Right above this comment, in the comment at the header of the file, the sentence is repeated, so their is no need for it to exist twice.