### PR TITLE
fix: prohibited the use of CREATE[2] in assembly blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Changed
 
 - `solc` is not called anymore if its data is not needed in combined JSON mode
+- Prohibited the use of `create`/`create2` in assembly blocks
 
 ### Fixed
 

--- a/docs/src/03-standard-json.md
+++ b/docs/src/03-standard-json.md
@@ -166,9 +166,10 @@ Internally, *zksolc* extracts all *zksolc*-specific options and converts the inp
       "-disable-early-taildup"
     ],
     // Optional, zksolc: suppressed errors.
-    // Available options: "sendtransfer".
+    // Available options: "sendtransfer", "assemblycreate".
     "suppressedErrors": [
-      "sendtransfer"
+      "sendtransfer",
+      "assemblycreate"
     ],
     // Optional, zksolc: suppressed warnings.
     // Available options: "txorigin".

--- a/docs/src/04-combined-json.md
+++ b/docs/src/04-combined-json.md
@@ -29,16 +29,14 @@ The following selectors are supported:
 | **bin**                       | Deploy ytecode (always enabled)             | Hexadecimal string        | **zksolc** |
 | **bin-runtime**               | Runtime bytecode (EVM-only, always enabled) | Hexadecimal string        | **zksolc** |
 
-<div class="warning">
-It is only possible to use Combined JSON with Solidity input, so the path to <b>solc</b> must be always provided to *zksolc*.
-Support for other languages is planned for future releases.
-</div>
+> **Warning:** It is only possible to use Combined JSON with Solidity input, so the path to **solc** must be always provided to **zksolc**. Support for other languages is planned for future releases.
 
 
 
 ## Output Format
 
 The format below is a modification of the original combined JSON [output](https://docs.soliditylang.org/en/latest/using-the-compiler.html#output-description) format implemented by *solc*. It means that there are:
+
 - *zksolc*-specific options that are not present in the original format: they are marked as *zksolc* in the specification below.
 - *solc*-specific options that are not supported by *zksolc*: they are not mentioned in the specification below.
 

--- a/era-compiler-solidity/tests/cli/eravm/suppress_errors.rs
+++ b/era-compiler-solidity/tests/cli/eravm/suppress_errors.rs
@@ -2,13 +2,16 @@
 //! CLI tests for the eponymous option.
 //!
 
+use era_solc::StandardJsonInputErrorType;
 use predicates::prelude::*;
+use test_case::test_case;
 
-#[test]
-fn default() -> anyhow::Result<()> {
+#[test_case(StandardJsonInputErrorType::SendTransfer)]
+#[test_case(StandardJsonInputErrorType::AssemblyCreate)]
+fn default(error_type: StandardJsonInputErrorType) -> anyhow::Result<()> {
     crate::common::setup()?;
 
-    let error_type = era_solc::StandardJsonInputErrorType::SendTransfer.to_string();
+    let error_type = error_type.to_string();
     let args = &[
         "--bin",
         crate::common::TEST_SOLIDITY_CONTRACT_PATH,

--- a/era-compiler-solidity/tests/unit/messages.rs
+++ b/era-compiler-solidity/tests/unit/messages.rs
@@ -22,7 +22,7 @@ contract SendExample {
 }
 "#;
 
-pub const SEND_TEST_SOURCE: &str = r#"
+pub const SEND_TEST_SOURCE_08: &str = r#"
 contract SendExample {
     function s() public payable returns (bool) {
         address r = address(0);
@@ -54,12 +54,12 @@ contract SendExample {
 #[test_case(
     era_solc::Compiler::LAST_SUPPORTED_VERSION,
     era_solc::StandardJsonInputCodegen::EVMLA,
-    SEND_TEST_SOURCE
+    SEND_TEST_SOURCE_08
 )]
 #[test_case(
     era_solc::Compiler::LAST_SUPPORTED_VERSION,
     era_solc::StandardJsonInputCodegen::Yul,
-    SEND_TEST_SOURCE
+    SEND_TEST_SOURCE_08
 )]
 fn send(version: semver::Version, codegen: era_solc::StandardJsonInputCodegen, source_code: &str) {
     if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
@@ -101,12 +101,12 @@ fn send(version: semver::Version, codegen: era_solc::StandardJsonInputCodegen, s
 #[test_case(
     era_solc::Compiler::LAST_SUPPORTED_VERSION,
     era_solc::StandardJsonInputCodegen::EVMLA,
-    SEND_TEST_SOURCE
+    SEND_TEST_SOURCE_08
 )]
 #[test_case(
     era_solc::Compiler::LAST_SUPPORTED_VERSION,
     era_solc::StandardJsonInputCodegen::Yul,
-    SEND_TEST_SOURCE
+    SEND_TEST_SOURCE_08
 )]
 fn send_suppressed(
     version: semver::Version,
@@ -147,7 +147,7 @@ contract TransferExample {
 }
 "#;
 
-pub const TRANSFER_TEST_SOURCE: &str = r#"
+pub const TRANSFER_TEST_SOURCE_08: &str = r#"
 contract TransferExample {
     function s() public payable {
         address r = address(0);
@@ -179,12 +179,12 @@ contract TransferExample {
 #[test_case(
     era_solc::Compiler::LAST_SUPPORTED_VERSION,
     era_solc::StandardJsonInputCodegen::EVMLA,
-    TRANSFER_TEST_SOURCE
+    TRANSFER_TEST_SOURCE_08
 )]
 #[test_case(
     era_solc::Compiler::LAST_SUPPORTED_VERSION,
     era_solc::StandardJsonInputCodegen::Yul,
-    TRANSFER_TEST_SOURCE
+    TRANSFER_TEST_SOURCE_08
 )]
 fn transfer(
     version: semver::Version,
@@ -230,12 +230,12 @@ fn transfer(
 #[test_case(
     era_solc::Compiler::LAST_SUPPORTED_VERSION,
     era_solc::StandardJsonInputCodegen::EVMLA,
-    TRANSFER_TEST_SOURCE
+    TRANSFER_TEST_SOURCE_08
 )]
 #[test_case(
     era_solc::Compiler::LAST_SUPPORTED_VERSION,
     era_solc::StandardJsonInputCodegen::Yul,
-    TRANSFER_TEST_SOURCE
+    TRANSFER_TEST_SOURCE_08
 )]
 fn transfer_suppressed(
     version: semver::Version,
@@ -258,7 +258,303 @@ fn transfer_suppressed(
     .expect("Test failure"));
 }
 
-pub const RUNTIME_CODE_SOURCE_CODE: &str = r#"
+pub const ASSEMBLY_CREATE_SOURCE_04: &str = r#"
+// SPDX-License-Identifier: Unlicensed
+
+pragma solidity >=0.4.12;
+
+contract AssemblyCreate {
+    function main(bytes) external {
+        assembly {
+            let size := calldataload(0x04)
+            calldatacopy(0, 0x24, size)
+            let result := create(0, 0, size)
+        }
+    }
+}
+"#;
+
+pub const ASSEMBLY_CREATE2_SOURCE_04: &str = r#"
+// SPDX-License-Identifier: Unlicensed
+
+pragma solidity >=0.4.12;
+
+contract AssemblyCreate {
+    function main(bytes, uint salt) external {
+        assembly {
+            let size := calldataload(0x04)
+            calldatacopy(0, 0x24, size)
+            let result := create2(0, 0, size, salt)
+        }
+    }
+}
+"#;
+
+pub const ASSEMBLY_CREATE_SOURCE_05_06: &str = r#"
+// SPDX-License-Identifier: Unlicensed
+
+pragma solidity >=0.5.0;
+
+contract AssemblyCreate {
+    function main(bytes calldata) external {
+        assembly {
+            let size := calldataload(0x04)
+            calldatacopy(0, 0x24, size)
+            let result := create(0, 0, size)
+        }
+    }
+}
+"#;
+
+pub const ASSEMBLY_CREATE2_SOURCE_05_06: &str = r#"
+// SPDX-License-Identifier: Unlicensed
+
+pragma solidity >=0.5.0;
+
+contract AssemblyCreate {
+    function main(bytes calldata, uint salt) external {
+        assembly {
+            let size := calldataload(0x04)
+            calldatacopy(0, 0x24, size)
+            let result := create2(0, 0, size, salt)
+        }
+    }
+}
+"#;
+
+pub const ASSEMBLY_CREATE_SOURCE_07_08: &str = r#"
+// SPDX-License-Identifier: Unlicensed
+
+pragma solidity >=0.7.0;
+
+contract AssemblyCreate {
+    function main(bytes calldata input) external {
+        assembly {
+            let result := create(0, add(input.offset, 0x20), input.length)
+        }
+    }
+}
+"#;
+
+pub const ASSEMBLY_CREATE2_SOURCE_07_08: &str = r#"
+// SPDX-License-Identifier: Unlicensed
+
+pragma solidity >=0.7.0;
+
+contract AssemblyCreate {
+    function main(bytes calldata input, uint salt) external {
+        assembly {
+            let result := create2(0, add(input.offset, 0x20), input.length, salt)
+        }
+    }
+}
+"#;
+
+#[test_case(
+    semver::Version::new(0, 4, 26),
+    era_solc::StandardJsonInputCodegen::EVMLA,
+    ASSEMBLY_CREATE_SOURCE_04
+)]
+#[test_case(
+    semver::Version::new(0, 5, 17),
+    era_solc::StandardJsonInputCodegen::EVMLA,
+    ASSEMBLY_CREATE_SOURCE_05_06
+)]
+#[test_case(
+    semver::Version::new(0, 6, 12),
+    era_solc::StandardJsonInputCodegen::EVMLA,
+    ASSEMBLY_CREATE_SOURCE_05_06
+)]
+#[test_case(
+    semver::Version::new(0, 7, 6),
+    era_solc::StandardJsonInputCodegen::EVMLA,
+    ASSEMBLY_CREATE_SOURCE_07_08
+)]
+#[test_case(
+    era_solc::Compiler::LAST_SUPPORTED_VERSION,
+    era_solc::StandardJsonInputCodegen::EVMLA,
+    ASSEMBLY_CREATE_SOURCE_07_08
+)]
+#[test_case(
+    era_solc::Compiler::LAST_SUPPORTED_VERSION,
+    era_solc::StandardJsonInputCodegen::Yul,
+    ASSEMBLY_CREATE_SOURCE_07_08
+)]
+fn assembly_create(
+    version: semver::Version,
+    codegen: era_solc::StandardJsonInputCodegen,
+    source_code: &str,
+) {
+    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
+        return;
+    }
+
+    assert!(crate::common::check_solidity_message(
+        source_code,
+        "You are using 'create'/'create2' in an assembly block",
+        era_solc::StandardJsonInputLibraries::default(),
+        &version,
+        codegen,
+        vec![],
+        vec![],
+    )
+    .expect("Test failure"));
+}
+
+#[test_case(
+    semver::Version::new(0, 4, 26),
+    era_solc::StandardJsonInputCodegen::EVMLA,
+    ASSEMBLY_CREATE2_SOURCE_04
+)]
+#[test_case(
+    semver::Version::new(0, 5, 17),
+    era_solc::StandardJsonInputCodegen::EVMLA,
+    ASSEMBLY_CREATE2_SOURCE_05_06
+)]
+#[test_case(
+    semver::Version::new(0, 6, 12),
+    era_solc::StandardJsonInputCodegen::EVMLA,
+    ASSEMBLY_CREATE2_SOURCE_05_06
+)]
+#[test_case(
+    semver::Version::new(0, 7, 6),
+    era_solc::StandardJsonInputCodegen::EVMLA,
+    ASSEMBLY_CREATE2_SOURCE_07_08
+)]
+#[test_case(
+    era_solc::Compiler::LAST_SUPPORTED_VERSION,
+    era_solc::StandardJsonInputCodegen::EVMLA,
+    ASSEMBLY_CREATE2_SOURCE_07_08
+)]
+#[test_case(
+    era_solc::Compiler::LAST_SUPPORTED_VERSION,
+    era_solc::StandardJsonInputCodegen::Yul,
+    ASSEMBLY_CREATE2_SOURCE_07_08
+)]
+fn assembly_create2(
+    version: semver::Version,
+    codegen: era_solc::StandardJsonInputCodegen,
+    source_code: &str,
+) {
+    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
+        return;
+    }
+
+    assert!(crate::common::check_solidity_message(
+        source_code,
+        "You are using 'create'/'create2' in an assembly block",
+        era_solc::StandardJsonInputLibraries::default(),
+        &version,
+        codegen,
+        vec![],
+        vec![],
+    )
+    .expect("Test failure"));
+}
+
+#[test_case(
+    semver::Version::new(0, 4, 26),
+    era_solc::StandardJsonInputCodegen::EVMLA,
+    ASSEMBLY_CREATE_SOURCE_04
+)]
+#[test_case(
+    semver::Version::new(0, 5, 17),
+    era_solc::StandardJsonInputCodegen::EVMLA,
+    ASSEMBLY_CREATE_SOURCE_05_06
+)]
+#[test_case(
+    semver::Version::new(0, 6, 12),
+    era_solc::StandardJsonInputCodegen::EVMLA,
+    ASSEMBLY_CREATE_SOURCE_05_06
+)]
+#[test_case(
+    semver::Version::new(0, 7, 6),
+    era_solc::StandardJsonInputCodegen::EVMLA,
+    ASSEMBLY_CREATE_SOURCE_07_08
+)]
+#[test_case(
+    era_solc::Compiler::LAST_SUPPORTED_VERSION,
+    era_solc::StandardJsonInputCodegen::EVMLA,
+    ASSEMBLY_CREATE_SOURCE_07_08
+)]
+#[test_case(
+    era_solc::Compiler::LAST_SUPPORTED_VERSION,
+    era_solc::StandardJsonInputCodegen::Yul,
+    ASSEMBLY_CREATE_SOURCE_07_08
+)]
+fn assembly_create_suppressed(
+    version: semver::Version,
+    codegen: era_solc::StandardJsonInputCodegen,
+    source_code: &str,
+) {
+    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
+        return;
+    }
+
+    assert!(!crate::common::check_solidity_message(
+        source_code,
+        "You are using 'create'/'create2' in an assembly block",
+        era_solc::StandardJsonInputLibraries::default(),
+        &version,
+        codegen,
+        vec![era_solc::StandardJsonInputErrorType::AssemblyCreate],
+        vec![],
+    )
+    .expect("Test failure"));
+}
+
+#[test_case(
+    semver::Version::new(0, 4, 26),
+    era_solc::StandardJsonInputCodegen::EVMLA,
+    ASSEMBLY_CREATE2_SOURCE_04
+)]
+#[test_case(
+    semver::Version::new(0, 5, 17),
+    era_solc::StandardJsonInputCodegen::EVMLA,
+    ASSEMBLY_CREATE2_SOURCE_05_06
+)]
+#[test_case(
+    semver::Version::new(0, 6, 12),
+    era_solc::StandardJsonInputCodegen::EVMLA,
+    ASSEMBLY_CREATE2_SOURCE_05_06
+)]
+#[test_case(
+    semver::Version::new(0, 7, 6),
+    era_solc::StandardJsonInputCodegen::EVMLA,
+    ASSEMBLY_CREATE2_SOURCE_07_08
+)]
+#[test_case(
+    era_solc::Compiler::LAST_SUPPORTED_VERSION,
+    era_solc::StandardJsonInputCodegen::EVMLA,
+    ASSEMBLY_CREATE2_SOURCE_07_08
+)]
+#[test_case(
+    era_solc::Compiler::LAST_SUPPORTED_VERSION,
+    era_solc::StandardJsonInputCodegen::Yul,
+    ASSEMBLY_CREATE2_SOURCE_07_08
+)]
+fn assembly_create2_suppressed(
+    version: semver::Version,
+    codegen: era_solc::StandardJsonInputCodegen,
+    source_code: &str,
+) {
+    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
+        return;
+    }
+
+    assert!(!crate::common::check_solidity_message(
+        source_code,
+        "You are using 'create'/'create2' in an assembly block",
+        era_solc::StandardJsonInputLibraries::default(),
+        &version,
+        codegen,
+        vec![era_solc::StandardJsonInputErrorType::AssemblyCreate],
+        vec![],
+    )
+    .expect("Test failure"));
+}
+
+pub const RUNTIME_CODE_SOURCE: &str = r#"
 // SPDX-License-Identifier: Unlicensed
 
 pragma solidity >=0.5.3;
@@ -298,8 +594,8 @@ fn runtime_code(version: semver::Version, codegen: era_solc::StandardJsonInputCo
     }
 
     assert!(crate::common::check_solidity_message(
-        RUNTIME_CODE_SOURCE_CODE,
-        "Deploy and runtime code are merged together on ZKsync",
+        RUNTIME_CODE_SOURCE,
+        "Deploy and runtime code are merged in EraVM",
         era_solc::StandardJsonInputLibraries::default(),
         &version,
         codegen,

--- a/era-solc/src/standard_json/input/settings/error_type.rs
+++ b/era-solc/src/standard_json/input/settings/error_type.rs
@@ -12,6 +12,8 @@ use std::str::FromStr;
 pub enum ErrorType {
     /// The eponymous feature.
     SendTransfer,
+    /// The eponymous feature.
+    AssemblyCreate,
 }
 
 impl ErrorType {
@@ -32,6 +34,7 @@ impl FromStr for ErrorType {
     fn from_str(string: &str) -> Result<Self, Self::Err> {
         match string {
             "sendtransfer" => Ok(Self::SendTransfer),
+            "assemblycreate" => Ok(Self::AssemblyCreate),
             r#type => Err(anyhow::anyhow!("Invalid suppressed error type: {type}")),
         }
     }
@@ -41,6 +44,7 @@ impl std::fmt::Display for ErrorType {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Self::SendTransfer => write!(f, "sendtransfer"),
+            Self::AssemblyCreate => write!(f, "assemblycreate"),
         }
     }
 }


### PR DESCRIPTION
# What ❔

Prohibits the use of CREATE[2] in assembly blocks.
Fixes https://github.com/matter-labs/era-compiler-solidity/issues/239 to some extent.

## Why ❔

It does not work with bytecode, and silently produces invalid bytecode.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
