### PR TITLE
chore: bump serde json dep

### DIFF
--- a/era-compiler-solidity/Cargo.toml
+++ b/era-compiler-solidity/Cargo.toml
@@ -25,7 +25,7 @@ rusty_pool = { version = "=0.7.0", default-features = false }
 num_cpus = "=1.16.0"
 
 serde = { version = "=1.0.210", "features" = [ "derive" ] }
-serde_json = { version = "=1.0.128", features = [ "arbitrary_precision" ] }
+serde_json = { version = "=1.0.133", features = [ "arbitrary_precision" ] }
 semver = { version = "=1.0.23", features = [ "serde" ] }
 hex = "=0.4.3"
 num = "=0.4.3"

--- a/era-solc/Cargo.toml
+++ b/era-solc/Cargo.toml
@@ -16,7 +16,7 @@ which = "=6.0.3"
 rayon = "=1.10.0"
 
 serde = { version = "=1.0.210", "features" = [ "derive" ] }
-serde_json = { version = "=1.0.128", features = [ "arbitrary_precision" ] }
+serde_json = { version = "=1.0.133", features = [ "arbitrary_precision" ] }
 semver = { version = "=1.0.23", features = [ "serde" ] }
 hex = "=0.4.3"
 num = "=0.4.3"


### PR DESCRIPTION
# What ❔

- Bumps `serde_json` so https://github.com/matter-labs/era-compiler-solidity may be used as dependency in `foundry-zksync`
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

- `foundry-zksync` uses 1.0.133
<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR.
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
