### PR TITLE
fix: change the assembly-CREATE error to a warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # The `zksolc` changelog
 
+## [1.5.10] - 2025-01-17
+
+### Changed
+
+- The error about using `create`/`create2` in assembly is made a warning
+
 ## [1.5.9] - 2025-01-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "era-compiler-solidity"
-version = "1.5.9"
+version = "1.5.10"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "era-solc"
-version = "1.5.9"
+version = "1.5.10"
 dependencies = [
  "anyhow",
  "boolinator",
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "era-yul"
-version = "1.5.9"
+version = "1.5.10"
 dependencies = [
  "anyhow",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ authors = [
 ]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-version = "1.5.9"
+version = "1.5.10"

--- a/docs/src/02-command-line-interface.md
+++ b/docs/src/02-command-line-interface.md
@@ -158,7 +158,7 @@ zksolc './Simple.sol' --asm --bin
 
 Enables the output of contract metadata. The metadata is a JSON object that contains information about the contract, such as its name, source code hash, the list of dependencies, compiler versions, and so on.
 
-The *zksolc* metadata format is compatible with the [Solidity metadata format](https://soliditylang.org/docs/develop/metadata.html). This means that the metadata output can be used with other tools that support Solidity metadata. Essentially, *solc* metadata is a part of *zksolc* metadata, and it is included as `source_metadata` without any modifications.
+The *zksolc* metadata format is compatible with the [Solidity metadata format](https://docs.soliditylang.org/en/latest/metadata.html#contract-metadata). This means that the metadata output can be used with other tools that support Solidity metadata. Essentially, *solc* metadata is a part of *zksolc* metadata, and it is included as `source_metadata` without any modifications.
 
 Usage:
 

--- a/era-compiler-solidity/tests/cli/eravm/suppress_errors.rs
+++ b/era-compiler-solidity/tests/cli/eravm/suppress_errors.rs
@@ -7,7 +7,6 @@ use predicates::prelude::*;
 use test_case::test_case;
 
 #[test_case(StandardJsonInputErrorType::SendTransfer)]
-#[test_case(StandardJsonInputErrorType::AssemblyCreate)]
 fn default(error_type: StandardJsonInputErrorType) -> anyhow::Result<()> {
     crate::common::setup()?;
 

--- a/era-compiler-solidity/tests/cli/eravm/suppress_warnings.rs
+++ b/era-compiler-solidity/tests/cli/eravm/suppress_warnings.rs
@@ -2,13 +2,16 @@
 //! CLI tests for the eponymous option.
 //!
 
+use era_solc::StandardJsonInputWarningType;
 use predicates::prelude::*;
+use test_case::test_case;
 
-#[test]
-fn default() -> anyhow::Result<()> {
+#[test_case(StandardJsonInputWarningType::TxOrigin)]
+#[test_case(StandardJsonInputWarningType::AssemblyCreate)]
+fn default(warning_type: StandardJsonInputWarningType) -> anyhow::Result<()> {
     crate::common::setup()?;
 
-    let warning_type = era_solc::StandardJsonInputWarningType::TxOrigin.to_string();
+    let warning_type = warning_type.to_string();
     let args = &[
         "--bin",
         crate::common::TEST_SOLIDITY_CONTRACT_PATH,

--- a/era-compiler-solidity/tests/unit/messages.rs
+++ b/era-compiler-solidity/tests/unit/messages.rs
@@ -497,8 +497,8 @@ fn assembly_create_suppressed(
         era_solc::StandardJsonInputLibraries::default(),
         &version,
         codegen,
-        vec![era_solc::StandardJsonInputErrorType::AssemblyCreate],
         vec![],
+        vec![era_solc::StandardJsonInputWarningType::AssemblyCreate],
     )
     .expect("Test failure"));
 }
@@ -548,8 +548,8 @@ fn assembly_create2_suppressed(
         era_solc::StandardJsonInputLibraries::default(),
         &version,
         codegen,
-        vec![era_solc::StandardJsonInputErrorType::AssemblyCreate],
         vec![],
+        vec![era_solc::StandardJsonInputWarningType::AssemblyCreate],
     )
     .expect("Test failure"));
 }

--- a/era-solc/src/standard_json/input/settings/error_type.rs
+++ b/era-solc/src/standard_json/input/settings/error_type.rs
@@ -12,8 +12,6 @@ use std::str::FromStr;
 pub enum ErrorType {
     /// The eponymous feature.
     SendTransfer,
-    /// The eponymous feature.
-    AssemblyCreate,
 }
 
 impl ErrorType {
@@ -34,7 +32,6 @@ impl FromStr for ErrorType {
     fn from_str(string: &str) -> Result<Self, Self::Err> {
         match string {
             "sendtransfer" => Ok(Self::SendTransfer),
-            "assemblycreate" => Ok(Self::AssemblyCreate),
             r#type => Err(anyhow::anyhow!("Invalid suppressed error type: {type}")),
         }
     }
@@ -44,7 +41,6 @@ impl std::fmt::Display for ErrorType {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Self::SendTransfer => write!(f, "sendtransfer"),
-            Self::AssemblyCreate => write!(f, "assemblycreate"),
         }
     }
 }

--- a/era-solc/src/standard_json/input/settings/warning_type.rs
+++ b/era-solc/src/standard_json/input/settings/warning_type.rs
@@ -12,6 +12,8 @@ use std::str::FromStr;
 pub enum WarningType {
     /// The eponymous feature.
     TxOrigin,
+    /// The eponymous feature.
+    AssemblyCreate,
 }
 
 impl WarningType {
@@ -32,6 +34,7 @@ impl FromStr for WarningType {
     fn from_str(string: &str) -> Result<Self, Self::Err> {
         match string {
             "txorigin" => Ok(Self::TxOrigin),
+            "assemblycreate" => Ok(Self::AssemblyCreate),
             r#type => Err(anyhow::anyhow!("Invalid suppressed warning type: {type}")),
         }
     }
@@ -41,6 +44,7 @@ impl std::fmt::Display for WarningType {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Self::TxOrigin => write!(f, "txorigin"),
+            Self::AssemblyCreate => write!(f, "assemblycreate"),
         }
     }
 }

--- a/era-solc/src/standard_json/output/error/mod.rs
+++ b/era-solc/src/standard_json/output/error/mod.rs
@@ -171,9 +171,9 @@ You may disable this error with:
     }
 
     ///
-    /// Returns the `create` and `create2` in assembly blocks usage error.
+    /// Returns the `create` and `create2` in assembly blocks usage warning.
     ///
-    pub fn error_assembly_create(
+    pub fn warning_assembly_create(
         node: Option<&str>,
         id_paths: &BTreeMap<usize, &String>,
         sources: &BTreeMap<String, StandardJsonInputSource>,
@@ -182,15 +182,15 @@ You may disable this error with:
 You are using 'create'/'create2' in an assembly block, probably by providing bytecode and expecting an EVM-like behavior.
 EraVM does not use bytecode for contract deployment. Instead, it refers to contracts using their bytecode hashes.
 In order to deploy a contract, please use the `new` operator in Solidity instead of raw 'create'/'create2' in assembly.
-In Solidity v0.6 and older, it can be a false-positive error if there is 'create(' or 'create2(' in comments within assembly.
+In Solidity v0.6 and older, it can be a false-positive warning if there is 'create(' or 'create2(' in comments within assembly.
 Learn more about CREATE/CREATE2 EraVM limitations at https://docs.zksync.io/zksync-protocol/differences/evm-instructions#create-create2
 
-You may disable this error with:
-    1. `suppressedErrors = ["assemblycreate"]` in standard JSON.
-    2. `--suppress-errors assemblycreate` in the CLI.
+You may disable this warning with:
+    1. `suppressedWarnings = ["assemblycreate"]` in standard JSON.
+    2. `--suppress-warnings assemblycreate` in the CLI.
 "#;
 
-        Self::new_error(
+        Self::new_warning(
             message,
             node.and_then(|node| SourceLocation::try_from_ast(node, id_paths)),
             Some(sources),

--- a/era-solc/src/standard_json/output/source.rs
+++ b/era-solc/src/standard_json/output/source.rs
@@ -101,7 +101,7 @@ impl Source {
             _ => return None,
         }
 
-        Some(StandardJsonOutputError::error_assembly_create(
+        Some(StandardJsonOutputError::warning_assembly_create(
             ast.get("src")?.as_str(),
             id_paths,
             sources,
@@ -215,7 +215,7 @@ impl Source {
                 messages.push(message);
             }
         }
-        if !suppressed_errors.contains(&StandardJsonInputSettingsErrorType::AssemblyCreate) {
+        if !suppressed_warnings.contains(&StandardJsonInputSettingsWarningType::AssemblyCreate) {
             if let Some(message) = Self::check_assembly_create(solc_version, ast, id_paths, sources)
             {
                 messages.push(message);


### PR DESCRIPTION
# What ❔

Changes the `create`/`create2` in assembly error to a warning.

## Why ❔

It is not possible to compiler openzeppelin and forge-std with this error.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
