### PR TITLE
fix: new line characters in Yul string literals on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # The `zksolc` changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Windows new line characters in Yul string literals
+
 ## [1.5.10] - 2025-01-17
 
 ### Changed

--- a/era-compiler-solidity/src/yul/parser/statement/expression/literal.rs
+++ b/era-compiler-solidity/src/yul/parser/statement/expression/literal.rs
@@ -123,14 +123,10 @@ impl Literal {
                                     era_compiler_common::BASE_HEXADECIMAL,
                                 )
                                 .map_err(|error| {
-                                    anyhow::anyhow!(
-                                        "Invalid codepoint `{}`: {}",
-                                        codepoint_str,
-                                        error
-                                    )
+                                    anyhow::anyhow!("Invalid codepoint `{codepoint_str}`: {error}")
                                 })?;
                                 let unicode_char = char::from_u32(codepoint).ok_or_else(|| {
-                                    anyhow::anyhow!("Invalid codepoint {}", codepoint)
+                                    anyhow::anyhow!("Invalid codepoint {codepoint}")
                                 })?;
                                 let mut unicode_bytes = vec![0u8; 3];
                                 unicode_char.encode_utf8(&mut unicode_bytes);
@@ -148,7 +144,9 @@ impl Literal {
                             } else if string[index..].starts_with('r') {
                                 hex_string.push_str("0d");
                                 index += 1;
-                            } else if string[index..].starts_with('\n') {
+                            } else if cfg!(windows) && string[index..].starts_with("\r\n") {
+                                index += 2;
+                            } else if cfg!(not(windows)) && string[index..].starts_with('\n') {
                                 index += 1;
                             } else {
                                 hex_string


### PR DESCRIPTION
Fixes Windows new line characters in Yul string literals.

```
"jsdjsjdjd\
12312\\/\"\x12\u220E"
```

Literals such as the one above have been parsed incorrectly, resulting in `\r\n` bytes spilled into the constant value.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
