### PR TITLE
fix: remove platform checks for Yul string literals

### DIFF
--- a/era-compiler-solidity/src/yul/parser/statement/expression/literal.rs
+++ b/era-compiler-solidity/src/yul/parser/statement/expression/literal.rs
@@ -144,9 +144,9 @@ impl Literal {
                             } else if string[index..].starts_with('r') {
                                 hex_string.push_str("0d");
                                 index += 1;
-                            } else if cfg!(windows) && string[index..].starts_with("\r\n") {
+                            } else if string[index..].starts_with("\r\n") {
                                 index += 2;
-                            } else if cfg!(not(windows)) && string[index..].starts_with('\n') {
+                            } else if string[index..].starts_with('\n') {
                                 index += 1;
                             } else {
                                 hex_string


### PR DESCRIPTION
# What ❔

Removes platform checks for Yul string literals.

## Why ❔

It is possible to have CRLF-encoded files on Linux, and the other way around.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
