### PR TITLE
fix(docs): metadata.bytecodeHash -> metadata.hashType

### DIFF
--- a/docs/src/03-standard-json.md
+++ b/docs/src/03-standard-json.md
@@ -136,7 +136,7 @@ Internally, *zksolc* extracts all *zksolc*-specific options and converts the inp
       // Available options: "none", "keccak256", "ipfs".
       // The metadata hash can be removed from the bytecode via option "none".
       // Default: "keccak256".
-      "bytecodeHash": "ipfs",
+      "hashType": "ipfs",
       // Optional: Use only literal content and not URLs.
       // Passed through to solc and does not affect the zksolc-specific metadata.
       // Default: false.

--- a/era-solc/src/standard_json/input/settings/metadata.rs
+++ b/era-solc/src/standard_json/input/settings/metadata.rs
@@ -13,7 +13,11 @@ pub struct Metadata {
     pub use_literal_content: bool,
 
     /// The metadata hash type.
-    #[serde(default = "Metadata::default_hash_type", skip_serializing)]
+    #[serde(
+        alias = "bytecodeHash",
+        default = "Metadata::default_hash_type",
+        skip_serializing
+    )]
     pub hash_type: era_compiler_common::HashType,
 }
 


### PR DESCRIPTION
Fixes the incorrect name of metadata hash type field in standard JSON input.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
