### PR TITLE
fix(eravm): make the codegen warning more informative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # The `zksolc` changelog
 
+## [Unreleased]
+
+### Changed
+
+- The warning about the default codegen is made more verbose and informative
+
 ## [1.5.11] - 2025-01-27
 
 ### Fixed

--- a/era-compiler-solidity/tests/cli/codegen.rs
+++ b/era-compiler-solidity/tests/cli/codegen.rs
@@ -159,7 +159,7 @@ fn missing(target: Target) -> anyhow::Result<()> {
 
     let result = crate::cli::execute_zksolc_with_target(args, target)?;
     result.success().stdout(predicate::str::contains(
-        "The `codegen` setting will become mandatory in future versions of zksolc. Please set it to either `evmla` or `yul`.",
+        "The default codegen of `zksolc` does not match that of `solc` for historical reasons.",
     ));
 
     Ok(())

--- a/era-solc/src/solc.rs
+++ b/era-solc/src/solc.rs
@@ -162,7 +162,36 @@ impl Compiler {
         }
         if input.settings.codegen.is_none() {
             messages.push(StandardJsonOutputError::new_warning(
-                "The `codegen` setting will become mandatory in future versions of zksolc. Please set it to either `evmla` or `yul`.",
+                r#"
+The default codegen of `zksolc` does not match that of `solc` for historical reasons.
+Whereas `solc` uses the EVM [legacy] assembly codegen by default, zksolc uses the Yul codegen.
+
+It often leads to different behavior of the bytecode generated from specific cases of Solidity language features.
+In practice, contracts that work correctly on EVM may produce different and unexpected results on ZKsync.
+
+The affected Solidity features are listed at https://docs.soliditylang.org/en/latest/ir-breaking-changes.html,
+although this list may be incomplete.
+
+>>> IMPORTANT! This warning will become a hard error in future versions of `zksolc` to reduce potential security issues <<<
+
+To mitigate the warning, please follow the instructions below depending on how you are using `zksolc`.
+`foundry-zksync`:
+    - `codegen = value` in the `[profile.default.zksync]` section of the project config (e.g. `foundry.toml`)
+`hardhat`:
+    - "codegen": <value> in the `zksolc.settings.codegen` field of the project config (e.g. `hardhat.config.js`)
+Directly via standard JSON I/O without tooling:
+    - "codegen": <value> in the `<root>.settings.codegen` field
+Directly via CLI:
+    - pass the `--codegen <value>` parameter
+
+Allowed values:
+    "evmla": the default codegen used in `solc` by default, a.k.a. EVM legacy assembly or simply EVM assembly.
+    "yul": the new experimental `solc` codegen that has been used in `zksolc` by default.
+
+For reference, see the following links:
+- `zksolc` CLI reference: https://matter-labs.github.io/era-compiler-solidity/latest/02-command-line-interface.html#--codegen
+- `zksolc` standard JSON input reference: https://matter-labs.github.io/era-compiler-solidity/latest/03-standard-json.html#input-json
+                "#,
                 None,
                 None,
             ));

--- a/era-solc/src/solc.rs
+++ b/era-solc/src/solc.rs
@@ -178,9 +178,9 @@ To mitigate the warning, please follow the instructions below depending on how y
 `foundry-zksync`:
     - `codegen = value` in the `[profile.default.zksync]` section of the project config (e.g. `foundry.toml`)
 `hardhat`:
-    - "codegen": <value> in the `zksolc.settings.codegen` field of the project config (e.g. `hardhat.config.js`)
+    - "codegen": <value> in the `zksolc.settings` section of the project config (e.g. `hardhat.config.js`)
 Directly via standard JSON I/O without tooling:
-    - "codegen": <value> in the `<root>.settings.codegen` field
+    - "codegen": <value> in the `<root>.settings` section of the input JSON
 Directly via CLI:
     - pass the `--codegen <value>` parameter
 


### PR DESCRIPTION
# What ❔

Makes the codegen warning more informative.

## Why ❔

It was not clear to users how to fix it, and what is it about at all.

Fixes https://github.com/matter-labs/era-compiler-solidity/issues/272

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
