### PR TITLE
docs: fixed typo in "diagnostics" to "diagnostic"

### DIFF
--- a/docs/src/02-command-line-interface.md
+++ b/docs/src/02-command-line-interface.md
@@ -513,7 +513,7 @@ Binary:
 0000000100200190000000060000c13d0000002a01000039000000000010043f...
 ```
 
-*zksolc* is able to compile Yul without *solc*. However, using *solc* is still recommended as it provides additional validation, diagnostics and better error messages:
+*zksolc* is able to compile Yul without *solc*. However, using *solc* is still recommended as it provides additional validation, diagnostic and better error messages:
 
 ```bash
 zksolc --yul './Simple.yul' --bin --solc '/path/to/solc'


### PR DESCRIPTION
# What ❔

I corrected a typo where "diagnostics" was used incorrectly.
It should be "diagnostic" as it is intended as an adjective in this context.

## Checklist

- [x] PR title corresponds to the body of PR.
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
