### PR TITLE
docs: Fix minor grammar mistake in documentation

### DIFF
--- a/docs/src/guides/01-sanitizers.md
+++ b/docs/src/guides/01-sanitizers.md
@@ -61,7 +61,7 @@ zksync-llvm build --sanitizer=Address \
 
 To build the ZKsync compiler with sanitizer enabled, you need to set the `RUSTFLAGS` environment variable
 to `-Z sanitizer=address` and run the `cargo build` command.
-Sanitizers build is the feature that is available only for the nightly Rust compiler, it is recommended
+Sanitizers build is a feature that is available only for the nightly Rust compiler, it is recommended
 to set `RUSTC_BOOTSTRAP=1` environment variable before the build.
 
 It is also mandatory to use `--target` option to specify the target architecture. Otherwise, the build will fail.


### PR DESCRIPTION
# What ❔

A grammar issue in the docs: "is the feature" → "is a feature."

## Why ❔

This fix makes the sentence more natural.

## Checklist

- [x] PR title corresponds to the body of PR.
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
