### PR TITLE
docs: fix Yul example to match pseudocode and Solidity usage

### DIFF
--- a/docs/src/eravm/06-extensions.md
+++ b/docs/src/eravm/06-extensions.md
@@ -229,7 +229,7 @@ assembly {
 Yul usage:
 ```solidity
 assembly {
-    let return_value := verbatim_2i_01("decommit", input_data, ergs)
+    let return_value := verbatim_2i_01("decommit", versioned_hash, ergs)
 }
 ```
 


### PR DESCRIPTION
# What ❔

the Yul example should use `versioned_hash` instead of `input_data`. The corrected Yul example would look like this:

```solidity
assembly {
    let return_value := verbatim_2i_01("decommit", versioned_hash, ergs)
}
```

## Checklist

- [x] PR title corresponds to the body of PR.
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
