### PR TITLE
feat: enable fallback-Oz and check runtime code size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # The `zksolc` changelog
 
-## [1.5.12] - 2025-03-20
+## [1.5.12] - 2025-03-24
 
 ### Added
 
@@ -11,7 +11,7 @@
 ### Changed
 
 - The warning about the default codegen is made more verbose and informative
-- Updated to Rust v1.83.0
+- Updated to Rust v1.85.1
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,7 +599,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "era-compiler-common"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#bd45b0ca590810480dfae9f8b49aec4af571ccf5"
+source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#9fb4fb47268c9f0b83e02b607d1eca3987d1a3ee"
 dependencies = [
  "anyhow",
  "base58",
@@ -615,7 +615,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-downloader"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#bd45b0ca590810480dfae9f8b49aec4af571ccf5"
+source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#9fb4fb47268c9f0b83e02b607d1eca3987d1a3ee"
 dependencies = [
  "anyhow",
  "colored",
@@ -628,7 +628,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#fdf50bb1a4c08f4774a0c15b3efea22c671bb9ae"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#2639dd42c92fb1be1cd05cf13a9113a1972cd469"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -1264,7 +1264,7 @@ dependencies = [
 [[package]]
 name = "inkwell"
 version = "0.4.0"
-source = "git+https://github.com/matter-labs-forks/inkwell?branch=llvm-17#49b96062340ea89a2ac45c3ba037e339592bb783"
+source = "git+https://github.com/matter-labs-forks/inkwell?branch=llvm-17#b2b81c254e25ffbf42c41e40de0748a81f750f94"
 dependencies = [
  "either",
  "inkwell_internals",
@@ -1279,7 +1279,7 @@ dependencies = [
 [[package]]
 name = "inkwell_internals"
 version = "0.9.0"
-source = "git+https://github.com/matter-labs-forks/inkwell?branch=llvm-17#49b96062340ea89a2ac45c3ba037e339592bb783"
+source = "git+https://github.com/matter-labs-forks/inkwell?branch=llvm-17#b2b81c254e25ffbf42c41e40de0748a81f750f94"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1417,7 +1417,7 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 [[package]]
 name = "llvm-sys"
 version = "170.0.1"
-source = "git+https://github.com/matter-labs-forks/llvm-sys.rs?branch=llvm-17.0#686fdddec1389b48a3a44c32e8725a2817ab5089"
+source = "git+https://github.com/matter-labs-forks/llvm-sys.rs?branch=llvm-17.0#94f9489e149d6bf99444dc049f6c2fecd1172922"
 dependencies = [
  "anyhow",
  "cc",

--- a/era-compiler-solidity/src/project/contract/mod.rs
+++ b/era-compiler-solidity/src/project/contract/mod.rs
@@ -174,7 +174,7 @@ impl Contract {
             IR::LLVMIR(mut llvm_ir) => {
                 llvm_ir.source.push(char::from(0));
                 let memory_buffer = inkwell::memory_buffer::MemoryBuffer::create_from_memory_range(
-                    &llvm_ir.source.as_bytes()[..llvm_ir.source.as_bytes().len() - 1],
+                    &llvm_ir.source.as_bytes()[..llvm_ir.source.len() - 1],
                     self.name.full_path.as_str(),
                     true,
                 );
@@ -463,7 +463,7 @@ impl Contract {
 
                 llvm_ir.source.push(char::from(0));
                 let memory_buffer = inkwell::memory_buffer::MemoryBuffer::create_from_memory_range(
-                    &llvm_ir.source.as_bytes()[..llvm_ir.source.as_bytes().len() - 1],
+                    &llvm_ir.source.as_bytes()[..llvm_ir.source.len() - 1],
                     self.name.full_path.as_str(),
                     true,
                 );

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.83.0"
+channel = "1.85.1"


### PR DESCRIPTION
1. Enables falling back to -Oz if the EVM runtime bytecode size is exceeded.
2. Enables the check for EVM runtime bytecode size of 24576 bytes.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
