### PR TITLE
chore: fix incorrect use of `document.location.pathname`

### DIFF
--- a/docs/js/version-box.js
+++ b/docs/js/version-box.js
@@ -1,6 +1,6 @@
 document.addEventListener("DOMContentLoaded", () => {
     // Get the base URL from the current location path
-    const baseUrl = document.location.pathname.split('/').slice(0, -2).join('/');
+    const baseUrl = window.location.pathname.split('/').slice(0, -2).join('/');
 
     // Utility function to create and populate the version selector
     const createVersionSelector = (versions) => {


### PR DESCRIPTION
# What ❔  
Replaced `document.location.pathname` with `window.location.pathname` to use the correct property.  

## Why ❔  
`document.location.pathname` is not a standard approach, while `window.location.pathname` is more reliable and widely used. This change ensures consistency and prevents potential issues.  

## Checklist  

- [x] PR title corresponds to the body of PR.  
- [ ] Tests for the changes have been added / updated.  
- [ ] Documentation comments have been added / updated.  
- [ ] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.  