### PR TITLE
chore: release docs only when a new release is published

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -1,12 +1,8 @@
 name: Deploy docs
 
 on:
-  push:
-    tags:
-      - "*.*.*"
-    paths:
-      - 'docs/**'
-      - '.github/workflows/deploy-docs.yaml'
+  release:
+    types: [ released ]
   pull_request:
     paths:
       - 'docs/**'


### PR DESCRIPTION
# What ❔

Release docs only when a new release is published.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To overcome the situation when release is not created (e.g. binaries publishing failure), but the tag is.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
