### PR TITLE
fix: false-positive warning on error suppression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # The `zksolc` changelog
 
+## [Unreleased]
+
+### Fixed
+
+- False-positive warning about incorrect suppression of errors and warnings
+
 ## [1.5.12] - 2025-03-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "era-compiler-solidity"
-version = "1.5.12"
+version = "1.5.13"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "era-solc"
-version = "1.5.12"
+version = "1.5.13"
 dependencies = [
  "anyhow",
  "boolinator",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "era-yul"
-version = "1.5.12"
+version = "1.5.13"
 dependencies = [
  "anyhow",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ authors = [
 ]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-version = "1.5.12"
+version = "1.5.13"

--- a/README.md
+++ b/README.md
@@ -16,13 +16,7 @@ For local development, [build zksolc from sources](./docs/src/01-installation.md
 
 For the detailed usage guide, see the [comprehensive documentation](https://matter-labs.github.io/era-compiler-solidity/latest/).
 
-## Testing
-
-To run the unit and CLI tests, execute the following command from the repository root:
-
-```shell
-cargo test
-```
+Alternatively, you may check out its Markdown representation in [this repository](./docs/src/).
 
 ## Documentation
 
@@ -62,8 +56,8 @@ at your option.
 
 - [Website](https://zksync.io/)
 - [GitHub](https://github.com/matter-labs)
-- [Twitter](https://twitter.com/zksync)
-- [Twitter for Devs](https://twitter.com/ZKsyncDevs)
+- [Twitter](https://x.com/zksync)
+- [Twitter for Devs](https://x.com/ZKsyncDevs)
 - [Discord](https://join.zksync.dev/)
 
 ## Disclaimer

--- a/era-compiler-solidity/src/process/mod.rs
+++ b/era-compiler-solidity/src/process/mod.rs
@@ -105,6 +105,7 @@ where
     command.stdout(std::process::Stdio::piped());
     command.stderr(std::process::Stdio::piped());
     command.arg("--recursive-process");
+    command.arg(path);
     command.arg("--target");
     command.arg(target.to_string());
 

--- a/era-compiler-solidity/src/zksolc/arguments.rs
+++ b/era-compiler-solidity/src/zksolc/arguments.rs
@@ -262,16 +262,6 @@ impl Arguments {
             ));
         }
 
-        if self.recursive_process
-            && std::env::args().count() > 2 + (self.target.is_some() as usize) * 2
-        {
-            messages.push(era_solc::StandardJsonOutputError::new_error(
-                "No other options are allowed in recursive mode.",
-                None,
-                None,
-            ));
-        }
-
         let modes_count = [
             self.yul,
             self.llvm_ir,

--- a/era-compiler-solidity/tests/cli/recursive_process.rs
+++ b/era-compiler-solidity/tests/cli/recursive_process.rs
@@ -20,21 +20,3 @@ fn missing_input(target: Target) -> anyhow::Result<()> {
 
     Ok(())
 }
-
-#[test_case(Target::EraVM)]
-#[test_case(Target::EVM)]
-fn excess_arguments(target: Target) -> anyhow::Result<()> {
-    crate::common::setup()?;
-
-    let args = &[
-        "--recursive-process",
-        crate::common::TEST_SOLIDITY_CONTRACT_PATH,
-    ];
-
-    let result = crate::cli::execute_zksolc_with_target(args, target)?;
-    result.failure().stderr(predicate::str::contains(
-        "No other options are allowed in recursive mode.",
-    ));
-
-    Ok(())
-}

--- a/era-solc/src/standard_json/input/mod.rs
+++ b/era-solc/src/standard_json/input/mod.rs
@@ -153,8 +153,8 @@ impl Input {
                 detect_missing_libraries,
                 via_ir,
             ),
-            suppressed_errors,
-            suppressed_warnings,
+            suppressed_errors: vec![],
+            suppressed_warnings: vec![],
         })
     }
 


### PR DESCRIPTION
A warning about using `suppressWarnings` in standard JSON root is printed even when the standard JSON mode is not used.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
