### PR TITLE
feat: syncs EVM functionality with solx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,9 +255,9 @@ checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bstr"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "2.0.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#4785cde7dbc949d89cd15ebc13fb5d43bd0e2b9a"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#aa3667e7f0f9af5044b2b977fce1f33bc32901c6"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -669,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "era-compiler-solidity"
-version = "1.5.13"
+version = "1.5.14"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "era-solc"
-version = "1.5.13"
+version = "1.5.14"
 dependencies = [
  "anyhow",
  "boolinator",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "era-yul"
-version = "1.5.13"
+version = "1.5.14"
 dependencies = [
  "anyhow",
  "regex",
@@ -1424,15 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -1483,9 +1477,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -1687,9 +1681,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.4.2+3.4.1"
+version = "300.5.0+3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
+checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
 dependencies = [
  "cc",
 ]
@@ -2124,19 +2118,6 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
@@ -2144,7 +2125,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.9.3",
+ "linux-raw-sys",
  "windows-sys 0.59.0",
 ]
 
@@ -2537,7 +2518,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.5",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -2941,13 +2922,13 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "7.0.2"
+version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2774c861e1f072b3aadc02f8ba886c26ad6321567ecc294c935434cad06f1283"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
 dependencies = [
  "either",
  "env_home",
- "rustix 0.38.44",
+ "rustix",
  "winsafe",
 ]
 
@@ -3134,9 +3115,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ authors = [
 ]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-version = "1.5.13"
+version = "1.5.14"

--- a/era-compiler-solidity/src/yul/parser/statement/expression/function_call/mod.rs
+++ b/era-compiler-solidity/src/yul/parser/statement/expression/function_call/mod.rs
@@ -2112,8 +2112,8 @@ impl FunctionCall {
                 let object_name = arguments[0].original.take().ok_or_else(|| {
                     anyhow::anyhow!("{} `dataoffset` literal is missing", location)
                 })?;
-                era_compiler_llvm_context::evm_code::data_offset(context, object_name.as_str())
-                    .map(Some)
+                let object_name = object_name.split('.').last().expect("Always exists");
+                era_compiler_llvm_context::evm_code::data_offset(context, object_name).map(Some)
             }
             Name::DataSize => {
                 let mut arguments = self.pop_arguments_evm::<1>(context)?;
@@ -2121,8 +2121,8 @@ impl FunctionCall {
                     .original
                     .take()
                     .ok_or_else(|| anyhow::anyhow!("{} `datasize` literal is missing", location))?;
-                era_compiler_llvm_context::evm_code::data_size(context, object_name.as_str())
-                    .map(Some)
+                let object_name = object_name.split('.').last().expect("Always exists");
+                era_compiler_llvm_context::evm_code::data_size(context, object_name).map(Some)
             }
             Name::DataCopy => {
                 let arguments = self.pop_arguments_llvm_evm::<3>(context)?;

--- a/era-compiler-solidity/src/zksolc/main.rs
+++ b/era-compiler-solidity/src/zksolc/main.rs
@@ -420,16 +420,11 @@ fn main_inner(
                 build.write_to_directory(
                     &output_directory,
                     arguments.output_metadata,
-                    arguments.output_assembly,
                     arguments.output_binary,
                     arguments.overwrite,
                 )?;
             } else {
-                build.write_to_terminal(
-                    arguments.output_metadata,
-                    arguments.output_assembly,
-                    arguments.output_binary,
-                )?;
+                build.write_to_terminal(arguments.output_metadata, arguments.output_binary)?;
             }
         }
     }

--- a/era-compiler-solidity/tests/cli/asm.rs
+++ b/era-compiler-solidity/tests/cli/asm.rs
@@ -7,7 +7,6 @@ use predicates::prelude::*;
 use test_case::test_case;
 
 #[test_case(Target::EraVM, "__entry:")]
-#[test_case(Target::EVM, "Coming soon")]
 fn default(target: Target, pattern: &str) -> anyhow::Result<()> {
     crate::common::setup()?;
 

--- a/era-compiler-solidity/tests/cli/general.rs
+++ b/era-compiler-solidity/tests/cli/general.rs
@@ -35,11 +35,6 @@ fn no_arguments() -> anyhow::Result<()> {
     crate::common::SOLIDITY_BIN_OUTPUT_NAME_ERAVM,
     crate::common::SOLIDITY_ASM_OUTPUT_NAME_ERAVM
 )]
-#[test_case(
-    Target::EVM,
-    crate::common::SOLIDITY_BIN_OUTPUT_NAME_EVM,
-    crate::common::SOLIDITY_ASM_OUTPUT_NAME_EVM
-)]
 fn multiple_output_options(
     target: Target,
     bin_output_file_name: &str,

--- a/era-compiler-solidity/tests/cli/output_dir.rs
+++ b/era-compiler-solidity/tests/cli/output_dir.rs
@@ -83,7 +83,6 @@ fn yul(target: Target, extension: &str) -> anyhow::Result<()> {
 }
 
 #[test_case(Target::EraVM, crate::common::SOLIDITY_ASM_OUTPUT_NAME_ERAVM)]
-#[test_case(Target::EVM, crate::common::SOLIDITY_ASM_OUTPUT_NAME_EVM)]
 fn asm_and_metadata(target: Target, asm_file_name: &str) -> anyhow::Result<()> {
     crate::common::setup()?;
 

--- a/era-compiler-solidity/tests/cli/overwrite.rs
+++ b/era-compiler-solidity/tests/cli/overwrite.rs
@@ -134,7 +134,6 @@ fn asm(target: Target) -> anyhow::Result<()> {
 }
 
 #[test_case(Target::EraVM)]
-#[test_case(Target::EVM)]
 fn asm_missing(target: Target) -> anyhow::Result<()> {
     crate::common::setup()?;
 

--- a/era-compiler-solidity/tests/common/const.rs
+++ b/era-compiler-solidity/tests/common/const.rs
@@ -68,9 +68,6 @@ pub const SOLIDITY_BIN_OUTPUT_NAME_EVM: &str = "Test.bin";
 pub const SOLIDITY_ASM_OUTPUT_NAME_ERAVM: &str = "Test.zasm";
 
 /// A test input file.
-pub const SOLIDITY_ASM_OUTPUT_NAME_EVM: &str = "Test.asm";
-
-/// A test input file.
 pub const TEST_YUL_CONTRACT_PATH: &str = "tests/data/contracts/yul/Default.yul";
 
 /// A test input file.

--- a/era-solc/src/standard_json/input/mod.rs
+++ b/era-solc/src/standard_json/input/mod.rs
@@ -65,7 +65,7 @@ impl Input {
     }
 
     ///
-    /// A shortcut constructor from Solidity source paths.
+    /// A shortcut constructor from paths to Solidity source files.
     ///
     pub fn try_from_solidity_paths(
         paths: &[PathBuf],
@@ -158,7 +158,28 @@ impl Input {
     }
 
     ///
-    /// A shortcut constructor from source code.
+    /// A shortcut constructor from paths to Yul source files.
+    ///
+    pub fn from_yul_paths(
+        paths: &[PathBuf],
+        libraries: era_compiler_common::Libraries,
+        optimizer: StandardJsonInputSettingsOptimizer,
+        llvm_options: Vec<String>,
+    ) -> Self {
+        let sources = paths
+            .iter()
+            .map(|path| {
+                (
+                    path.to_string_lossy().to_string(),
+                    Source::from(path.as_path()),
+                )
+            })
+            .collect();
+        Self::from_yul_sources(sources, libraries, optimizer, llvm_options)
+    }
+
+    ///
+    /// A shortcut constructor from Yul source code.
     ///
     pub fn from_yul_sources(
         sources: BTreeMap<String, Source>,
@@ -192,9 +213,9 @@ impl Input {
     }
 
     ///
-    /// A shortcut constructor from source code.
+    /// A shortcut constructor from paths to LLVM IR source files.
     ///
-    pub fn from_yul_paths(
+    pub fn from_llvm_ir_paths(
         paths: &[PathBuf],
         libraries: era_compiler_common::Libraries,
         optimizer: StandardJsonInputSettingsOptimizer,
@@ -210,6 +231,38 @@ impl Input {
             })
             .collect();
         Self::from_yul_sources(sources, libraries, optimizer, llvm_options)
+    }
+
+    ///
+    /// A shortcut constructor from LLVM IR source code.
+    ///
+    pub fn from_llvm_ir_sources(
+        sources: BTreeMap<String, Source>,
+        libraries: era_compiler_common::Libraries,
+        optimizer: StandardJsonInputSettingsOptimizer,
+        llvm_options: Vec<String>,
+    ) -> Self {
+        Self {
+            language: Language::LLVMIR,
+            sources,
+            settings: Settings::new(
+                optimizer,
+                libraries,
+                BTreeSet::new(),
+                None,
+                None,
+                false,
+                StandardJsonInputSettingsSelection::default(),
+                StandardJsonInputSettingsMetadata::default(),
+                llvm_options,
+                vec![],
+                vec![],
+                false,
+                false,
+            ),
+            suppressed_errors: vec![],
+            suppressed_warnings: vec![],
+        }
     }
 
     ///

--- a/era-yul/src/yul/parser/statement/expression/function_call/mod.rs
+++ b/era-yul/src/yul/parser/statement/expression/function_call/mod.rs
@@ -122,18 +122,18 @@ impl FunctionCall {
     ///
     pub fn accumulate_evm_dependencies(&self, dependencies: &mut Dependencies) {
         match self.name {
-            Name::CodeCopy | Name::DataCopy | Name::DataSize | Name::DataOffset => {
+            Name::DataSize | Name::DataOffset => {
                 if let Expression::Literal(Literal {
                     inner: LexicalLiteral::String(identifier),
                     ..
                 }) = self.arguments.first().expect("Always exists")
                 {
+                    let object_name = identifier.inner.split(".").last().expect("Always exists");
                     let is_runtime_code = dependencies.identifier.as_str()
-                        == identifier
-                            .inner
+                        == object_name
                             .strip_suffix("_deployed")
                             .unwrap_or(dependencies.identifier.as_str());
-                    dependencies.push(identifier.to_string(), is_runtime_code);
+                    dependencies.push(object_name.to_owned(), is_runtime_code);
                 }
                 return;
             }


### PR DESCRIPTION
1. Adds EVM LLVM IR compilation.
2. Fixes incorrect namings of Yul objects in dependencies.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
