### PR TITLE
ci: remove semver condition for submodules during releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,15 +65,6 @@ jobs:
           submodules: 'recursive'
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || '' }}
 
-      - name: Check LLVM version
-        if: github.ref_type == 'tag'
-        shell: 'bash -ex {0}'
-        run: |
-          # Extracts submodule branch from the submodule status output. Works in case of shallow clone.
-          LLVM_BRANCH=$(git submodule status llvm | awk -F '[()/]' '{print $3}')
-          [[ "${LLVM_BRANCH}" =~ ^v[0-9]+(\.[0-9]+)+(\.[0-9]+).*$ ]] || \
-             { echo "LLVM branch is not semver: '${LLVM_BRANCH}'. Please, update LLVM.lock file."; exit 1; }
-
       - name: Prepare matrix
         id: prepare-matrix
         run: |


### PR DESCRIPTION
# What ❔

Remove semver condition check for releases.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To allow use `main` branch for LLVM submodule.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
