### PR TITLE
chore: bump solc revision to v1.0.2

### DIFF
--- a/era-compiler-solidity/tests/scripts/solc_exit_code_failed.bat
+++ b/era-compiler-solidity/tests/scripts/solc_exit_code_failed.bat
@@ -3,7 +3,7 @@
 if "%~1"=="--version" (
     echo solc, the solidity compiler commandline interface
     echo Version: 0.8.29+commit.deadbeef.platform.toolchain
-    echo ZKsync: 0.8.29-1.0.1
+    echo ZKsync: 0.8.29-1.0.2
     exit /b 0
 )
 

--- a/era-compiler-solidity/tests/scripts/solc_exit_code_failed.sh
+++ b/era-compiler-solidity/tests/scripts/solc_exit_code_failed.sh
@@ -3,7 +3,7 @@
 if [ "$1" == "--version" ]; then
     echo 'solc, the solidity compiler commandline interface'
     echo 'Version: 0.8.29+commit.deadbeef.platform.toolchain'
-    echo 'ZKsync: 0.8.29-1.0.1'
+    echo 'ZKsync: 0.8.29-1.0.2'
     exit 0
 fi
 

--- a/era-compiler-solidity/tests/scripts/solc_invalid_output_json.bat
+++ b/era-compiler-solidity/tests/scripts/solc_invalid_output_json.bat
@@ -3,7 +3,7 @@
 if "%~1"=="--version" (
     echo solc, the solidity compiler commandline interface
     echo Version: 0.8.29+commit.deadbeef.platform.toolchain
-    echo ZKsync: 0.8.29-1.0.1
+    echo ZKsync: 0.8.29-1.0.2
     exit /b 0
 )
 

--- a/era-compiler-solidity/tests/scripts/solc_invalid_output_json.sh
+++ b/era-compiler-solidity/tests/scripts/solc_invalid_output_json.sh
@@ -3,7 +3,7 @@
 if [ "$1" == "--version" ]; then
     echo 'solc, the solidity compiler commandline interface'
     echo 'Version: 0.8.29+commit.deadbeef.platform.toolchain'
-    echo 'ZKsync: 0.8.29-1.0.1'
+    echo 'ZKsync: 0.8.29-1.0.2'
     exit 0
 fi
 

--- a/era-compiler-solidity/tests/scripts/solc_version_too_new.bat
+++ b/era-compiler-solidity/tests/scripts/solc_version_too_new.bat
@@ -2,4 +2,4 @@
 
 echo solc, the solidity compiler commandline interface
 echo Version: 0.8.30+commit.deadbeef.platform.toolchain
-echo ZKsync: 0.8.30-1.0.1
+echo ZKsync: 0.8.30-1.0.2

--- a/era-compiler-solidity/tests/scripts/solc_version_too_new.sh
+++ b/era-compiler-solidity/tests/scripts/solc_version_too_new.sh
@@ -2,4 +2,4 @@
 
 echo 'solc, the solidity compiler commandline interface'
 echo 'Version: 0.8.30+commit.deadbeef.platform.toolchain'
-echo 'ZKsync: 0.8.30-1.0.1'
+echo 'ZKsync: 0.8.30-1.0.2'

--- a/era-compiler-solidity/tests/scripts/solc_version_too_old.bat
+++ b/era-compiler-solidity/tests/scripts/solc_version_too_old.bat
@@ -2,4 +2,4 @@
 
 echo solc, the solidity compiler commandline interface
 echo Version: 0.4.11+commit.deadbeef.platform.toolchain
-echo ZKsync: 0.4.11-1.0.1
+echo ZKsync: 0.4.11-1.0.2

--- a/era-compiler-solidity/tests/scripts/solc_version_too_old.sh
+++ b/era-compiler-solidity/tests/scripts/solc_version_too_old.sh
@@ -2,4 +2,4 @@
 
 echo 'solc, the solidity compiler commandline interface'
 echo 'Version: 0.4.11+commit.deadbeef.platform.toolchain'
-echo 'ZKsync: 0.4.11-1.0.1'
+echo 'ZKsync: 0.4.11-1.0.2'

--- a/era-compiler-solidity/tests/solc-bin.json
+++ b/era-compiler-solidity/tests/solc-bin.json
@@ -3,31 +3,31 @@
     "0.4.26": {
       "is_enabled": true,
       "protocol": "https",
-      "source": "https://github.com/matter-labs/era-solidity/releases/download/${VERSION}-1.0.1/solc-${PLATFORM}-${VERSION}-1.0.1",
+      "source": "https://github.com/matter-labs/era-solidity/releases/download/${VERSION}-1.0.2/solc-${PLATFORM}-${VERSION}-1.0.2",
       "destination": "./solc-bin/solc-${VERSION}"
     },
     "0.5.17": {
       "is_enabled": true,
       "protocol": "https",
-      "source": "https://github.com/matter-labs/era-solidity/releases/download/${VERSION}-1.0.1/solc-${PLATFORM}-${VERSION}-1.0.1",
+      "source": "https://github.com/matter-labs/era-solidity/releases/download/${VERSION}-1.0.2/solc-${PLATFORM}-${VERSION}-1.0.2",
       "destination": "./solc-bin/solc-${VERSION}"
     },
     "0.6.12": {
       "is_enabled": true,
       "protocol": "https",
-      "source": "https://github.com/matter-labs/era-solidity/releases/download/${VERSION}-1.0.1/solc-${PLATFORM}-${VERSION}-1.0.1",
+      "source": "https://github.com/matter-labs/era-solidity/releases/download/${VERSION}-1.0.2/solc-${PLATFORM}-${VERSION}-1.0.2",
       "destination": "./solc-bin/solc-${VERSION}"
     },
     "0.7.6": {
       "is_enabled": true,
       "protocol": "https",
-      "source": "https://github.com/matter-labs/era-solidity/releases/download/${VERSION}-1.0.1/solc-${PLATFORM}-${VERSION}-1.0.1",
+      "source": "https://github.com/matter-labs/era-solidity/releases/download/${VERSION}-1.0.2/solc-${PLATFORM}-${VERSION}-1.0.2",
       "destination": "./solc-bin/solc-${VERSION}"
     },
     "0.8.29": {
       "is_enabled": true,
       "protocol": "https",
-      "source": "https://github.com/matter-labs/era-solidity/releases/download/${VERSION}-1.0.1/solc-${PLATFORM}-${VERSION}-1.0.1",
+      "source": "https://github.com/matter-labs/era-solidity/releases/download/${VERSION}-1.0.2/solc-${PLATFORM}-${VERSION}-1.0.2",
       "destination": "./solc-bin/solc-${VERSION}"
     }
   },

--- a/era-compiler-solidity/tests/unit/factory_dependency.rs
+++ b/era-compiler-solidity/tests/unit/factory_dependency.rs
@@ -31,10 +31,6 @@ use test_case::test_case;
     era_solc::StandardJsonInputCodegen::Yul
 )]
 fn default(version: semver::Version, codegen: era_solc::StandardJsonInputCodegen) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     let sources = crate::common::read_sources(&[
         crate::common::TEST_SOLIDITY_CONTRACT_CALLER_MAIN_PATH,
         crate::common::TEST_SOLIDITY_CONTRACT_CALLER_CALLABLE_PATH,

--- a/era-compiler-solidity/tests/unit/ir_artifacts.rs
+++ b/era-compiler-solidity/tests/unit/ir_artifacts.rs
@@ -14,10 +14,6 @@ use test_case::test_case;
 #[test_case(semver::Version::new(0, 7, 6))]
 #[test_case(era_solc::Compiler::LAST_SUPPORTED_VERSION)]
 fn evmla(version: semver::Version) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     let sources = crate::common::read_sources(&[crate::common::TEST_SOLIDITY_CONTRACT_PATH]);
 
     let build = crate::common::build_solidity_standard_json(

--- a/era-compiler-solidity/tests/unit/libraries.rs
+++ b/era-compiler-solidity/tests/unit/libraries.rs
@@ -31,10 +31,6 @@ use test_case::test_case;
     era_solc::StandardJsonInputCodegen::Yul
 )]
 fn not_specified(version: semver::Version, codegen: era_solc::StandardJsonInputCodegen) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     let sources =
         crate::common::read_sources(&[crate::common::TEST_SOLIDITY_CONTRACT_SIMPLE_CONTRACT_PATH]);
 
@@ -93,10 +89,6 @@ fn not_specified(version: semver::Version, codegen: era_solc::StandardJsonInputC
     era_solc::StandardJsonInputCodegen::Yul
 )]
 fn specified(version: semver::Version, codegen: era_solc::StandardJsonInputCodegen) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     let sources =
         crate::common::read_sources(&[crate::common::TEST_SOLIDITY_CONTRACT_SIMPLE_CONTRACT_PATH]);
 

--- a/era-compiler-solidity/tests/unit/linker.rs
+++ b/era-compiler-solidity/tests/unit/linker.rs
@@ -71,10 +71,6 @@ fn library_not_passed_compile_time(
     version: semver::Version,
     codegen: era_solc::StandardJsonInputCodegen,
 ) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     let bytecode = get_bytecode(
         crate::common::TEST_SOLIDITY_CONTRACT_SIMPLE_CONTRACT_PATH,
         "SimpleContract",
@@ -122,10 +118,6 @@ fn library_not_passed_post_compile_time(
     version: semver::Version,
     codegen: era_solc::StandardJsonInputCodegen,
 ) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     let bytecode = get_bytecode(
         crate::common::TEST_SOLIDITY_CONTRACT_SIMPLE_CONTRACT_PATH,
         "SimpleContract",
@@ -176,10 +168,6 @@ fn library_passed_compile_time(
     version: semver::Version,
     codegen: era_solc::StandardJsonInputCodegen,
 ) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     let libraries =
         vec!["tests/data/contracts/solidity/SimpleContract.sol:SimpleLibrary=0x1234567890abcdef1234567890abcdef12345678".to_owned()];
     let libraries =
@@ -229,10 +217,6 @@ fn library_passed_post_compile_time(
     version: semver::Version,
     codegen: era_solc::StandardJsonInputCodegen,
 ) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     let libraries =
         vec!["tests/data/contracts/solidity/SimpleContract.sol:SimpleLibrary=0x1234567890abcdef1234567890abcdef12345678".to_owned()];
 
@@ -286,10 +270,6 @@ fn library_passed_post_compile_time_second_call(
     version: semver::Version,
     codegen: era_solc::StandardJsonInputCodegen,
 ) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     let library_arguments =
         vec!["tests/data/contracts/solidity/SimpleContract.sol:SimpleLibrary=0x1234567890abcdef1234567890abcdef12345678".to_owned()];
     let linker_symbols = era_compiler_common::Libraries::try_from(library_arguments.as_slice())
@@ -350,10 +330,6 @@ fn library_passed_post_compile_time_redundant_args(
     version: semver::Version,
     codegen: era_solc::StandardJsonInputCodegen,
 ) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     let libraries = vec![
         "tests/data/contracts/solidity/fake.sol:Fake=0x0000000000000000000000000000000000000000".to_owned(),
         "tests/data/contracts/solidity/scam.sol:Scam=0x0000000000000000000000000000000000000000".to_owned(),
@@ -411,10 +387,6 @@ fn library_passed_post_compile_time_non_elf(
     version: semver::Version,
     codegen: era_solc::StandardJsonInputCodegen,
 ) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        panic!("Input binary is not an EraVM ELF file");
-    }
-
     let library_arguments =
         vec!["tests/data/contracts/solidity/SimpleContract.sol:SimpleLibrary=0x1234567890abcdef1234567890abcdef12345678".to_owned()];
     let libraries = era_compiler_common::Libraries::try_from(library_arguments.as_slice())
@@ -471,10 +443,6 @@ fn library_produce_equal_bytecode_in_both_cases(
     version: semver::Version,
     codegen: era_solc::StandardJsonInputCodegen,
 ) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     let library_arguments =
         vec!["tests/data/contracts/solidity/SimpleContract.sol:SimpleLibrary=0x1234567890abcdef1234567890abcdef12345678".to_owned()];
     let libraries = era_compiler_common::Libraries::try_from(library_arguments.as_slice())

--- a/era-compiler-solidity/tests/unit/messages.rs
+++ b/era-compiler-solidity/tests/unit/messages.rs
@@ -62,10 +62,6 @@ contract SendExample {
     SEND_TEST_SOURCE_08
 )]
 fn send(version: semver::Version, codegen: era_solc::StandardJsonInputCodegen, source_code: &str) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     assert!(crate::common::check_solidity_message(
         source_code,
         "You are using '<address payable>.send/transfer(<X>)' without providing",
@@ -113,10 +109,6 @@ fn send_suppressed(
     codegen: era_solc::StandardJsonInputCodegen,
     source_code: &str,
 ) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     assert!(!crate::common::check_solidity_message(
         source_code,
         "You are using '<address payable>.send/transfer(<X>)' without providing",
@@ -191,10 +183,6 @@ fn transfer(
     codegen: era_solc::StandardJsonInputCodegen,
     source_code: &str,
 ) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     assert!(crate::common::check_solidity_message(
         source_code,
         "You are using '<address payable>.send/transfer(<X>)' without providing",
@@ -242,10 +230,6 @@ fn transfer_suppressed(
     codegen: era_solc::StandardJsonInputCodegen,
     source_code: &str,
 ) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     assert!(!crate::common::check_solidity_message(
         source_code,
         "You are using '<address payable>.send/transfer(<X>)' without providing",
@@ -385,10 +369,6 @@ fn assembly_create(
     codegen: era_solc::StandardJsonInputCodegen,
     source_code: &str,
 ) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     assert!(crate::common::check_solidity_message(
         source_code,
         "You are using 'create'/'create2' in an assembly block",
@@ -436,10 +416,6 @@ fn assembly_create2(
     codegen: era_solc::StandardJsonInputCodegen,
     source_code: &str,
 ) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     assert!(crate::common::check_solidity_message(
         source_code,
         "You are using 'create'/'create2' in an assembly block",
@@ -487,10 +463,6 @@ fn assembly_create_suppressed(
     codegen: era_solc::StandardJsonInputCodegen,
     source_code: &str,
 ) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     assert!(!crate::common::check_solidity_message(
         source_code,
         "You are using 'create'/'create2' in an assembly block",
@@ -538,10 +510,6 @@ fn assembly_create2_suppressed(
     codegen: era_solc::StandardJsonInputCodegen,
     source_code: &str,
 ) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     assert!(!crate::common::check_solidity_message(
         source_code,
         "You are using 'create'/'create2' in an assembly block",
@@ -589,10 +557,6 @@ contract Test {
     era_solc::StandardJsonInputCodegen::Yul
 )]
 fn runtime_code(version: semver::Version, codegen: era_solc::StandardJsonInputCodegen) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     assert!(crate::common::check_solidity_message(
         RUNTIME_CODE_SOURCE,
         "Deploy and runtime code are merged in EraVM",
@@ -638,10 +602,6 @@ contract TxOriginExample {
     era_solc::StandardJsonInputCodegen::Yul
 )]
 fn tx_origin(version: semver::Version, codegen: era_solc::StandardJsonInputCodegen) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     assert!(crate::common::check_solidity_message(
         TX_ORIGIN_TEST_SOURCE,
         "You are checking for 'tx.origin', which might lead to",
@@ -679,10 +639,6 @@ fn tx_origin(version: semver::Version, codegen: era_solc::StandardJsonInputCodeg
     era_solc::StandardJsonInputCodegen::Yul
 )]
 fn tx_origin_suppressed(version: semver::Version, codegen: era_solc::StandardJsonInputCodegen) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     assert!(!crate::common::check_solidity_message(
         TX_ORIGIN_TEST_SOURCE,
         "You are checking for 'tx.origin', which might lead to",
@@ -730,10 +686,6 @@ contract TxOriginExample {
     era_solc::StandardJsonInputCodegen::Yul
 )]
 fn tx_origin_assembly(version: semver::Version, codegen: era_solc::StandardJsonInputCodegen) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     assert!(crate::common::check_solidity_message(
         TX_ORIGIN_ASSEMBLY_TEST_SOURCE,
         "You are checking for 'tx.origin', which might lead to",
@@ -774,10 +726,6 @@ fn tx_origin_assembly_suppressed(
     version: semver::Version,
     codegen: era_solc::StandardJsonInputCodegen,
 ) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     assert!(!crate::common::check_solidity_message(
         TX_ORIGIN_ASSEMBLY_TEST_SOURCE,
         "You are checking for 'tx.origin' in your code, which might lead to",
@@ -827,10 +775,6 @@ contract Test {
     era_solc::StandardJsonInputCodegen::Yul
 )]
 fn ripemd160(version: semver::Version, codegen: era_solc::StandardJsonInputCodegen) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     assert!(crate::common::check_solidity_message(
         RIPEMD160_CODE_SOURCE,
         "The `ripemd160` precompile is not supported in EraVM yet.",

--- a/era-compiler-solidity/tests/unit/optimizer.rs
+++ b/era-compiler-solidity/tests/unit/optimizer.rs
@@ -31,10 +31,6 @@ use test_case::test_case;
     era_solc::StandardJsonInputCodegen::Yul
 )]
 fn default(version: semver::Version, codegen: era_solc::StandardJsonInputCodegen) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     let sources =
         crate::common::read_sources(&[crate::common::TEST_SOLIDITY_CONTRACT_OPTIMIZED_PATH]);
 

--- a/era-compiler-solidity/tests/unit/remappings.rs
+++ b/era-compiler-solidity/tests/unit/remappings.rs
@@ -31,10 +31,6 @@ use test_case::test_case;
     era_solc::StandardJsonInputCodegen::Yul
 )]
 fn default(version: semver::Version, codegen: era_solc::StandardJsonInputCodegen) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        return;
-    }
-
     let sources = crate::common::read_sources(&[
         crate::common::TEST_SOLIDITY_CONTRACT_CALLER_MAIN_PATH,
         crate::common::TEST_SOLIDITY_CONTRACT_CALLER_CALLABLE_PATH,

--- a/era-compiler-solidity/tests/unit/unsupported_instructions.rs
+++ b/era-compiler-solidity/tests/unit/unsupported_instructions.rs
@@ -121,10 +121,6 @@ contract CallcodeTest {
 )]
 #[should_panic(expected = "The `CALLCODE` instruction is not supported")]
 fn callcode(version: semver::Version, codegen: era_solc::StandardJsonInputCodegen) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        panic!("The `CALLCODE` instruction is not supported");
-    }
-
     let mut sources = BTreeMap::new();
     sources.insert("test.sol".to_owned(), CALLCODE_TEST_SOURCE.to_owned());
 
@@ -184,10 +180,6 @@ contract ExternalCodeCopy {
 )]
 #[should_panic(expected = "The `EXTCODECOPY` instruction is not supported")]
 fn extcodecopy(version: semver::Version, codegen: era_solc::StandardJsonInputCodegen) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        panic!("The `EXTCODECOPY` instruction is not supported");
-    }
-
     let mut sources = BTreeMap::new();
     sources.insert("test.sol".to_owned(), EXTCODECOPY_TEST_SOURCE.to_owned());
 
@@ -315,10 +307,6 @@ fn selfdestruct(
     codegen: era_solc::StandardJsonInputCodegen,
     source: &str,
 ) {
-    if cfg!(target_os = "windows") && version < semver::Version::new(0, 6, 0) {
-        panic!("The `SELFDESTRUCT` instruction is not supported");
-    }
-
     let mut sources = BTreeMap::new();
     sources.insert("test.sol".to_owned(), source.to_owned());
 


### PR DESCRIPTION
# What ❔

Bumps solc revision to v1.0.2.

## Why ❔

It has just been released.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
