### PR TITLE
chore: do not use rust-lld for musl builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,9 +16,6 @@ rustflags = [
     "-C", "link-arg=-mmacosx-version-min=11.0",
 ]
 
-[target.aarch64-unknown-linux-musl]
-linker = "rust-lld"
-
 [target.aarch64-unknown-linux-musl.compiler-rt-zksolc]
 rustc-link-search = ["./target-llvm/target-host/lib/clang/19/lib/aarch64-unknown-linux-musl"]
 rustc-link-lib = ["clang_rt.builtins"]


### PR DESCRIPTION
# What ❔

Do not use rust-lld for Linux musl builds, it is unable to properly link the final executable in unified CI config.
To use the common code, we use `lld` on Linux in CI for all compilers.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

Related https://github.com/matter-labs/era-compiler-ci/pull/81 to be merged before this one.

## Tests

Tested here: https://github.com/matter-labs/era-compiler-solidity/actions/runs/15215151919

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
